### PR TITLE
AG-18120 Add new marketing CTAs to the charts website

### DIFF
--- a/external/ag-website-shared/plugins/agLinkChecker.ts
+++ b/external/ag-website-shared/plugins/agLinkChecker.ts
@@ -10,6 +10,12 @@ const { TestSuites, TestSuite, TestCase } = junitProcessor;
 type Options = {
     include: boolean;
     prefix?: string;
+    /**
+     * Framework agnostic redirect pages, eg `/r/{page}`, which forward the visitor's query
+     * and fragment on to `/{framework}/{page}`. Their own markup is a redirecting stub, so
+     * anchor links to them are validated against the framework pages they forward to.
+     */
+    frameworkRedirect?: { path: string; frameworks: readonly string[] };
 };
 
 const IGNORED_PATHS = ['/archive'];
@@ -80,7 +86,7 @@ function outputJunitReport(validationResults: any) {
 const checkLinks = async (dir: string, files: string[], options: Options) => {
     const anchors = new Set<string>();
     const linksToValidate: Record<string, { filePaths: Set<string> }> = {};
-    const { prefix } = options;
+    const { prefix, frameworkRedirect } = options;
 
     for (let i = 0; i < files.length; i++) {
         const filePath = files[i];
@@ -177,6 +183,25 @@ const checkLinks = async (dir: string, files: string[], options: Options) => {
         }
     }
 
+    const hasAnchor = (link: string) => anchors.has(link) || anchors.has(link.replace('#', '/#'));
+
+    /**
+     * The framework specific equivalents of a link to a framework agnostic redirect page,
+     * which sends the visitor on to whichever framework they last used, fragment included.
+     * Empty for any other link, and when the site has no such pages.
+     */
+    const frameworkRedirectLinks = (link: string): string[] => {
+        if (frameworkRedirect == null) {
+            return [];
+        }
+        const { path, frameworks } = frameworkRedirect;
+        const redirectPrefix = `/${path}/`;
+        if (!link.startsWith(redirectPrefix)) {
+            return [];
+        }
+        return frameworks.map((framework) => `/${framework}/${link.slice(redirectPrefix.length)}`);
+    };
+
     // for junit reporting
     const validationResults = {};
 
@@ -225,8 +250,10 @@ const checkLinks = async (dir: string, files: string[], options: Options) => {
             validationResults[link] = { error };
             return;
         } else {
-            // Check if the hash exists in the file
-            if (!anchors.has(linkWithoutPrefix) && !anchors.has(linkWithoutPrefix.replace('#', '/#'))) {
+            // Check if the hash exists in the file, or in the pages a framework redirect
+            // page forwards the fragment on to
+            const candidates = [linkWithoutPrefix, ...frameworkRedirectLinks(linkWithoutPrefix)];
+            if (!candidates.some(hasAnchor)) {
                 errors.push(
                     `Link to ${originalLink} could not be resolved in (${filePathsString(filePaths, options)}).`
                 );

--- a/external/ag-website-shared/src/components/landing-pages/LandingPageSection.module.scss
+++ b/external/ag-website-shared/src/components/landing-pages/LandingPageSection.module.scss
@@ -85,6 +85,15 @@
     gap: $spacing-size-2;
 }
 
+// Lays out the section's CTAs in a row. A section with a single CTA is unaffected; sections that
+// add a secondary CTA wrap onto a second line rather than overflowing on narrow viewports.
+.ctaGroup {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: $spacing-size-3;
+}
+
 .ctaButton {
     display: inline-flex;
     align-items: center;

--- a/external/ag-website-shared/src/components/landing-pages/LandingPageSection.tsx
+++ b/external/ag-website-shared/src/components/landing-pages/LandingPageSection.tsx
@@ -31,6 +31,15 @@ const FRAMEWORK_CONFIGS: Record<Framework, { Icon: any; name: string }> = {
     },
 };
 
+/** An additional CTA rendered alongside the section's main CTA. */
+export interface SecondaryCta {
+    title: string;
+    url: string;
+    id?: string;
+    /** Resolve `url` against the visitor's selected framework, as the main CTA does when `isFramework`. */
+    isFramework?: boolean;
+}
+
 interface Props {
     id: string;
     tag: string;
@@ -42,6 +51,7 @@ interface Props {
     ctaTitle?: string;
     ctaUrl?: string;
     ctaId?: string;
+    secondaryCta?: SecondaryCta;
     sectionClass?: string;
     showBackgroundGradient?: boolean;
     children: ReactNode;
@@ -160,6 +170,21 @@ const CTAWithFrameworks: FunctionComponent<{ ctaId: string; ctaTitle: string; ct
     );
 };
 
+/**
+ * A secondary CTA. Carries no framework picker of its own — when `isFramework` is set it follows
+ * whichever framework the visitor has already selected, so it stays in step with the main CTA.
+ */
+const SecondaryCtaLink: FunctionComponent<{ cta: SecondaryCta }> = ({ cta }) => {
+    const { framework } = useFrameworkSelector();
+    const href = cta.isFramework ? gridUrlWithPrefix({ framework, url: cta.url }) : cta.url;
+
+    return (
+        <a id={cta.id} href={href} className={classnames([styles.ctaButton, 'button-tertiary'])}>
+            {cta.title} <Icon name="chevronRight" />
+        </a>
+    );
+};
+
 export const LandingPageSection: FunctionComponent<Props> = ({
     id,
     tag,
@@ -170,6 +195,7 @@ export const LandingPageSection: FunctionComponent<Props> = ({
     ctaTitle = 'Learn more',
     ctaUrl,
     ctaId,
+    secondaryCta,
     isFramework = false,
     sectionClass,
     showBackgroundGradient,
@@ -180,7 +206,7 @@ export const LandingPageSection: FunctionComponent<Props> = ({
     // strip pass no tag/heading/subHeading and must not render empty <h2>/<h3>/<h4> tags.
     const hasHeading = Boolean(heading || headingHtml);
     const hasSubHeading = Boolean(subHeading || subHeadingHtml);
-    const hasHeader = Boolean(tag) || hasHeading || hasSubHeading || Boolean(ctaUrl);
+    const hasHeader = Boolean(tag) || hasHeading || hasSubHeading || Boolean(ctaUrl) || Boolean(secondaryCta);
 
     return (
         <div
@@ -210,12 +236,24 @@ export const LandingPageSection: FunctionComponent<Props> = ({
                             <h4 className={styles.subHeading}>{subHeading}</h4>
                         ))}
 
-                    {ctaUrl && isFramework && <CTAWithFrameworks ctaId={ctaId} ctaTitle={ctaTitle} ctaUrl={ctaUrl} />}
+                    {(ctaUrl || secondaryCta) && (
+                        <div className={styles.ctaGroup}>
+                            {ctaUrl && isFramework && (
+                                <CTAWithFrameworks ctaId={ctaId} ctaTitle={ctaTitle} ctaUrl={ctaUrl} />
+                            )}
 
-                    {ctaUrl && !isFramework && (
-                        <a id={ctaId} href={ctaUrl} className={classnames([styles.ctaButton, 'button-tertiary'])}>
-                            {ctaTitle} <Icon name="chevronRight" />
-                        </a>
+                            {ctaUrl && !isFramework && (
+                                <a
+                                    id={ctaId}
+                                    href={ctaUrl}
+                                    className={classnames([styles.ctaButton, 'button-tertiary'])}
+                                >
+                                    {ctaTitle} <Icon name="chevronRight" />
+                                </a>
+                            )}
+
+                            {secondaryCta && <SecondaryCtaLink cta={secondaryCta} />}
+                        </div>
                     )}
                 </header>
             )}

--- a/packages/ag-charts-website/astro.config.mjs
+++ b/packages/ag-charts-website/astro.config.mjs
@@ -26,6 +26,7 @@ import agDevMarkdownNegotiation from './plugins/agDevMarkdownNegotiation';
 import agHotModuleReload from './plugins/agHotModuleReload';
 import agHtaccessGen from './plugins/agHtaccessGen';
 import agRedirectsChecker from './plugins/agRedirectsChecker';
+import { FRAMEWORKS, FRAMEWORK_REDIRECT_PATH } from './src/constants';
 import { getAstroRedirectRules } from './src/utils/htaccess/htaccessRules';
 import { getSitemapConfig } from './src/utils/sitemap';
 import { urlWithBaseUrl } from './src/utils/urlWithBaseUrl';
@@ -224,7 +225,11 @@ export default defineConfig({
                   },
               ]),
         agHtaccessGen({ htaccessEnv: HTACCESS }),
-        agLinkChecker({ include: CHECK_LINKS === 'true', prefix: PUBLIC_BASE_URL }),
+        agLinkChecker({
+            include: CHECK_LINKS === 'true',
+            prefix: PUBLIC_BASE_URL,
+            frameworkRedirect: { path: FRAMEWORK_REDIRECT_PATH, frameworks: FRAMEWORKS },
+        }),
         agRedirectsChecker({
             skip: CHECK_REDIRECTS !== 'true',
         }),

--- a/packages/ag-charts-website/src/components/gallery/galleryCtas.ts
+++ b/packages/ag-charts-website/src/components/gallery/galleryCtas.ts
@@ -11,7 +11,7 @@ export const GALLERY_CTAS: GalleryCta[] = [
     {
         id: 'gallery-page-free-trial-cta',
         title: 'Free Trial',
-        url: '/react/community-vs-enterprise/#request-a-30-day-enterprise-bundle-trial-licence',
+        url: '/r/community-vs-enterprise/#request-a-30-day-enterprise-bundle-trial-licence',
     },
     {
         id: 'gallery-page-buy-now-cta',

--- a/packages/ag-charts-website/src/components/gallery/galleryCtas.ts
+++ b/packages/ag-charts-website/src/components/gallery/galleryCtas.ts
@@ -6,7 +6,8 @@ export interface GalleryCta {
 }
 
 // Shared with the /gallery.md twin. The trial page is framework-prefixed and the gallery is not,
-// so it takes the default framework.
+// so it links through `/r/`, which redirects on to the framework the visitor last used. The twin
+// resolves that to the default framework instead (see `withDefaultFramework`).
 export const GALLERY_CTAS: GalleryCta[] = [
     {
         id: 'gallery-page-free-trial-cta',

--- a/packages/ag-charts-website/src/components/gallery/galleryCtas.ts
+++ b/packages/ag-charts-website/src/components/gallery/galleryCtas.ts
@@ -1,0 +1,21 @@
+export interface GalleryCta {
+    id: string;
+    title: string;
+    /** Raw path; the page and its markdown twin each base-prefix it. */
+    url: string;
+}
+
+// Shared with the /gallery.md twin. The trial page is framework-prefixed and the gallery is not,
+// so it takes the default framework.
+export const GALLERY_CTAS: GalleryCta[] = [
+    {
+        id: 'gallery-page-free-trial-cta',
+        title: 'Free Trial',
+        url: '/react/community-vs-enterprise/#request-a-30-day-enterprise-bundle-trial-licence',
+    },
+    {
+        id: 'gallery-page-buy-now-cta',
+        title: 'Buy Now',
+        url: '/license-pricing/',
+    },
+];

--- a/packages/ag-charts-website/src/content.config.ts
+++ b/packages/ag-charts-website/src/content.config.ts
@@ -264,6 +264,13 @@ const landingPages = defineCollection({
     }),
 });
 
+// `url` is a raw path, base-prefixed at render.
+const homepageSectionCta = z.object({
+    title: z.string(),
+    url: z.string(),
+    id: z.string(),
+});
+
 // Homepage marketing copy (index.astro). The bespoke interactive islands stay inline in the
 // page; only the hero and section text lives here so it can be shared with the /index.md twin.
 const homepage = defineCollection({
@@ -282,9 +289,8 @@ const homepage = defineCollection({
             gallery: z.object({
                 tag: z.string(),
                 heading: z.string(),
-                ctaTitle: z.string(),
-                ctaUrl: z.string(),
-                ctaId: z.string(),
+                // Rendered as one row by index.astro; LandingPageSection only takes a single CTA.
+                ctas: z.array(homepageSectionCta),
             }),
             financial: z.object({
                 tag: z.string(),

--- a/packages/ag-charts-website/src/content/homepage/homepage.json
+++ b/packages/ag-charts-website/src/content/homepage/homepage.json
@@ -19,7 +19,7 @@
                 },
                 {
                     "title": "Free Trial",
-                    "url": "/react/community-vs-enterprise/?utm_source=charts-homepage&utm_medium=features-section&utm_campaign=homepage-cta#request-a-30-day-enterprise-bundle-trial-licence",
+                    "url": "/r/community-vs-enterprise/?utm_source=charts-homepage&utm_medium=features-section&utm_campaign=homepage-cta#request-a-30-day-enterprise-bundle-trial-licence",
                     "id": "gallery-section-free-trial-cta"
                 },
                 {

--- a/packages/ag-charts-website/src/content/homepage/homepage.json
+++ b/packages/ag-charts-website/src/content/homepage/homepage.json
@@ -11,9 +11,23 @@
         "gallery": {
             "tag": "AG Charts JavaScript Charting Library",
             "heading": "JavaScript Charts Designed for Every Use Case",
-            "ctaTitle": "Get Started For Free",
-            "ctaUrl": "/react/quick-start/?utm_source=charts-homepage&utm_medium=features-section&utm_campaign=homepage-cta",
-            "ctaId": "get-started-for-free"
+            "ctas": [
+                {
+                    "title": "Explore the Docs",
+                    "url": "/react/quick-start/?utm_source=charts-homepage&utm_medium=features-section&utm_campaign=homepage-cta",
+                    "id": "get-started-for-free"
+                },
+                {
+                    "title": "Free Trial",
+                    "url": "/react/community-vs-enterprise/?utm_source=charts-homepage&utm_medium=features-section&utm_campaign=homepage-cta#request-a-30-day-enterprise-bundle-trial-licence",
+                    "id": "gallery-section-free-trial-cta"
+                },
+                {
+                    "title": "Buy Now",
+                    "url": "/license-pricing/?utm_source=charts-homepage&utm_medium=features-section&utm_campaign=homepage-cta",
+                    "id": "gallery-section-buy-now-cta"
+                }
+            ]
         },
         "financial": {
             "tag": "JavaScript Financial Charts - Create Trading Views in Minutes",

--- a/packages/ag-charts-website/src/content/homepage/homepage.json
+++ b/packages/ag-charts-website/src/content/homepage/homepage.json
@@ -14,7 +14,7 @@
             "ctas": [
                 {
                     "title": "Explore the Docs",
-                    "url": "/react/quick-start/?utm_source=charts-homepage&utm_medium=features-section&utm_campaign=homepage-cta",
+                    "url": "/r/quick-start/?utm_source=charts-homepage&utm_medium=features-section&utm_campaign=homepage-cta",
                     "id": "get-started-for-free"
                 },
                 {

--- a/packages/ag-charts-website/src/pages-styles/gallery.module.scss
+++ b/packages/ag-charts-website/src/pages-styles/gallery.module.scss
@@ -47,3 +47,31 @@
         font-size: clamp(20px, 5vw, var(--text-fs-2xl));
     }
 }
+
+.toolbarTitleGroup {
+    display: flex;
+    align-items: center;
+    gap: $spacing-size-6;
+}
+
+// Dropped below the gallery breakpoint, where the title and theme dropdown already fill
+// the fixed-height toolbar band.
+.toolbarCtas {
+    display: none;
+
+    @media screen and (min-width: $breakpoint-gallery-small) {
+        display: flex;
+        align-items: center;
+        gap: $spacing-size-2;
+    }
+
+    :global(.icon) {
+        --icon-size: #{$spacing-size-4};
+
+        transition: transform $transition-default-timing;
+    }
+
+    a:hover :global(.icon) {
+        transform: translateX(4px);
+    }
+}

--- a/packages/ag-charts-website/src/pages-styles/homepage.module.scss
+++ b/packages/ag-charts-website/src/pages-styles/homepage.module.scss
@@ -750,3 +750,33 @@ $z-index-debug-panel: $z-index-debug-canvas + 200;
     pointer-events: none;
     z-index: $z-index-debug-canvas;
 }
+
+// LandingPageSection renders a single CTA, so this row is rendered as the section's first child
+// instead; the negative margin lifts it into the header's bottom margin, where that CTA would sit.
+.gallerySectionCtas {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: $spacing-size-3;
+    margin-top: calc(#{$spacing-size-3} - #{$spacing-size-12});
+    margin-bottom: $spacing-size-12;
+
+    a {
+        display: inline-flex;
+        align-items: center;
+        gap: $spacing-size-2;
+        width: fit-content;
+        padding: 0.5em 0.5em 0.5em 1em;
+
+        :global(.icon) {
+            --icon-size: #{$spacing-size-4};
+
+            transform: translate(-3px, 1px);
+            transition: transform $transition-default-timing;
+        }
+
+        &:hover :global(.icon) {
+            transform: translate(4px, 1px);
+        }
+    }
+}

--- a/packages/ag-charts-website/src/pages/gallery.astro
+++ b/packages/ag-charts-website/src/pages/gallery.astro
@@ -6,6 +6,7 @@ import { getPageHashUrl } from '@components/gallery/utils/urlPaths';
 import type { GalleryData, GalleryExample, GalleryExampleChartType } from '@ag-grid-types';
 import { GalleryExampleLink } from '@components/gallery/components/GalleryExampleLink';
 import { GalleryExampleThemeDropdown } from '@components/gallery/components/GalleryExampleThemeDropdown';
+import { GALLERY_CTAS } from '@components/gallery/galleryCtas';
 import { DISABLE_MARKDOWN_DOCS, GALLERY_IMAGE_DPR_ENHANCEMENT } from '@constants';
 import { getModifiedGalleryExamples } from '@components/gallery/utils/modifiedExamples';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
@@ -28,7 +29,18 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/gallery
 >
     <div class={styles.toolbar} data-gallery-toolbar>
         <div class:list={[styles.toolbarInner, 'layout-page-max-width']}>
-            <h1>AG Charts Gallery</h1>
+            <div class={styles.toolbarTitleGroup}>
+                <h1>AG Charts Gallery</h1>
+                <div class={styles.toolbarCtas}>
+                    {
+                        GALLERY_CTAS.map((cta) => (
+                            <a id={cta.id} href={urlWithBaseUrl(cta.url)} class="button-tertiary">
+                                {cta.title} <Icon name="chevronRight" />
+                            </a>
+                        ))
+                    }
+                </div>
+            </div>
             <GalleryExampleThemeDropdown client:only="react" />
         </div>
     </div>

--- a/packages/ag-charts-website/src/pages/index.astro
+++ b/packages/ag-charts-website/src/pages/index.astro
@@ -106,13 +106,16 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/index.m
             </div>
         </div>
 
-        <LandingPageSection
-            tag={sections.gallery.tag}
-            heading={sections.gallery.heading}
-            ctaTitle={sections.gallery.ctaTitle}
-            ctaUrl={urlWithBaseUrl(sections.gallery.ctaUrl)}
-            ctaId={sections.gallery.ctaId}
-        >
+        <LandingPageSection tag={sections.gallery.tag} heading={sections.gallery.heading}>
+            <div class={styles.gallerySectionCtas}>
+                {
+                    sections.gallery.ctas.map((cta) => (
+                        <a id={cta.id} href={urlWithBaseUrl(cta.url)} class="button-tertiary">
+                            {cta.title} <Icon name="chevronRight" />
+                        </a>
+                    ))
+                }
+            </div>
             <HomepageGalleryExamples />
         </LandingPageSection>
 

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.test.ts
@@ -13,7 +13,7 @@ describe('buildGalleryMarkdown', () => {
 
     it('renders the trial and pricing CTAs', () => {
         expect(output).toContain(
-            '[Free Trial](https://www.ag-grid.com/react/community-vs-enterprise/#request-a-30-day-enterprise-bundle-trial-licence) | [Buy Now](https://www.ag-grid.com/license-pricing/)'
+            '[Free Trial](https://www.ag-grid.com/r/community-vs-enterprise/#request-a-30-day-enterprise-bundle-trial-licence) | [Buy Now](https://www.ag-grid.com/license-pricing/)'
         );
     });
 

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.test.ts
@@ -13,7 +13,7 @@ describe('buildGalleryMarkdown', () => {
 
     it('renders the trial and pricing CTAs', () => {
         expect(output).toContain(
-            '[Free Trial](https://www.ag-grid.com/r/community-vs-enterprise/#request-a-30-day-enterprise-bundle-trial-licence) | [Buy Now](https://www.ag-grid.com/license-pricing/)'
+            '[Free Trial](https://www.ag-grid.com/react/community-vs-enterprise/#request-a-30-day-enterprise-bundle-trial-licence) | [Buy Now](https://www.ag-grid.com/license-pricing/)'
         );
     });
 

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.test.ts
@@ -11,6 +11,12 @@ describe('buildGalleryMarkdown', () => {
         expect(output).toContain('\n# AG Charts Gallery');
     });
 
+    it('renders the trial and pricing CTAs', () => {
+        expect(output).toContain(
+            '[Free Trial](https://www.ag-grid.com/react/community-vs-enterprise/#request-a-30-day-enterprise-bundle-trial-licence) | [Buy Now](https://www.ag-grid.com/license-pricing/)'
+        );
+    });
+
     it('groups examples under a chart-type heading', () => {
         expect(output).toContain('## Bar');
         expect(output).toContain('## Line');

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.ts
@@ -1,4 +1,5 @@
 import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { GALLERY_CTAS } from '@components/gallery/galleryCtas';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 
 import galleryData from '../../content/gallery/data.json';
@@ -45,6 +46,7 @@ export function buildGalleryMarkdown({ siteRoot }: { siteRoot?: string } = {}): 
         frontmatter,
         '# AG Charts Gallery',
         'Browse the AG Charts gallery of chart examples, grouped by chart type. Each example links to a live, interactive demo.',
+        GALLERY_CTAS.map((cta) => `[${cta.title}](${toAbsoluteUrl(urlWithBaseUrl(cta.url), siteRoot)})`).join(' | '),
     ];
 
     for (const chartType of series.flat()) {

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.ts
@@ -3,6 +3,7 @@ import { GALLERY_CTAS } from '@components/gallery/galleryCtas';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 
 import galleryData from '../../content/gallery/data.json';
+import { withDefaultFramework } from './withDefaultFramework';
 
 // Shape of the slice of the gallery collection this twin consumes (see data.json). The
 // `series` field is an array of groups, each group a list of chart types holding their
@@ -46,7 +47,9 @@ export function buildGalleryMarkdown({ siteRoot }: { siteRoot?: string } = {}): 
         frontmatter,
         '# AG Charts Gallery',
         'Browse the AG Charts gallery of chart examples, grouped by chart type. Each example links to a live, interactive demo.',
-        GALLERY_CTAS.map((cta) => `[${cta.title}](${toAbsoluteUrl(urlWithBaseUrl(cta.url), siteRoot)})`).join(' | '),
+        GALLERY_CTAS.map(
+            (cta) => `[${cta.title}](${toAbsoluteUrl(urlWithBaseUrl(withDefaultFramework(cta.url)), siteRoot)})`
+        ).join(' | '),
     ];
 
     for (const chartType of series.flat()) {

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.test.ts
@@ -35,10 +35,15 @@ describe('buildHomepageMarkdown', () => {
 
     it("renders the gallery section's CTAs as one row", () => {
         expect(output).toMatch(/\[Explore the Docs\]\([^)]*\) \| \[Free Trial\]\([^)]*\) \| \[Buy Now\]\([^)]*\)/);
-        expect(output).toMatch(
-            /\[Free Trial\]\(https:\/\/www\.ag-grid\.com\/[^)]*community-vs-enterprise\/[^)]*#request-a-30-day-enterprise-bundle-trial-licence\)/
-        );
         expect(output).toMatch(/\[Buy Now\]\(https:\/\/www\.ag-grid\.com\/[^)]*license-pricing\/[^)]*\)/);
+    });
+
+    it('resolves framework agnostic CTA links to the default framework', () => {
+        // `/r/{page}` redirects client side, which the tools reading this markdown don't run.
+        expect(output).toContain(
+            '[Free Trial](https://www.ag-grid.com/react/community-vs-enterprise/?utm_source=charts-homepage&utm_medium=features-section&utm_campaign=homepage-cta#request-a-30-day-enterprise-bundle-trial-licence)'
+        );
+        expect(output).not.toContain('ag-grid.com/r/');
     });
 
     it('converts the integrated subHeadingHtml links to markdown (no raw anchor tags)', () => {

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.test.ts
@@ -29,8 +29,16 @@ describe('buildHomepageMarkdown', () => {
 
     it('resolves section CTA links absolutely', () => {
         expect(output).toContain(
-            '[Get Started For Free](https://www.ag-grid.com/react/quick-start/?utm_source=charts-homepage&utm_medium=features-section&utm_campaign=homepage-cta)'
+            '[Explore the Docs](https://www.ag-grid.com/react/quick-start/?utm_source=charts-homepage&utm_medium=features-section&utm_campaign=homepage-cta)'
         );
+    });
+
+    it("renders the gallery section's CTAs as one row", () => {
+        expect(output).toMatch(/\[Explore the Docs\]\([^)]*\) \| \[Free Trial\]\([^)]*\) \| \[Buy Now\]\([^)]*\)/);
+        expect(output).toMatch(
+            /\[Free Trial\]\(https:\/\/www\.ag-grid\.com\/[^)]*community-vs-enterprise\/[^)]*#request-a-30-day-enterprise-bundle-trial-licence\)/
+        );
+        expect(output).toMatch(/\[Buy Now\]\(https:\/\/www\.ag-grid\.com\/[^)]*license-pricing\/[^)]*\)/);
     });
 
     it('converts the integrated subHeadingHtml links to markdown (no raw anchor tags)', () => {

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.ts
@@ -18,8 +18,7 @@ interface HomepageHero {
     subHeading: string;
     cta: HomepageCta;
 }
-// Sections carrying a "read more" CTA share this shape; `subHeading` is absent on the
-// gallery section, which only has a CTA.
+// Sections carrying a single "read more" CTA share this shape.
 interface CtaSection {
     tag: string;
     heading: string;
@@ -28,12 +27,18 @@ interface CtaSection {
     ctaUrl: string;
     ctaId: string;
 }
+// The gallery section carries a row of CTAs instead of one.
+interface CtaListSection {
+    tag: string;
+    heading: string;
+    ctas: HomepageCta[];
+}
 interface MapCard {
     heading: string;
     description: string;
 }
 interface HomepageSections {
-    gallery: Omit<CtaSection, 'subHeading'>;
+    gallery: CtaListSection;
     financial: CtaSection;
     maps: CtaSection & { cards: MapCard[] };
     integrated: { tag: string; heading: string; subHeadingHtml: string };
@@ -52,16 +57,17 @@ function ctaLink(title: string, url: string, siteRoot?: string): string {
     return `[${title}](${toAbsoluteUrl(urlWithBaseUrl(url), siteRoot)})`;
 }
 
-function ctaSectionBlock(
-    section: { heading: string; subHeading?: string; ctaTitle?: string; ctaUrl?: string },
-    siteRoot?: string
-): string {
+type CtaSectionBlock = Partial<Omit<CtaSection, 'heading'>> & { heading: string; ctas?: HomepageCta[] };
+
+function ctaSectionBlock(section: CtaSectionBlock, siteRoot?: string): string {
     const parts = [`## ${section.heading}`];
     if (section.subHeading) {
         parts.push(section.subHeading);
     }
-    if (section.ctaTitle && section.ctaUrl) {
-        parts.push(ctaLink(section.ctaTitle, section.ctaUrl, siteRoot));
+    const ctas =
+        section.ctas ?? (section.ctaTitle && section.ctaUrl ? [{ title: section.ctaTitle, url: section.ctaUrl }] : []);
+    if (ctas.length) {
+        parts.push(ctas.map((cta) => ctaLink(cta.title, cta.url, siteRoot)).join(' | '));
     }
     return parts.join('\n\n');
 }

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildHomepageMarkdown.ts
@@ -6,6 +6,7 @@ import faqData from '../../content/faqs/homepage.json';
 import homepage from '../../content/homepage/homepage.json';
 import versionsData from '../../content/versions/ag-charts-versions.json';
 import { latestReleasesMarkdown } from './latestReleasesMarkdown';
+import { withDefaultFramework } from './withDefaultFramework';
 
 const NUM_LATEST_RELEASES = 3;
 
@@ -54,7 +55,7 @@ interface FaqItem {
     answer: string;
 }
 function ctaLink(title: string, url: string, siteRoot?: string): string {
-    return `[${title}](${toAbsoluteUrl(urlWithBaseUrl(url), siteRoot)})`;
+    return `[${title}](${toAbsoluteUrl(urlWithBaseUrl(withDefaultFramework(url)), siteRoot)})`;
 }
 
 type CtaSectionBlock = Partial<Omit<CtaSection, 'heading'>> & { heading: string; ctas?: HomepageCta[] };

--- a/packages/ag-charts-website/src/utils/markdown-pages/withDefaultFramework.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/withDefaultFramework.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { withDefaultFramework } from './withDefaultFramework';
+
+describe('withDefaultFramework', () => {
+    it('swaps the framework redirect segment for the default framework', () => {
+        expect(withDefaultFramework('/r/quick-start/')).toBe('/react/quick-start/');
+    });
+
+    it('keeps the query and fragment of a redirect url', () => {
+        expect(withDefaultFramework('/r/community-vs-enterprise/?utm_source=charts#trial')).toBe(
+            '/react/community-vs-enterprise/?utm_source=charts#trial'
+        );
+    });
+
+    it.each(['/license-pricing/', '/react/quick-start/', '/gallery', '#anchor', 'https://www.ag-grid.com/r/security/'])(
+        'leaves %s unchanged',
+        (url) => {
+            expect(withDefaultFramework(url)).toBe(url);
+        }
+    );
+});

--- a/packages/ag-charts-website/src/utils/markdown-pages/withDefaultFramework.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/withDefaultFramework.ts
@@ -1,0 +1,18 @@
+import { DEFAULT_FRAMEWORK, FRAMEWORK_REDIRECT_PATH } from '@constants';
+
+const REDIRECT_PREFIX = `/${FRAMEWORK_REDIRECT_PATH}/`;
+
+/**
+ * Swap the framework agnostic segment of a docs url (`/r/{page}`) for the default framework.
+ *
+ * `/r/{page}` is a stub that redirects the visitor, client side, to whichever framework they
+ * last used, which makes it the right target for the site's own pages but not for their `.md`
+ * twins: those are read by tools that don't run the redirect, and there is no `/r/{page}.md`
+ * for them to be sent on to. Urls that aren't framework redirects are returned unchanged.
+ */
+export function withDefaultFramework(url: string): string {
+    if (!url.startsWith(REDIRECT_PREFIX)) {
+        return url;
+    }
+    return `/${DEFAULT_FRAMEWORK}/${url.slice(REDIRECT_PREFIX.length)}`;
+}


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-18120

Fix #AG-18120

Charts side of the marketing CTA list. The grid side is ag-grid/ag-grid#14927.

### Changes

- **`/charts/`** — gallery section CTA renamed to **Explore the Docs**, with **Free Trial** and **Buy Now** added on the same row.
- **`/charts/gallery/`** — **Free Trial** and **Buy Now** next to the `AG Charts Gallery` heading.
- Both sets carry into the `/index.md` and `/gallery.md` twins, with tests.

### Notes for review

- The sheet lists the *grid* URLs for the charts rows; these point at the charts equivalents instead — the charts `community-vs-enterprise` trial anchor and `/charts/license-pricing/` — so visitors stay on the charts site.
- The renamed CTA keeps its `get-started-for-free` id so its analytics history survives the copy change. Grid #14927 does the same.
- `external/ag-website-shared/src/components/landing-pages/LandingPageSection.{tsx,module.scss}` are **byte-identical** to #14927 (verified against that PR head). Its `secondaryCta` takes a single CTA, so the charts homepage row is rendered by `index.astro` rather than by extending the shared component — worth collapsing into the shared component if it ever gains multi-CTA support.

### Not included

The `/charts/react/financial-charts/` row is left out: its note ("Where there is an Enterprise Symbol this needs to be replaced throughout pages") is a docs-wide change to the Enterprise icon treatment and is still flagged under **Points for Discussion** on the sheet.