### PR TITLE
AG-3390 - Read the scorecard from api.scorecard.dev, not the deprecated host

### DIFF
--- a/external/ag-shared/scripts/ossf-scorecard/getAndCheckResults.mjs
+++ b/external/ag-shared/scripts/ossf-scorecard/getAndCheckResults.mjs
@@ -6,8 +6,8 @@ export async function getOSSFScorecardResults({ project, threshold }) {
         process.exit(1);
     }
 
-    const scorecardJsonUrl = `https://api.securityscorecards.dev/projects/github.com/ag-grid/ag-${project}`;
-    const response = await fetch(scorecardJsonUrl);
+    const scorecardJsonUrl = `https://api.scorecard.dev/projects/github.com/ag-grid/ag-${project}`;
+    const response = await fetch(`${scorecardJsonUrl}?cachebust=${Date.now()}`);
     const results = await response.json();
 
     const score = results.score;
@@ -37,7 +37,7 @@ export async function getOSSFScorecardResults({ project, threshold }) {
             tests: [
                 {
                     name: `OpenSSF Score >= ${threshold}`,
-                    message: `Score = ${score}, from ${scorecardJsonUrl}. See ${resultsUrl} for full details.`,
+                    message: `Score = ${score}, scanned ${results.date}, from ${scorecardJsonUrl}. See ${resultsUrl} for full details.`,
                     status,
                     duration: 0,
                 },


### PR DESCRIPTION
## Problem

The OSS Scorecard gate reported a score that disagreed with the published scorecard. [Run 32663506688](https://github.com/ag-grid/ag-charts/actions/runs/32663506688) failed with `Score = 7`, while the [viewer](https://scorecard.dev/viewer/?uri=github.com/ag-grid/ag-charts) showed `6.9`.

Nothing is cached on the Actions side. The check fetched `api.securityscorecards.dev` — the hostname Scorecard used before it moved under the OpenSSF umbrella and was [renamed to `scorecard.dev`](https://openssf.org/blog/2024/03/05/openssf-scorecard-evaluating-and-improving-the-health-of-critical-oss-projects/). The old host still resolves, but its CDN edge is serving objects **days** past their advertised 10-minute `max-age`:

| Request | `age` | Score | Scan date | Commit |
| --- | --- | --- | --- | --- |
| `api.securityscorecards.dev` (as the check called it) | 232519s (~2.7d) | **7** | 2026-08-21T15:02:21Z | `9643ab8b` |
| `api.securityscorecards.dev?cb=<random>` | 0 | **6.9** | 2026-08-23T20:08:09Z | `bae50472` |
| `api.scorecard.dev` (what the viewer reads) | 2652s | **6.9** | 2026-08-23T20:08:09Z | `bae50472` |

The origin is healthy — a cache-buster against the *same* legacy host returns the current result, so this is purely edge staleness. The failing run's own `oss-scorecard-response` artifact contains the stale Aug-21 payload, confirming that is what the job read.

`ag-grid` is affected identically (`age: 235481`, also frozen at the Aug-21 scan). It went unnoticed there only because its score happened not to move.

The real score change was a single check: `Code-Review` 10 → 9, caused by `bae50472` (the automated version bump) landing on `latest` without review.

## Change

In `external/ag-shared/scripts/ossf-scorecard/getAndCheckResults.mjs`:

- Point at `api.scorecard.dev`, with a comment linking the OpenSSF post that explains the rename.
- Add a cache-buster to the fetch. The new host carries the same 10-minute `max-age` behind the same CDN, so it can go stale the same way. A `Cache-Control: no-cache` *request* header does not work — verified, the edge ignores it and still returns `x-cache: HIT` with a multi-day `age`.
- Include the scan date in the CTRF test message, so a stale read shows up in the `#ci-chart-gate` Slack notification. Commit and scan date were already in the GitHub step summary via `generateGithubSummary.mjs`; the Slack path had neither.

## Verification

Ran the patched module directly against the live API for both projects:

```
charts: score 6.9  scanned 2026-08-23T20:08:09Z  commit bae50472  passed=false
grid:   score 7.8  scanned 2026-08-24T07:54:03Z                  passed=true
```

`charts` now matches the viewer. `yarn nx format` is clean. `external/ag-shared/` sits outside the repo's prettier and eslint scope, so there is no lint target covering this file — `node --check` passes, and eslint reports the same pre-existing "not found by the project service" parse error on the untouched sibling file.

## Notes

- This does not change the gate outcome for the linked run: the threshold is `7.3`, and both `7` and `6.9` fail. Only the reported number was wrong.
- `external/ag-shared` is a git-subrepo of `ag-grid/ag-shared`. This needs a `git subrepo push` to reach the shared repo and fix `ag-grid`'s copy of the same check.
