### PR TITLE
Consolidate the bar-family label wiring

### DIFF
--- a/packages/ag-charts-community/src/chart/labelUtil.ts
+++ b/packages/ag-charts-community/src/chart/labelUtil.ts
@@ -561,9 +561,9 @@ export interface BarLabelDataContext {
     readonly collideWith: CollideWith;
     readonly threshold: number;
     /** Drawn-box footprint of `text` under the configured label font: the measured glyph plus {@link box}. */
-    measureBox(text: NormalisedTextOrSegments): { width: number; height: number };
+    readonly measureBox: (text: NormalisedTextOrSegments) => { width: number; height: number };
     /** Per-candidate fit inputs for `text`, or `undefined` when the label opted out of overflow control. */
-    fitFor(text: NormalisedTextOrSegments): LabelFitDescriptor | undefined;
+    readonly fitFor: (text: NormalisedTextOrSegments) => LabelFitDescriptor | undefined;
 }
 
 /**
@@ -580,7 +580,7 @@ export function barLabelDataContext<TParams>(label: BarLabelSurface<TParams>): B
         alwaysShow,
         collideWith: label.collision.resolveCollideWith(),
         threshold: label.collision.threshold ?? 0,
-        measureBox(text) {
+        measureBox: (text) => {
             const { width, height } = measureLabelText(text, label);
             return { width: width + box.left + box.right, height: height + box.top + box.bottom };
         },

--- a/packages/ag-charts-community/src/chart/labelUtil.ts
+++ b/packages/ag-charts-community/src/chart/labelUtil.ts
@@ -1,16 +1,19 @@
 import type {
     AutoSizedLabelText,
+    BakedLabelSource,
     BarValueAnchor,
     BoxBounds,
     Callback,
     CallbackParam,
     CandidateLabelStyle,
     CandidateStyleResolver,
+    CollideWith,
     DynamicContext,
     FitRegion,
     FontOptions,
     IsAny,
     LabelFit,
+    LabelFitDescriptor,
     LabelPlacement,
     NormalisedColorType,
     NormalisedTextOrSegments,
@@ -18,12 +21,15 @@ import type {
     Point,
     PointLabelDatum,
     PositionedLabelCandidate,
+    RectObstacleSource,
     RegionAlign,
 } from 'ag-charts-core';
 import {
     type NormalisedChartLabelStyleOptions,
+    barLabelObstacles,
     fitLabelTextOrOverflow,
     fitLabelTextOrOverflowAutoSize,
+    fontWithSize,
     getMinOuterRectSize,
     insetFitRegion,
     insideBarContainer,
@@ -32,6 +38,7 @@ import {
     measureLabelText,
     mergeDefaults,
     orientationAngles,
+    resolveLabelFitDescriptors,
     rotatedGlyphDrift,
     rotatedLabelInset,
     sectorLabelContainer,
@@ -60,6 +67,7 @@ import {
     type Label,
     type LabelPlacementStyle,
     expandLabelBoxExtent,
+    expandPlacementLabelBoxExtent,
     resolvePlacementLabelBoxExtent,
     resolvePlacementLabelStyle,
 } from './label';
@@ -538,6 +546,69 @@ export interface StyledBarLabelBox {
     /** The styler disabled this label, so it must be left out of the label data entirely. */
     readonly hidden: boolean;
 }
+
+/** A bar-family label surface: the placement-styled label every bar/histogram/waterfall/funnel series holds. */
+export type BarLabelSurface<TParams = never> = Label<TParams> & {
+    insideStyle: LabelPlacementStyle;
+    outsideStyle: LabelPlacementStyle;
+};
+
+/** The per-series values a bar-family `getLabelData` resolves once before walking its label data. */
+export interface BarLabelDataContext {
+    /** Per-side extent of the drawn box (padding plus border) around the glyph. */
+    readonly box: Required<PaddingOptions>;
+    readonly alwaysShow: boolean;
+    readonly collideWith: CollideWith;
+    readonly threshold: number;
+    /** Drawn-box footprint of `text` under the configured label font: the measured glyph plus {@link box}. */
+    measureBox(text: NormalisedTextOrSegments): { width: number; height: number };
+    /** Per-candidate fit inputs for `text`, or `undefined` when the label opted out of overflow control. */
+    fitFor(text: NormalisedTextOrSegments): LabelFitDescriptor | undefined;
+}
+
+/**
+ * Resolves the collision and fit inputs shared by every label in a bar-family series. Every such series
+ * needs the same six values in the same way, so they are derived here rather than restated per series.
+ */
+export function barLabelDataContext<TParams>(label: BarLabelSurface<TParams>): BarLabelDataContext {
+    // Inflate the measured text by the label's drawn box (padding + border stroke) so collisions
+    // avoid the box, not just the text.
+    const box = expandPlacementLabelBoxExtent(label);
+    const alwaysShow = label.collision.alwaysShow;
+    return {
+        box,
+        alwaysShow,
+        collideWith: label.collision.resolveCollideWith(),
+        threshold: label.collision.threshold ?? 0,
+        measureBox(text) {
+            const { width, height } = measureLabelText(text, label);
+            return { width: width + box.left + box.right, height: height + box.top + box.bottom };
+        },
+        fitFor: resolveLabelFitDescriptors(label, box, !alwaysShow),
+    };
+}
+
+/**
+ * The obstacles a bar-family series contributes: its bar rects, plus its own baked labels when they are
+ * not routed through the placement engine. `pick` names the label on each element, which is the only
+ * part that differs between series (a bar hangs its label off the node, a range bar flattens the pair).
+ */
+export function barLabelObstaclesFor<TParams, TElement>(
+    label: BarLabelSurface<TParams>,
+    nodeData: readonly RectObstacleSource[] | undefined,
+    labelData: Iterable<TElement> | undefined,
+    includeBaked: boolean,
+    pick: (element: TElement) => BakedBarLabel | undefined
+) {
+    const box = expandPlacementLabelBoxExtent(label);
+    return barLabelObstacles(nodeData, labelData, includeBaked, (element) => {
+        const picked = pick(element);
+        return { label: picked, config: fontWithSize(label, picked?.fittedFontSize), box };
+    });
+}
+
+/** A baked bar label, plus the reduced font size a shrink-to-fit pass left it drawn at. */
+type BakedBarLabel = NonNullable<BakedLabelSource['label']> & { readonly fittedFontSize?: number };
 
 /** The `itemStyler` geometry of one bar-label candidate; see {@link buildBarLabelCandidates}. */
 export type BarCandidateStyleResolver = (

--- a/packages/ag-charts-community/src/chart/layout/labelManager.test.ts
+++ b/packages/ag-charts-community/src/chart/layout/labelManager.test.ts
@@ -1,0 +1,204 @@
+import { vi } from 'vitest';
+
+import type { LabelObstacle, PlacedLabel, PointLabelDatum } from 'ag-charts-core';
+
+import { BBox } from '../../scene/bbox';
+import type { ISeries, ISeriesProperties, SeriesNodeDatum } from '../series/seriesTypes';
+import { LabelManager } from './labelManager';
+
+type AnySeries = ISeries<SeriesNodeDatum, ISeriesProperties, unknown>;
+
+const NO_PADDING = { top: 0, right: 0, bottom: 0, left: 0 };
+const RECT = new BBox(0, 0, 200, 200);
+
+function labelDatum(x: number, y: number, text: string, overrides?: Partial<PointLabelDatum>): PointLabelDatum {
+    return {
+        point: { x, y, size: 0 },
+        label: { text, width: 40, height: 10 },
+        anchor: undefined,
+        placement: undefined,
+        placements: ['top'],
+        alwaysShow: false,
+        ...overrides,
+    };
+}
+
+interface FakeSeriesOptions {
+    id: string;
+    datums?: PointLabelDatum[];
+    obstacles?: LabelObstacle[];
+    usesPlacedLabels?: boolean;
+}
+
+function fakeSeries({ id, datums = [], obstacles, usesPlacedLabels = true }: FakeSeriesOptions) {
+    const series = {
+        id,
+        nodeDataVersion: 1,
+        usesPlacedLabels,
+        getLabelData: vi.fn((): PointLabelDatum[] => datums),
+        getLabelObstacles: vi.fn((): LabelObstacle[] | undefined => obstacles),
+        updatePlacedLabelData: vi.fn((_labels: PlacedLabel[]) => {}),
+    };
+    return series as typeof series & AnySeries;
+}
+
+function placedTexts(series: ReturnType<typeof fakeSeries>, call = -1): string[] {
+    const { calls } = series.updatePlacedLabelData.mock;
+    const labels = calls.at(call)?.[0] ?? [];
+    return labels.map((label) => label.text as string);
+}
+
+describe('LabelManager', () => {
+    describe('placement caching', () => {
+        it('reuses the cached solve while the placement inputs are unchanged', () => {
+            const manager = new LabelManager();
+            const series = fakeSeries({ id: 'a', datums: [labelDatum(50, 50, 'one')] });
+
+            manager.updateLabels([series], NO_PADDING, RECT);
+            manager.updateLabels([series], NO_PADDING, RECT);
+
+            // The solve runs once, but is re-applied on both updates: SERIES_UPDATE also fires on
+            // hover, where the labels still have to be rebuilt to pick up highlight styling.
+            expect(series.getLabelData).toHaveBeenCalledTimes(1);
+            expect(series.updatePlacedLabelData).toHaveBeenCalledTimes(2);
+            expect(placedTexts(series)).toEqual(['one']);
+        });
+
+        it('re-solves when a series bumps its node-data version', () => {
+            const manager = new LabelManager();
+            const series = fakeSeries({ id: 'a', datums: [labelDatum(50, 50, 'one')] });
+
+            manager.updateLabels([series], NO_PADDING, RECT);
+            series.nodeDataVersion += 1;
+            manager.updateLabels([series], NO_PADDING, RECT);
+
+            expect(series.getLabelData).toHaveBeenCalledTimes(2);
+        });
+
+        it('re-solves when the layout bounds change', () => {
+            const manager = new LabelManager();
+            const series = fakeSeries({ id: 'a', datums: [labelDatum(50, 50, 'one')] });
+
+            manager.updateLabels([series], NO_PADDING, RECT);
+            manager.updateLabels([series], NO_PADDING, new BBox(0, 0, 300, 200));
+
+            expect(series.getLabelData).toHaveBeenCalledTimes(2);
+        });
+
+        it('re-solves when the chart padding changes the bounds', () => {
+            const manager = new LabelManager();
+            const series = fakeSeries({ id: 'a', datums: [labelDatum(50, 50, 'one')] });
+
+            manager.updateLabels([series], NO_PADDING, RECT);
+            manager.updateLabels([series], { ...NO_PADDING, left: 10 }, RECT);
+
+            expect(series.getLabelData).toHaveBeenCalledTimes(2);
+        });
+
+        it('re-solves when the set of visible series changes', () => {
+            const manager = new LabelManager();
+            const first = fakeSeries({ id: 'a', datums: [labelDatum(50, 50, 'one')] });
+            const second = fakeSeries({ id: 'b', datums: [labelDatum(150, 50, 'two')] });
+
+            manager.updateLabels([first], NO_PADDING, RECT);
+            manager.updateLabels([first, second], NO_PADDING, RECT);
+
+            expect(first.getLabelData).toHaveBeenCalledTimes(2);
+            expect(second.getLabelData).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('no placed-label series', () => {
+        it('places nothing and clears the cached solve', () => {
+            const manager = new LabelManager();
+            const series = fakeSeries({ id: 'a', datums: [labelDatum(50, 50, 'one')] });
+            const plain = fakeSeries({ id: 'b', usesPlacedLabels: false });
+
+            manager.updateLabels([series], NO_PADDING, RECT);
+            manager.updateLabels([plain], NO_PADDING, RECT);
+            expect(plain.getLabelData).not.toHaveBeenCalled();
+            expect(plain.updatePlacedLabelData).not.toHaveBeenCalled();
+
+            // The cache was cleared, so the identical inputs of the first update re-solve rather
+            // than replaying a solve taken while a different series set was visible.
+            manager.updateLabels([series], NO_PADDING, RECT);
+            expect(series.getLabelData).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('label data carry-forward', () => {
+        it('keeps the previous label data for a series that reports non-point data', () => {
+            const manager = new LabelManager();
+            const series = fakeSeries({ id: 'a', datums: [labelDatum(50, 50, 'one')] });
+
+            manager.updateLabels([series], NO_PADDING, RECT);
+            expect(placedTexts(series)).toEqual(['one']);
+
+            // Bar-family series report baked label data between placement passes; the manager has to
+            // carry the last point-label solve forward rather than drop the series' labels.
+            series.getLabelData.mockReturnValue([{ notALabelDatum: true }] as unknown as PointLabelDatum[]);
+            series.nodeDataVersion += 1;
+            manager.updateLabels([series], NO_PADDING, RECT);
+
+            expect(placedTexts(series)).toEqual(['one']);
+        });
+
+        it('places nothing for a series that has never reported point data', () => {
+            const manager = new LabelManager();
+            const series = fakeSeries({ id: 'a' });
+            series.getLabelData.mockReturnValue([{ notALabelDatum: true }] as unknown as PointLabelDatum[]);
+
+            manager.updateLabels([series], NO_PADDING, RECT);
+
+            expect(placedTexts(series)).toEqual([]);
+        });
+    });
+
+    describe('obstacles', () => {
+        it('gathers obstacles from every visible series, including those placing no labels', () => {
+            const manager = new LabelManager();
+            const series = fakeSeries({ id: 'a', datums: [labelDatum(50, 50, 'one')] });
+            const blocker = fakeSeries({
+                id: 'b',
+                usesPlacedLabels: false,
+                obstacles: [{ kind: 'rect', category: 'seriesItem', box: new BBox(0, 0, 200, 200) }],
+            });
+
+            manager.updateLabels([series, blocker], NO_PADDING, RECT);
+
+            expect(blocker.getLabelObstacles).toHaveBeenCalled();
+            // The blanket obstacle leaves the droppable label nowhere to go.
+            expect(placedTexts(series)).toEqual([]);
+        });
+    });
+
+    describe('resolution order', () => {
+        it('resolves series in declaration order, and restores it after a hide and show', () => {
+            const manager = new LabelManager();
+            // Both labels want the same spot; placement is greedy, so the first series declared wins.
+            const first = fakeSeries({ id: 'a', datums: [labelDatum(100, 100, 'first')] });
+            const second = fakeSeries({ id: 'b', datums: [labelDatum(100, 100, 'second')] });
+
+            manager.updateLabels([first, second], NO_PADDING, RECT);
+            expect(placedTexts(first)).toEqual(['first']);
+            expect(placedTexts(second)).toEqual([]);
+
+            manager.updateLabels([first], NO_PADDING, RECT);
+            manager.updateLabels([first, second], NO_PADDING, RECT);
+
+            expect(placedTexts(first)).toEqual(['first']);
+            expect(placedTexts(second)).toEqual([]);
+        });
+
+        it('places both series when their labels do not compete', () => {
+            const manager = new LabelManager();
+            const first = fakeSeries({ id: 'a', datums: [labelDatum(50, 50, 'first')] });
+            const second = fakeSeries({ id: 'b', datums: [labelDatum(150, 150, 'second')] });
+
+            manager.updateLabels([first, second], NO_PADDING, RECT);
+
+            expect(placedTexts(first)).toEqual(['first']);
+            expect(placedTexts(second)).toEqual(['second']);
+        });
+    });
+});

--- a/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/barSeries.ts
@@ -25,7 +25,6 @@ import {
     applyBarLabelOrientation,
     applyPlacedBarLabelVisibility,
     areScalingEqual,
-    barLabelObstacles,
     barLabelOrientation,
     barLabelPropsRouteThroughEngine,
     barLabelPropsUsePositionedCandidates,
@@ -42,7 +41,6 @@ import {
     mergeDefaults,
     minValue,
     resolveLabelFit,
-    resolveLabelFitDescriptors,
     toArray,
     toNumber,
     zeroLike,
@@ -91,6 +89,8 @@ import { expandPlacementLabelBoxExtent, resolvePlacementLabelBoxExtent } from '.
 import type { BarCandidateStyleResolver, BarLabelPlacement, BarPositionedCandidate } from '../../labelUtil';
 import {
     adjustLabelPlacement,
+    barLabelDataContext,
+    barLabelObstaclesFor,
     buildBarLabelCandidates,
     createBarCandidateStyleResolver,
     fitLabelToContainerAutoSize,
@@ -1841,31 +1841,19 @@ export class BarSeries extends AbstractBarSeries<BarSeriesTypes> {
     }
 
     getLabelObstacles() {
-        const { label } = this.properties;
-        const box = expandPlacementLabelBoxExtent(label);
-        return barLabelObstacles(
+        return barLabelObstaclesFor(
+            this.properties.label,
             this.contextNodeData?.nodeData,
             this.contextNodeData?.labelData,
             this.isLabelEnabled() && !this.usesPlacedLabels,
-            (node) => ({ label: node.label, config: fontWithSize(label, node.label?.fittedFontSize), box })
+            (node) => node.label
         );
     }
 
     override getLabelData(): PointLabelDatum[] {
         if (!this.usesPlacedLabels || !this.isLabelEnabled()) return [];
         const { label } = this.properties;
-        // Inflate the measured text by the label's drawn box (padding + border stroke) so collisions
-        // avoid the box, not just the text.
-        const box = expandPlacementLabelBoxExtent(label);
-        const measureBox = (text: NormalisedTextOrSegments) => {
-            const { width, height } = measureLabelText(text, label);
-            return { width: width + box.left + box.right, height: height + box.top + box.bottom };
-        };
-        const alwaysShow = label.collision.alwaysShow;
-        const hideable = !alwaysShow;
-        const collideWith = label.collision.resolveCollideWith();
-        const threshold = label.collision.threshold ?? 0;
-        const fitFor = resolveLabelFitDescriptors(label, box, hideable);
+        const { alwaysShow, collideWith, threshold, measureBox, fitFor } = barLabelDataContext(label);
         if (barLabelPropsUsePositionedCandidates(label)) {
             const data: PointLabelDatum[] = [];
             for (const node of this.contextNodeData?.labelData ?? []) {

--- a/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/histogramSeries.ts
@@ -3,7 +3,6 @@ import type {
     DynamicContext,
     LabelFit,
     NormalisedHistogramSeriesStyle,
-    NormalisedTextOrSegments,
     PlacedLabel,
     PointLabelDatum,
 } from 'ag-charts-core';
@@ -16,7 +15,6 @@ import {
     addValues,
     applyBarLabelOrientation,
     applyPlacedBarLabelVisibility,
-    barLabelObstacles,
     barLabelOrientation,
     barLabelPropsRouteThroughEngine,
     barLabelPropsUsePositionedCandidates,
@@ -39,7 +37,6 @@ import {
     measureLabelText,
     mergeDefaults,
     resolveLabelFit,
-    resolveLabelFitDescriptors,
     tickStep,
     toArray,
     toNumber,
@@ -85,6 +82,8 @@ import {
 import { expandPlacementLabelBoxExtent, resolvePlacementLabelBoxExtent } from '../../label';
 import {
     adjustLabelPlacement,
+    barLabelDataContext,
+    barLabelObstaclesFor,
     buildBarLabelCandidates,
     createBarCandidateStyleResolver,
     fitLabelToContainerAutoSize,
@@ -981,13 +980,12 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
     }
 
     getLabelObstacles() {
-        const { label } = this.properties;
-        const box = expandPlacementLabelBoxExtent(label);
-        return barLabelObstacles(
+        return barLabelObstaclesFor(
+            this.properties.label,
             this.contextNodeData?.nodeData,
             this.contextNodeData?.labelData,
             this.isLabelEnabled() && !this.usesPlacedLabels,
-            (node) => ({ label: node.label, config: fontWithSize(label, node.label?.fittedFontSize), box })
+            (node) => node.label
         );
     }
 
@@ -1064,17 +1062,7 @@ export class HistogramSeries extends CartesianSeries<HistogramSeriesTypes> {
     override getLabelData(): PointLabelDatum[] {
         if (!this.usesPlacedLabels || !this.isLabelEnabled()) return [];
         const { label } = this.properties;
-        // Inflate the measured text by the label's drawn box (padding + border stroke) so collisions
-        // avoid the box, not just the text.
-        const box = expandPlacementLabelBoxExtent(label);
-        const measureBox = (text: NormalisedTextOrSegments) => {
-            const { width, height } = measureLabelText(text, label);
-            return { width: width + box.left + box.right, height: height + box.top + box.bottom };
-        };
-        const alwaysShow = label.collision.alwaysShow;
-        const collideWith = label.collision.resolveCollideWith();
-        const threshold = label.collision.threshold ?? 0;
-        const fitFor = resolveLabelFitDescriptors(label, box, !alwaysShow);
+        const { alwaysShow, collideWith, threshold, measureBox, fitFor } = barLabelDataContext(label);
         // The positioned path serves hideable, fitted and placement-cascading labels; an orientation-only
         // array stays on the baked path below, which resolves orientation against the bar region.
         if (barLabelPropsUsePositionedCandidates(label)) {

--- a/packages/ag-charts-community/src/module-support.ts
+++ b/packages/ag-charts-community/src/module-support.ts
@@ -192,6 +192,8 @@ export {
 export type { PreSceneRenderEvent, ProcessDataEvent } from './core/eventsHub';
 export {
     adjustLabelPlacement,
+    barLabelDataContext,
+    barLabelObstaclesFor,
     buildBarLabelCandidates,
     compassCandidatePlacement,
     createBarCandidateStyleResolver,
@@ -207,7 +209,9 @@ export {
 } from './chart/labelUtil';
 export type {
     BarCandidateStyleResolver,
+    BarLabelDataContext,
     BarLabelPlacement,
+    BarLabelSurface,
     BarPositionedCandidate,
     CandidatePlacementMapper,
     ResolvedLabelPlacement,

--- a/packages/ag-charts-core/src/main.ts
+++ b/packages/ag-charts-core/src/main.ts
@@ -127,6 +127,7 @@ export * as Vec2 from './utils/geometry/vector';
 export * as Vec4 from './utils/geometry/vector4';
 export * from './utils/geometry/fill';
 export * from './utils/geometry/bezier';
+export * from './utils/geometry/barLabelGeometry';
 export * from './utils/geometry/labelPlacement';
 export * from './utils/geometry/spatialIndex';
 export * from './utils/geometry/fitRegion';

--- a/packages/ag-charts-core/src/utils/geometry/barLabelGeometry.ts
+++ b/packages/ag-charts-core/src/utils/geometry/barLabelGeometry.ts
@@ -1,0 +1,596 @@
+import type { AgChartLabelOrientation, PaddingOptions } from 'ag-charts-types';
+
+import type { NormalisedTextOrSegments } from '../../types/normalised-options/normalisedCommonOptions';
+import type { Point } from '../../types/scene';
+import type { FontOptions } from '../../types/text';
+import { toArray } from '../data/arrays';
+import { type LabelFit } from '../text/textWrapper';
+import { toDegrees, toRadians } from './angle';
+import type { BoxBounds } from './boxBounds';
+import {
+    type CollideWith,
+    type LabelFitDescriptor,
+    type LabelFitOptions,
+    type LabelObstacle,
+    type OrientationAnchor,
+    type PlacedLabel,
+    type PointLabelDatum,
+    type PositionedLabelCandidate,
+    labelGlyphCentre,
+    measureLabelText,
+    orientationAngles,
+    resolveLabelFit,
+} from './labelPlacement';
+import { getMinOuterRectSize } from './math/shapeUtils';
+
+/**
+ * Rotation (radians) for a bar-family label from its `orientation`; `0` when the orientation is
+ * unset, so an unrotated label renders exactly as before.
+ */
+export function barLabelRotation(orientation: AgChartLabelOrientation | undefined): number {
+    return orientation == null ? 0 : toRadians(orientationAngles[orientation]);
+}
+
+/** Recovers a bar label's `orientation` from its render rotation (radians); inverse of {@link barLabelRotation}. */
+export function barLabelOrientation(rotation: number): AgChartLabelOrientation {
+    if (rotation < 0) return 'vertical';
+    if (rotation > 0) return 'vertical-reversed';
+    return 'horizontal';
+}
+
+/** Which value-axis end(s) an inside bar label is anchored against, so `spacing` reserves its gap there. */
+export type BarValueAnchor = 'start' | 'center' | 'end';
+
+/**
+ * Value-axis `spacing` reservation for an inside label, as an inset on the axis' min and max sides. A
+ * directional label reserves the gap on its single anchored end (text then fills toward the far end); a
+ * centred label reserves nothing (it fills to both edges, never shifted off centre). `start`/`end` map
+ * to the physical min/max side per bar orientation and direction — `start` anchors at the value origin.
+ */
+export function insideBarValueInsets(
+    anchor: BarValueAnchor,
+    isUpward: boolean,
+    isVertical: boolean,
+    spacing: number
+): { min: number; max: number } {
+    if (anchor === 'center') return { min: 0, max: 0 };
+    // The value-origin ('start') end sits at the axis minimum for a downward vertical / upward horizontal bar.
+    const startAtMin = isVertical ? !isUpward : isUpward;
+    const anchoredAtMin = anchor === 'start' ? startAtMin : !startAtMin;
+    return anchoredAtMin ? { min: spacing, max: 0 } : { min: 0, max: spacing };
+}
+
+/**
+ * Inside-label containment region: the bar rect inset by the {@link insideBarValueInsets} `spacing`
+ * reservation on the value axis — the gap the label keeps from the end(s) it is anchored against. The
+ * engine flushes and contains labels against this region, so the gap survives orientation/placement
+ * resolution, not just the anchor. Collision clearance is not part of it; the engine applies
+ * `collision.threshold` to every region uniformly.
+ */
+export function insideBarRegion(
+    rect: BoxBounds,
+    valueMinInset: number,
+    valueMaxInset: number,
+    isVertical: boolean
+): BoxBounds {
+    return isVertical
+        ? {
+              x: rect.x,
+              y: rect.y + valueMinInset,
+              width: rect.width,
+              height: rect.height - valueMinInset - valueMaxInset,
+          }
+        : {
+              x: rect.x + valueMinInset,
+              y: rect.y,
+              width: rect.width - valueMinInset - valueMaxInset,
+              height: rect.height,
+          };
+}
+
+/** Text container for a label inside its bar region: the region shrunk by the box drawn around the text. */
+export function insideBarContainer(
+    region: BoxBounds,
+    box: Required<PaddingOptions>
+): { width: number; height: number } {
+    return {
+        width: Math.max(0, region.width - box.left - box.right),
+        height: Math.max(0, region.height - box.top - box.bottom),
+    };
+}
+
+/**
+ * Size of the largest axis-aligned rectangle a horizontal label can occupy centred on `anchor` inside an
+ * origin-centred annular wedge. Lets a pie/donut sector label wrap/truncate to the room the wedge offers, the
+ * way a bar label fits its rect. `lineHeight` seeds the width with one line's height so the first line clears
+ * the arc; the returned height then bounds how many lines survive. Deliberately conservative — each boundary is
+ * treated independently — so the box always fits; placement (which is not centred on the anchor for a tilted
+ * wedge) is refined separately by the caller.
+ */
+export function sectorLabelContainer(
+    anchor: { x: number; y: number },
+    sector: { startAngle: number; endAngle: number; innerRadius: number; outerRadius: number },
+    lineHeight: number
+): { width: number; height: number } {
+    const { startAngle, endAngle, innerRadius, outerRadius } = sector;
+    const px = Math.abs(anchor.x);
+    const py = Math.abs(anchor.y);
+    const radius = Math.hypot(px, py);
+    if (radius < 1e-6) return { width: 0, height: 0 };
+
+    const cosMid = px / radius;
+    const sinMid = py / radius;
+    const halfSpan = Math.min(Math.abs(endAngle - startAngle) / 2, Math.PI / 2);
+    const edgeDistance = radius * Math.sin(halfSpan);
+    const edges = [startAngle, endAngle].map((angle) => ({
+        sin: Math.abs(Math.sin(angle)),
+        cos: Math.abs(Math.cos(angle)),
+    }));
+
+    // Half-width the wedge allows for a box of half-height `b`: bounded by the outer arc, each straight edge
+    // (box extent along the edge normal <= its perpendicular distance) and, for a donut, the inner arc.
+    const halfWidthGiven = (b: number) => {
+        const outer = Math.sqrt(Math.max(0, outerRadius ** 2 - (py + b) ** 2)) - px;
+        const edgeLimits = edges.map((e) => (e.sin > 1e-6 ? (edgeDistance - b * e.cos) / e.sin : Infinity));
+        const inner = innerRadius > 0 && cosMid > 1e-6 ? (radius - innerRadius - b * sinMid) / cosMid : Infinity;
+        return Math.max(0, Math.min(outer, inner, ...edgeLimits));
+    };
+    const halfHeightGiven = (a: number) => {
+        const outer = Math.sqrt(Math.max(0, outerRadius ** 2 - (px + a) ** 2)) - py;
+        const edgeLimits = edges.map((e) => (e.cos > 1e-6 ? (edgeDistance - a * e.sin) / e.cos : Infinity));
+        const inner = innerRadius > 0 && sinMid > 1e-6 ? (radius - innerRadius - a * cosMid) / sinMid : Infinity;
+        return Math.max(0, Math.min(outer, inner, ...edgeLimits));
+    };
+
+    const halfHeightSeed = lineHeight / 2;
+    const halfWidth = halfWidthGiven(halfHeightSeed);
+    const halfHeight = Math.max(halfHeightSeed, halfHeightGiven(halfWidth));
+    return { width: 2 * halfWidth, height: 2 * halfHeight };
+}
+
+const oppositeSide: Record<keyof Required<PaddingOptions>, keyof Required<PaddingOptions>> = {
+    top: 'bottom',
+    bottom: 'top',
+    left: 'right',
+    right: 'left',
+};
+
+/**
+ * Distance from a bar label's anchor to the bar-facing edge of its (rotated) background box — the gap
+ * the placement must leave, beyond `spacing`, so the box clears the bar.
+ *
+ * The node renders the padded box then rotates it about its own centre. So the reach is the box's
+ * half-extent along the facing axis after rotation, corrected for the anchor sitting on the glyph
+ * edge (not the box centre) and for asymmetric padding shifting the box centre off the glyph centre.
+ * At `rotation === 0` this reduces exactly to `padding[facing]`, leaving unrotated labels unchanged;
+ * a `vertical` label (±90°) instead reaches by the box's cross-axis half-extent.
+ */
+export function rotatedLabelInset(
+    facing: keyof Required<PaddingOptions>,
+    rotation: number,
+    labelWidth: number,
+    labelHeight: number,
+    padding: Required<PaddingOptions>
+): number {
+    const vertical = facing === 'top' || facing === 'bottom';
+    if (rotation === 0) return padding[facing];
+    const boxWidth = labelWidth + padding.left + padding.right;
+    const boxHeight = labelHeight + padding.top + padding.bottom;
+    const sin = Math.abs(Math.sin(rotation));
+    const cos = Math.abs(Math.cos(rotation));
+    const halfExtent = vertical
+        ? (boxWidth / 2) * sin + (boxHeight / 2) * cos
+        : (boxWidth / 2) * cos + (boxHeight / 2) * sin;
+    const glyphHalf = vertical ? labelHeight / 2 : labelWidth / 2;
+    return halfExtent - glyphHalf + (padding[facing] - padding[oppositeSide[facing]]) / 2;
+}
+
+/**
+ * How far a rotated label's glyph centre drifts from where the anchor placed it. The node rotates the
+ * padded box about its own centre, and asymmetric padding offsets that centre from the glyph centre by
+ * `shift = ((right − left)/2, (bottom − top)/2)`; the glyph therefore lands at `glyph + (I − R(θ))·shift`.
+ * Subtract this from the anchor to keep the glyph centred where the caller intended. Zero when
+ * unrotated or when padding is symmetric on the rotating axis.
+ */
+export function rotatedGlyphDrift(rotation: number, padding: Required<PaddingOptions>): Point {
+    const sx = (padding.right - padding.left) / 2;
+    const sy = (padding.bottom - padding.top) / 2;
+    const sin = Math.sin(rotation);
+    const cos = Math.cos(rotation);
+    return { x: sx * (1 - cos) + sy * sin, y: sy * (1 - cos) - sx * sin };
+}
+
+/**
+ * A bar-family label routed through {@link placeLabels} to resolve an ordered `orientation` array.
+ * `target` back-references the baked label datum the chosen rotation is written onto.
+ */
+export interface BarPlacedLabelDatum extends PointLabelDatum {
+    readonly target: BarLabelTarget;
+}
+
+/** The baked label datum an orientation resolution writes its chosen rotation and flush offset back onto. */
+export interface BarLabelTarget {
+    rotation: number;
+    offsetX?: number;
+    offsetY?: number;
+    /** The text fitted to the chosen candidate, when the label opted into per-candidate overflow control. */
+    fittedText?: NormalisedTextOrSegments;
+    /** Reduced font size that text was fitted at; `undefined` when it renders at the configured size. */
+    fittedFontSize?: number;
+    // Positioned-candidate writeback (placement-cascade path only): the chosen anchor and granular placement,
+    // so the label renders at the winning candidate rather than the baked first one.
+    x?: number;
+    y?: number;
+    textAlign?: CanvasTextAlign;
+    textBaseline?: CanvasTextBaseline;
+    placement?: string;
+}
+
+/**
+ * The bar-specific metadata a {@link PositionedLabelCandidate} carries when it comes from a bar-family
+ * label: the render anchor and granular placement written back onto the label node when the candidate
+ * wins. Kept string-typed for `placement` so core does not depend on the community `BarLabelPlacement`.
+ */
+interface BarPositionedCandidate extends PositionedLabelCandidate {
+    readonly anchor: OrientationAnchor;
+    readonly placement: string;
+}
+
+/**
+ * True when an `orientation` array offers more than one candidate to fall through. A single value
+ * (or unset) has nothing to resolve, so the series keeps its unconditional first-orientation bake
+ * and never enters the placement engine — leaving existing charts byte-identical.
+ */
+export function barLabelResolvesOrientation(
+    orientation: AgChartLabelOrientation | AgChartLabelOrientation[] | undefined
+): boolean {
+    return Array.isArray(orientation) && orientation.length > 1;
+}
+
+/**
+ * Axis-aligned obstacle footprint of a rendered label: its padded box centred on the glyph — the
+ * renderer pivots rotation about that centre — then the rotated box's outer AABB. `padding` is the
+ * per-side box extent (padding plus any border) and `rotationRad` the render rotation in radians, so
+ * a series can register a baked label (one not routed through {@link placeLabels}) as a `label`
+ * obstacle other series' labels must avoid. At `rotationRad === 0` the box is exact.
+ */
+export function labelFootprintBox(
+    anchor: OrientationAnchor,
+    glyphWidth: number,
+    glyphHeight: number,
+    padding: Required<PaddingOptions>,
+    rotationRad: number
+): BoxBounds {
+    const boxWidth = glyphWidth + padding.left + padding.right;
+    const boxHeight = glyphHeight + padding.top + padding.bottom;
+    const glyph = labelGlyphCentre(anchor, glyphWidth, glyphHeight);
+    const cx = glyph.x + (padding.right - padding.left) / 2;
+    const cy = glyph.y + (padding.bottom - padding.top) / 2;
+    const { width, height } = getMinOuterRectSize(toDegrees(rotationRad), boxWidth, boxHeight);
+    return { x: cx - width / 2, y: cy - height / 2, width, height };
+}
+
+/**
+ * Builds the {@link PointLabelDatum} routing a bar label through the placement engine: centred on its
+ * glyph box, constrained to `region` (its bar rect, or `undefined` for the plot bounds), offering the
+ * `orientations` candidates, avoiding the obstacle categories `collideWith` enables. The `region` doubles
+ * as the label's own-shape box: it lies within the bar rect, so a `seriesItem` obstacle for the label's
+ * own bar (which the region overlaps) is excluded while neighbouring bars — which the region cannot reach
+ * — are still avoided.
+ */
+export function buildBarLabelDatum(
+    anchor: OrientationAnchor,
+    text: NormalisedTextOrSegments,
+    width: number,
+    height: number,
+    orientations: AgChartLabelOrientation[],
+    region: BoxBounds | undefined,
+    collideWith: CollideWith,
+    threshold: number,
+    target: BarLabelTarget,
+    fit?: LabelFitDescriptor
+): BarPlacedLabelDatum {
+    const { x, y } = labelGlyphCentre(anchor, width, height);
+    return {
+        point: { x, y, size: 0 },
+        label: { text, width, height },
+        fit,
+        anchor: undefined,
+        placement: undefined,
+        orientation: orientations,
+        gap: 0,
+        neverDrop: true,
+        collideWith,
+        threshold,
+        region,
+        ownBox: region,
+        target,
+    };
+}
+
+/**
+ * Builds the {@link PointLabelDatum} routing a bar label through the positioned-candidate engine path:
+ * the pre-positioned `candidates` are cascaded in order (each carries its own region), avoiding other
+ * labels and bars in other columns. Dropped when no candidate fits unless `alwaysShow`. Hands the
+ * engine opaque boxes instead of an orientation array to resolve.
+ */
+export function buildBarPositionedLabelDatum(
+    text: NormalisedTextOrSegments,
+    width: number,
+    height: number,
+    candidates: readonly PositionedLabelCandidate[],
+    target: BarLabelTarget,
+    ownBox: BoxBounds,
+    alwaysShow: boolean,
+    collideWith: CollideWith,
+    threshold: number,
+    ownBoxLabelsCollide = false,
+    fit?: LabelFitDescriptor
+): BarPlacedLabelDatum {
+    return {
+        point: { x: 0, y: 0, size: 0 },
+        label: { text, width, height },
+        fit,
+        anchor: undefined,
+        placement: undefined,
+        gap: 0,
+        // When labels are hideable (`alwaysShow: false`) a no-fit candidate is dropped so the caller
+        // can hide it; otherwise the engine keeps the least-overflowing candidate.
+        neverDrop: alwaysShow,
+        collideWith,
+        threshold,
+        positionedCandidates: candidates,
+        ownBox,
+        ownBoxLabelsCollide,
+        target,
+    };
+}
+
+/**
+ * Writes each placed label's chosen orientation back as a render rotation (radians), plus the flush
+ * offset that slid it inside its region, onto its target. Labels the engine dropped are absent here
+ * and keep the first-orientation rotation baked at node-data time. Every datum here was produced by
+ * {@link buildBarLabelDatum}, so it carries `target`.
+ */
+export function applyBarLabelOrientation(placed: readonly PlacedLabel<unknown>[]): void {
+    for (const { datum, rotation, offsetX, offsetY, candidate, text, fontSize } of placed) {
+        const { target, fit } = datum as BarPlacedLabelDatum;
+        target.rotation = toRadians(rotation ?? 0);
+        target.offsetX = offsetX ?? 0;
+        target.offsetY = offsetY ?? 0;
+        // The engine fitted the text to the candidate it chose, so the node must render that rather than
+        // the unfitted source the datum was built from.
+        target.fittedText = fit == null ? undefined : text;
+        target.fittedFontSize = fit == null ? undefined : fontSize;
+        // Placement-cascade path: the engine chose a whole candidate, so also retarget the label to that
+        // candidate's anchor and granular placement.
+        if (candidate != null) {
+            const { anchor, placement } = candidate as BarPositionedCandidate;
+            target.x = anchor.x;
+            target.y = anchor.y;
+            target.textAlign = anchor.textAlign;
+            target.textBaseline = anchor.textBaseline;
+            target.placement = placement;
+        }
+    }
+}
+
+/**
+ * Flags each routed bar label hidden when the engine dropped it: a routed label (`candidates` set) the
+ * engine kept is in `placed`, one it dropped is absent. Baked labels (no candidates) are left visible.
+ * `resolveTarget` maps each element to its label object, which doubles as its {@link BarLabelTarget}.
+ */
+export function applyPlacedBarLabelVisibility<T>(
+    elements: Iterable<T> | undefined,
+    placed: readonly PlacedLabel<unknown>[],
+    resolveTarget: (element: T) => (BarLabelTarget & { candidates?: unknown; hidden?: boolean }) | undefined
+): void {
+    // The targets the engine kept: a hideable label it dropped is absent from `placed`.
+    const kept = new Set<BarLabelTarget>();
+    for (const { datum } of placed) {
+        kept.add((datum as BarPlacedLabelDatum).target);
+    }
+    for (const element of elements ?? []) {
+        const target = resolveTarget(element);
+        if (target?.candidates != null) target.hidden = !kept.has(target);
+    }
+}
+
+/**
+ * True when a `placement` array offers more than one candidate to cascade through. A single value (or
+ * unset) has nothing to resolve, so the series keeps its unconditional first-placement bake and never
+ * enters the positioned-candidate engine path — leaving existing charts byte-identical.
+ */
+export function barLabelResolvesPlacement(placement: unknown): boolean {
+    return Array.isArray(placement) && placement.length > 1;
+}
+
+/**
+ * Whether a bar-family label takes the positioned-candidate route rather than its unconditional
+ * fast-path bake: a multi-entry placement array cascades through obstacles, a hideable label
+ * (`alwaysShow: false`) routes even a single placement so a no-fit label can be dropped, and a label
+ * that opted into overflow control routes so an obstacle can be answered by shrinking into the room it
+ * leaves rather than by overlapping it — unless an orientation array already routes it, which resolves
+ * the same fit against the bar region on the cheaper baked path.
+ */
+export function barLabelUsesPositionedCandidates(
+    orientation: AgChartLabelOrientation | AgChartLabelOrientation[] | undefined,
+    placement: unknown,
+    alwaysShow: boolean,
+    fit: LabelFit | undefined
+): boolean {
+    return (
+        barLabelResolvesPlacement(placement) ||
+        !alwaysShow ||
+        (fit != null && !barLabelResolvesOrientation(orientation))
+    );
+}
+
+/**
+ * Whether a bar-family label must route through the placement engine rather than take its unconditional
+ * fast-path bake: an orientation array resolves against the bar region, and a placement array, a hideable
+ * label or a fit policy cascades through {@link barLabelUsesPositionedCandidates}.
+ */
+export function barLabelRoutesThroughEngine(
+    orientation: AgChartLabelOrientation | AgChartLabelOrientation[] | undefined,
+    placement: unknown,
+    alwaysShow: boolean,
+    fit: LabelFit | undefined
+): boolean {
+    return (
+        barLabelResolvesOrientation(orientation) || barLabelResolvesPlacement(placement) || !alwaysShow || fit != null
+    );
+}
+
+/** The label-surface fields a routing decision reads, so a caller hands over its label, not four arguments. */
+export interface BarLabelRoutingOptions extends LabelFitOptions {
+    readonly orientation?: AgChartLabelOrientation | AgChartLabelOrientation[];
+    readonly placement?: unknown;
+    readonly collision: { readonly alwaysShow: boolean };
+}
+
+/** {@link barLabelRoutesThroughEngine} for a whole label surface, resolving its own fit policy. */
+export function barLabelPropsRouteThroughEngine(label: BarLabelRoutingOptions): boolean {
+    const alwaysShow = label.collision.alwaysShow;
+    return barLabelRoutesThroughEngine(
+        label.orientation,
+        label.placement,
+        alwaysShow,
+        resolveLabelFit(label, !alwaysShow)
+    );
+}
+
+/** {@link barLabelUsesPositionedCandidates} for a whole label surface, resolving its own fit policy. */
+export function barLabelPropsUsePositionedCandidates(label: BarLabelRoutingOptions): boolean {
+    const alwaysShow = label.collision.alwaysShow;
+    return barLabelUsesPositionedCandidates(
+        label.orientation,
+        label.placement,
+        alwaysShow,
+        resolveLabelFit(label, !alwaysShow)
+    );
+}
+
+/** A baked bar-family label paired with the label config that governs its orientation and font. */
+export interface BarLabelSource {
+    readonly label:
+        | (OrientationAnchor & { text: NormalisedTextOrSegments; region?: BoxBounds } & BarLabelTarget)
+        | undefined;
+    readonly config: FontOptions & { orientation?: AgChartLabelOrientation | AgChartLabelOrientation[] };
+    /** Pre-measured footprint (text plus box padding/border); falls back to measuring `label.text` with `config`. */
+    readonly size?: { width: number; height: number };
+    /** Resolved obstacle-category toggles for this label, stamped onto the datum. */
+    readonly collideWith: CollideWith;
+    /** Collision clearance for this label's box, stamped onto the datum. */
+    readonly threshold: number;
+    /** Per-candidate fit inputs, so each orientation gets the text refitted to the room it actually has. */
+    readonly fit?: LabelFitDescriptor;
+}
+
+/**
+ * Builds the placement-engine data for a series' baked labels: for each element `resolve` yields the
+ * label object and its config; single-orientation labels are skipped (nothing to resolve).
+ */
+export function buildBarLabelData<T>(
+    elements: Iterable<T> | undefined,
+    resolve: (element: T) => BarLabelSource | undefined
+): BarPlacedLabelDatum[] {
+    const data: BarPlacedLabelDatum[] = [];
+    for (const element of elements ?? []) {
+        const source = resolve(element);
+        if (source?.label == null || source.label.text === '') continue;
+        const { label, config } = source;
+        const orientations = toArray(config.orientation);
+        if (orientations.length <= 1) continue;
+        const { width, height } = source.size ?? measureLabelText(label.text, config);
+        data.push(
+            buildBarLabelDatum(
+                label,
+                label.text,
+                width,
+                height,
+                orientations,
+                label.region,
+                source.collideWith,
+                source.threshold,
+                label,
+                source.fit
+            )
+        );
+    }
+    return data;
+}
+
+/** A rect-shaped node (bar, histogram bin) contributed to the obstacle index as its drawn footprint. */
+export interface RectObstacleSource {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+    readonly phantom?: boolean;
+}
+
+/**
+ * Maps rect-shaped node data (bars, histogram bins) to `seriesItem` label obstacles so that labels from
+ * other series route around them. Skips phantom (stacking/feather) nodes and zero-area rects.
+ */
+export function rectLabelObstacles(nodeData: readonly RectObstacleSource[] | undefined): LabelObstacle[] | undefined {
+    if (nodeData == null || nodeData.length === 0) return undefined;
+    const obstacles: LabelObstacle[] = [];
+    for (const { x, y, width, height, phantom } of nodeData) {
+        if (phantom === true || width <= 0 || height <= 0) continue;
+        obstacles.push({ kind: 'rect', box: { x, y, width, height }, category: 'seriesItem' });
+    }
+    return obstacles.length > 0 ? obstacles : undefined;
+}
+
+/** A baked bar-family label paired with the config and per-side box extent that size its footprint. */
+export interface BakedLabelSource {
+    readonly label:
+        | (OrientationAnchor & { text: NormalisedTextOrSegments; rotation: number; hidden?: boolean })
+        | undefined;
+    /** Font config for glyph measurement. */
+    readonly config: FontOptions;
+    /** Per-side drawn-box extent (padding plus any border). */
+    readonly box: Required<PaddingOptions>;
+}
+
+/**
+ * Builds `label` obstacles for a series' baked labels — labels drawn without routing through
+ * {@link placeLabels}, so they never enter the obstacle index there. Contributing their drawn footprint
+ * lets other series' labels avoid them. Skips absent, empty-text and hidden labels.
+ */
+export function bakedLabelObstacles<T>(
+    elements: Iterable<T> | undefined,
+    resolve: (element: T) => BakedLabelSource | undefined
+): LabelObstacle[] | undefined {
+    const obstacles: LabelObstacle[] = [];
+    for (const element of elements ?? []) {
+        const source = resolve(element);
+        const label = source?.label;
+        if (source == null || label == null || label.text === '' || label.hidden === true) continue;
+        const { width, height } = measureLabelText(label.text, source.config);
+        const box = labelFootprintBox(label, width, height, source.box, label.rotation);
+        obstacles.push({ kind: 'rect', box, category: 'label' });
+    }
+    return obstacles.length > 0 ? obstacles : undefined;
+}
+
+/**
+ * Combines a bar-family series' rendered-rect obstacles (`seriesItem`) with the footprints of its baked
+ * labels (`label`) — the obstacle set other series' labels must avoid. `bakeLabels` must be false when the
+ * series routes its labels through {@link placeLabels}: the engine indexes each routed label as it places
+ * it, so baking them here too would double-count them (see the caller's `usesPlacedLabels` guard).
+ */
+export function barLabelObstacles<T>(
+    nodeData: readonly RectObstacleSource[] | undefined,
+    labelData: Iterable<T> | undefined,
+    bakeLabels: boolean,
+    resolveBaked: (element: T) => BakedLabelSource | undefined
+): LabelObstacle[] | undefined {
+    const rects = rectLabelObstacles(nodeData);
+    if (!bakeLabels) return rects;
+    const labels = bakedLabelObstacles(labelData, resolveBaked);
+    if (labels == null) return rects;
+    return rects == null ? labels : rects.concat(labels);
+}

--- a/packages/ag-charts-core/src/utils/geometry/labelPlacement.test.ts
+++ b/packages/ag-charts-core/src/utils/geometry/labelPlacement.test.ts
@@ -3,10 +3,26 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AgChartLabelOrientation, PaddingOptions } from 'ag-charts-types';
 
 import type { Point, SizedPoint } from '../../types/scene';
-import { type BoxBounds, boxCollides, boxContains } from './boxBounds';
 import {
     type BarLabelTarget,
     type BarPlacedLabelDatum,
+    applyBarLabelOrientation,
+    bakedLabelObstacles,
+    barLabelResolvesOrientation,
+    barLabelResolvesPlacement,
+    buildBarLabelDatum,
+    buildBarPositionedLabelDatum,
+    insideBarContainer,
+    insideBarRegion,
+    insideBarValueInsets,
+    labelFootprintBox,
+    rectLabelObstacles,
+    rotatedGlyphDrift,
+    rotatedLabelInset,
+    sectorLabelContainer,
+} from './barLabelGeometry';
+import { type BoxBounds, boxCollides, boxContains } from './boxBounds';
+import {
     type CandidateLabelStyle,
     type CandidateStyleResolver,
     type CollideWith,
@@ -18,24 +34,10 @@ import {
     type PositionedLabelCandidate,
     type SeriesLabelDefaults,
     type SeriesLabels,
-    applyBarLabelOrientation,
-    bakedLabelObstacles,
-    barLabelResolvesOrientation,
-    barLabelResolvesPlacement,
-    buildBarLabelDatum,
-    buildBarPositionedLabelDatum,
-    insideBarContainer,
-    insideBarRegion,
-    insideBarValueInsets,
-    labelFootprintBox,
     labelGlyphCentre,
     measureLabelText,
     placeLabels,
-    rectLabelObstacles,
     resolveLabelFit,
-    rotatedGlyphDrift,
-    rotatedLabelInset,
-    sectorLabelContainer,
 } from './labelPlacement';
 import { SpatialIndex } from './spatialIndex';
 
@@ -1986,7 +1988,7 @@ describe('placeLabels per-candidate fit', () => {
     const fittedLabel = (region: BoxBounds, overrides: Partial<PointLabelDatum> = {}): PointLabelDatum => ({
         point: { x: region.x + region.width / 2, y: region.y + region.height / 2, size: 0 },
         label: { text: TEXT, width: 50, height: 20 },
-        fit: { text: TEXT, policy: { overflowStrategy: 'ellipsis' }, font: FONT },
+        fit: { text: TEXT, policy: { overflowStrategy: 'ellipsis' }, font: FONT, boundByRegion: true },
         anchor: undefined,
         placement: undefined,
         orientation: ['horizontal', 'vertical'],
@@ -2048,7 +2050,12 @@ describe('placeLabels per-candidate fit', () => {
                 { x: 0, y: 0, width: 400, height: 400 },
                 {
                     region: undefined,
-                    fit: { text: TEXT, policy: { maxWidth: 34, overflowStrategy: 'ellipsis' }, font: FONT },
+                    fit: {
+                        text: TEXT,
+                        policy: { maxWidth: 34, overflowStrategy: 'ellipsis' },
+                        font: FONT,
+                        boundByRegion: true,
+                    },
                 }
             )
         );
@@ -2063,7 +2070,7 @@ describe('placeLabels per-candidate fit', () => {
                 { x: 0, y: 0, width: 34, height: 34 },
                 {
                     orientation: 'horizontal',
-                    fit: { text: TEXT, policy: { overflowStrategy: 'hide' }, font: FONT },
+                    fit: { text: TEXT, policy: { overflowStrategy: 'hide' }, font: FONT, boundByRegion: true },
                 }
             )
         );
@@ -2177,7 +2184,7 @@ describe('placeLabels obstacle-driven shrink', () => {
     const shrinkableLabel = (overrides: Partial<PointLabelDatum> = {}): PointLabelDatum => ({
         point: POINT,
         label: { text: TEXT, width: 50, height: 20 },
-        fit: { text: TEXT, policy: { overflowStrategy: 'ellipsis' }, font: FONT },
+        fit: { text: TEXT, policy: { overflowStrategy: 'ellipsis' }, font: FONT, boundByRegion: true },
         anchor: undefined,
         placement: 'top',
         placements: ['top'],

--- a/packages/ag-charts-core/src/utils/geometry/labelPlacement.test.ts
+++ b/packages/ag-charts-core/src/utils/geometry/labelPlacement.test.ts
@@ -2539,3 +2539,179 @@ describe('placeLabels collision shrink', () => {
         expect(placed[1].x).toBeCloseTo(220);
     });
 });
+
+// Brute-force reference for the positioned-candidate path (bar family): the engine owns only the
+// generic containment/obstacle/flush/least-overflow logic there, so it can be restated directly.
+// Deliberately covers the no-fit case only — a datum without `fit` skips every shrink and re-fit
+// branch, leaving the candidate cascade itself as the thing under test.
+function obstacleExcludedOracle(o: LabelObstacle, d: PointLabelDatum): boolean {
+    const category = o.category ?? 'seriesItem';
+    const { ownBox } = d;
+    if (
+        ownBox != null &&
+        !(d.ownBoxLabelsCollide === true && category === 'label') &&
+        boxCollides(o.box, ownBox.x, ownBox.y, ownBox.width, ownBox.height)
+    ) {
+        return true;
+    }
+    return d.collideWith?.[category] === false;
+}
+
+function clampAxisOracle(pos: number, size: number, min: number, extent: number): number {
+    if (size > extent) return pos;
+    return Math.min(Math.max(pos, min), min + extent - size);
+}
+
+function regionOverflowOracle(region: BoxBounds, x: number, y: number, w: number, h: number): number {
+    return (
+        Math.max(0, region.x - x) +
+        Math.max(0, x + w - (region.x + region.width)) +
+        Math.max(0, region.y - y) +
+        Math.max(0, y + h - (region.y + region.height))
+    );
+}
+
+function orderKeepFirstOracle(data: Map<string, SeriesLabels>): [string, SeriesLabels][] {
+    const hides = (e: SeriesLabels) => e.defaults?.alwaysShow === false || e.datums.some((d) => d.alwaysShow === false);
+    const entries = [...data.entries()];
+    return entries.filter(([, e]) => !hides(e)).concat(entries.filter(([, e]) => hides(e)));
+}
+
+function placePositionedLabelsOracle(
+    data: Map<string, SeriesLabels>,
+    bounds: BoxBounds,
+    externalObstacles: readonly LabelObstacle[] = []
+) {
+    const result = new Map<string, PlacedLabel[]>();
+    const obstacles: LabelObstacle[] = [...externalObstacles];
+    for (const [seriesId, entry] of orderKeepFirstOracle(data)) {
+        const labels: PlacedLabel[] = [];
+        if (!entry.datums[0]?.label) continue;
+        for (let index = 0, ln = entry.datums.length; index < ln; index++) {
+            const d = entry.datums[index];
+            if (d.label.text === '') continue;
+            const { width, height } = d.label;
+            let winner: { x: number; y: number } | undefined;
+            let best: { x: number; y: number; overflow: number } | undefined;
+            for (const c of d.positionedCandidates ?? []) {
+                if (c.hidden === true) continue;
+                const region = c.region ?? bounds;
+                let { x, y } = c.box;
+                const { width: cw, height: ch } = c.box;
+                if (c.region != null && c.flushToRegion !== false) {
+                    x = clampAxisOracle(x, cw, region.x, region.width);
+                    y = clampAxisOracle(y, ch, region.y, region.height);
+                }
+                const contained = boxContains(region, x, y, cw, ch);
+                const blocked = obstacles.some(
+                    (o) => !obstacleExcludedOracle(o, d) && boxCollides(o.box, x, y, cw, ch)
+                );
+                if (contained && !blocked) {
+                    winner = { x, y };
+                    break;
+                }
+                if (d.neverDrop === true) {
+                    const overflow = regionOverflowOracle(region, x, y, cw, ch);
+                    if (best == null || overflow < best.overflow) best = { x, y, overflow };
+                }
+            }
+            const chosen = winner ?? best;
+            if (chosen == null) continue;
+            const placed = { index, text: d.label.text, x: chosen.x, y: chosen.y, width, height, datum: d };
+            labels.push(placed);
+            obstacles.push({ kind: 'rect', box: placed, category: 'label' });
+        }
+        result.set(seriesId, labels);
+    }
+    return result;
+}
+
+function makePositionedFixture(seriesCount: number, perSeries: number, bounds: BoxBounds, seed0: number) {
+    let seed = seed0;
+    const next = () => {
+        seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+        return seed / 0x7fffffff;
+    };
+    const data = new Map<string, SeriesLabels>();
+    for (let s = 0; s < seriesCount; s++) {
+        const datums: PointLabelDatum[] = [];
+        const barWidth = bounds.width / perSeries;
+        for (let i = 0; i < perSeries; i++) {
+            // A bar rect, its label box, and the candidates a bar series would offer around it.
+            const barHeight = 20 + next() * 200;
+            const ownBox: BoxBounds = {
+                x: bounds.x + i * barWidth + 2,
+                y: bounds.y + bounds.height - barHeight,
+                width: barWidth - 4,
+                height: barHeight,
+            };
+            const width = 20 + next() * 60;
+            const height = 10 + next() * 10;
+            const cx = ownBox.x + ownBox.width / 2 - width / 2;
+            const candidates: PositionedLabelCandidate[] = [
+                // inside-start, region-bound and flushed
+                { box: { x: cx, y: ownBox.y + 2, width, height }, region: ownBox },
+                // inside-center, collision boundary only
+                {
+                    box: { x: cx, y: ownBox.y + ownBox.height / 2 - height / 2, width, height },
+                    region: ownBox,
+                    flushToRegion: false,
+                },
+                // outside-start, unbounded
+                { box: { x: cx, y: ownBox.y - height - 2, width, height } },
+            ];
+            if (next() < 0.25) candidates[1] = { ...candidates[1], hidden: true };
+            const alwaysShow = next() < 0.5;
+            datums.push(
+                buildBarPositionedLabelDatum(
+                    `s${s}-${i}`,
+                    width,
+                    height,
+                    candidates,
+                    {} as BarLabelTarget,
+                    ownBox,
+                    alwaysShow,
+                    { marker: true, label: true, seriesItem: true },
+                    0,
+                    next() < 0.3
+                )
+            );
+        }
+        data.set(`series-${s}`, seriesLabels(datums));
+    }
+    return data;
+}
+
+describe('placeLabels (positioned candidates)', () => {
+    const bounds: BoxBounds = { x: 0, y: 0, width: 600, height: 400 };
+
+    it.each([1, 2, 3])('matches the brute-force oracle (%i series)', (seriesCount) => {
+        let placedCount = 0;
+        let droppedCount = 0;
+        for (let seed = 1; seed <= 12; seed++) {
+            const data = makePositionedFixture(seriesCount, 9, bounds, seed);
+            const placed = placeLabels(data, bounds, 5);
+            expect(normalise(placed)).toEqual(normalise(placePositionedLabelsOracle(data, bounds)));
+            for (const [id, labels] of placed) {
+                placedCount += labels.length;
+                droppedCount += (data.get(id)?.datums.length ?? 0) - labels.length;
+            }
+        }
+        // Parity is only worth asserting over a fixture that exercises both outcomes.
+        expect(placedCount).toBeGreaterThan(0);
+        expect(droppedCount).toBeGreaterThan(0);
+    });
+
+    it('matches the brute-force oracle with cross-series obstacles', () => {
+        const obstacles: LabelObstacle[] = [
+            { kind: 'rect', category: 'seriesItem', box: { x: 100, y: 150, width: 120, height: 80 } },
+            { kind: 'rect', category: 'label', box: { x: 380, y: 60, width: 90, height: 40 } },
+        ];
+        for (let seed = 1; seed <= 12; seed++) {
+            const data = makePositionedFixture(2, 9, bounds, seed);
+            expect(normalise(placeLabels(data, bounds, 5, obstacles))).toEqual(
+                normalise(placePositionedLabelsOracle(data, bounds, obstacles))
+            );
+        }
+    });
+});

--- a/packages/ag-charts-core/src/utils/geometry/labelPlacement.ts
+++ b/packages/ag-charts-core/src/utils/geometry/labelPlacement.ts
@@ -656,10 +656,6 @@ const boundedFit: {
 let candidateFontSize: number | undefined;
 // Size the collision-shrink search is currently re-running the cascade at, `undefined` outside a trial.
 let candidateTrialFontSize: number | undefined;
-// True while a candidate is being re-fitted to the room its obstacles leave. That pass trades text for
-// room, never font size: shrinking the font to clear a neighbour is the ladder's job (see
-// {@link shrinkToClear}), which runs once per label over every candidate rather than per candidate.
-let refittingToObstacles = false;
 // The candidate font at the trial size, refilled per candidate while a trial is running.
 const trialFont: FontOptions = { fontSize: 0 };
 
@@ -1291,6 +1287,7 @@ function fitLabelToCandidate(
     font: FontOptions,
     source: { width: number; height: number } | undefined,
     container: { width: number; height: number } | undefined,
+    fontSearch: boolean,
     candidateRegion?: FitRegion,
     candidateRegionAlign?: RegionAlign
 ) {
@@ -1321,10 +1318,7 @@ function fitLabelToCandidate(
     boundedFit.maxHeight = maxHeight === Infinity ? undefined : maxHeight;
     boundedFit.wrapping = policy.wrapping;
     boundedFit.overflowStrategy = policy.overflowStrategy;
-    // A trial already owns the size, so the inner search must not run a second one inside it; nor may the
-    // obstacle re-fit, which answers a collision with text rather than with a smaller font.
-    boundedFit.minimumFontSize =
-        candidateTrialFontSize == null && !refittingToObstacles ? policy.minimumFontSize : undefined;
+    boundedFit.minimumFontSize = fontSearch ? policy.minimumFontSize : undefined;
     boundedFit.region = region;
     boundedFit.regionAlign = regionAlign;
     const { text: fitted, fontSize } = fitLabelTextOrOverflowAutoSize(text, boundedFit, fit.fitOverflow, font);
@@ -1475,7 +1469,7 @@ function sizeCandidateLabel(
     // A styled or trialled candidate re-measures the source under its own font; an unstyled one at the
     // configured size shares the cascade's single measurement.
     const source = style == null && candidateTrialFontSize == null ? fitSource : styledFitSource(fit, font);
-    if (!fitLabelToCandidate(fit, font, source, container)) return false;
+    if (!fitLabelToCandidate(fit, font, source, container, candidateTrialFontSize == null)) return false;
     writeCandidateLabel(boxPadding, font);
     return true;
 }
@@ -1525,12 +1519,9 @@ function refitCandidateShrunk(
     // extent as well would forbid the wrap that trades width for height.
     shrunkContainer.width = reduceAxis(candidateLabel.maxWidth, candidateLabel.glyphWidth, reduceWidth);
     shrunkContainer.height = reduceAxis(candidateLabel.maxHeight, candidateLabel.glyphHeight, reduceHeight);
-    refittingToObstacles = true;
-    try {
-        if (!fitLabelToCandidate(fit, font, source, shrunkContainer)) return false;
-    } finally {
-        refittingToObstacles = false;
-    }
+    // The obstacle re-fit answers a collision with text, never with a smaller font: reducing the size is
+    // the ladder's job, which runs once per label over every candidate rather than per candidate.
+    if (!fitLabelToCandidate(fit, font, source, shrunkContainer, false)) return false;
     if (!hasRealChars(fittedLabel.text)) return false;
     writeCandidateLabel(boxPadding, font);
     return true;
@@ -2113,7 +2104,15 @@ function placeFromPositionedCandidates(
             const source = styledFont == null ? fitSource : styledFitSource(fit, styledFont);
             const container = deflateContainer(c.fitTo.container, threshold);
             if (
-                !fitLabelToCandidate(fit, styledFont ?? fit.font, source, container, c.fitTo.shape, c.fitTo.shapeAlign)
+                !fitLabelToCandidate(
+                    fit,
+                    styledFont ?? fit.font,
+                    source,
+                    container,
+                    candidateTrialFontSize == null,
+                    c.fitTo.shape,
+                    c.fitTo.shapeAlign
+                )
             ) {
                 continue;
             }
@@ -2127,6 +2126,7 @@ function placeFromPositionedCandidates(
                     styledFont ?? fit.font,
                     source,
                     c.fitTo.container,
+                    candidateTrialFontSize == null,
                     c.fitTo.shape,
                     c.fitTo.shapeAlign
                 )

--- a/packages/ag-charts-core/src/utils/geometry/labelPlacement.ts
+++ b/packages/ag-charts-core/src/utils/geometry/labelPlacement.ts
@@ -4,7 +4,6 @@ import { cachedTextMeasurer, measureTextSegments } from '../../rendering/textMea
 import type { NormalisedTextOrSegments } from '../../types/normalised-options/normalisedCommonOptions';
 import type { Point, SizedPoint } from '../../types/scene';
 import type { FontOptions } from '../../types/text';
-import { toArray } from '../data/arrays';
 import { toFontString, toTextString } from '../text/textUtils';
 import {
     type LabelFit,
@@ -17,7 +16,6 @@ import {
     resolveMinimumFontSize,
 } from '../text/textWrapper';
 import { isArray } from '../types/typeGuards';
-import { toDegrees, toRadians } from './angle';
 import { type BoxBounds, boxCollides, boxContains } from './boxBounds';
 import type { FitRegion } from './fitRegion';
 import { getMinOuterRectSize } from './math/shapeUtils';
@@ -108,11 +106,11 @@ export interface LabelFitDescriptor {
      */
     readonly fitOverflow?: LabelFit;
     /**
-     * Bound the text by the datum's {@link PointLabelDatum.region} as well as by {@link policy}; defaults
-     * to `true`. A bar label fits its bar rect, but a point label's region is the plotting area, which
-     * contains its labels rather than truncating them.
+     * Bound the text by the datum's {@link PointLabelDatum.region} as well as by {@link policy}. A bar
+     * label fits its bar rect, but a point label's region is the plotting area, which contains its
+     * labels rather than truncating them.
      */
-    readonly boundByRegion?: boolean;
+    readonly boundByRegion: boolean;
 }
 
 /**
@@ -128,7 +126,7 @@ export function resolveLabelFitDescriptors(
 ) {
     const policy = resolveLabelFit(fit, hideOnOverflow);
     return (text: NormalisedTextOrSegments): LabelFitDescriptor | undefined =>
-        policy == null ? undefined : { text, policy, font: fit, boxPadding };
+        policy == null ? undefined : { text, policy, font: fit, boxPadding, boundByRegion: true };
 }
 
 /**
@@ -496,235 +494,11 @@ export const orientationAngles: Record<AgChartLabelOrientation, number> = {
     'vertical-reversed': 90,
 };
 
-/**
- * Rotation (radians) for a bar-family label from its `orientation`; `0` when the orientation is
- * unset, so an unrotated label renders exactly as before.
- */
-export function barLabelRotation(orientation: AgChartLabelOrientation | undefined): number {
-    return orientation == null ? 0 : toRadians(orientationAngles[orientation]);
-}
-
-/** Recovers a bar label's `orientation` from its render rotation (radians); inverse of {@link barLabelRotation}. */
-export function barLabelOrientation(rotation: number): AgChartLabelOrientation {
-    if (rotation < 0) return 'vertical';
-    if (rotation > 0) return 'vertical-reversed';
-    return 'horizontal';
-}
-
-/** Which value-axis end(s) an inside bar label is anchored against, so `spacing` reserves its gap there. */
-export type BarValueAnchor = 'start' | 'center' | 'end';
-
-/**
- * Value-axis `spacing` reservation for an inside label, as an inset on the axis' min and max sides. A
- * directional label reserves the gap on its single anchored end (text then fills toward the far end); a
- * centred label reserves nothing (it fills to both edges, never shifted off centre). `start`/`end` map
- * to the physical min/max side per bar orientation and direction — `start` anchors at the value origin.
- */
-export function insideBarValueInsets(
-    anchor: BarValueAnchor,
-    isUpward: boolean,
-    isVertical: boolean,
-    spacing: number
-): { min: number; max: number } {
-    if (anchor === 'center') return { min: 0, max: 0 };
-    // The value-origin ('start') end sits at the axis minimum for a downward vertical / upward horizontal bar.
-    const startAtMin = isVertical ? !isUpward : isUpward;
-    const anchoredAtMin = anchor === 'start' ? startAtMin : !startAtMin;
-    return anchoredAtMin ? { min: spacing, max: 0 } : { min: 0, max: spacing };
-}
-
-/**
- * Inside-label containment region: the bar rect inset by the {@link insideBarValueInsets} `spacing`
- * reservation on the value axis — the gap the label keeps from the end(s) it is anchored against. The
- * engine flushes and contains labels against this region, so the gap survives orientation/placement
- * resolution, not just the anchor. Collision clearance is not part of it; the engine applies
- * `collision.threshold` to every region uniformly.
- */
-export function insideBarRegion(
-    rect: BoxBounds,
-    valueMinInset: number,
-    valueMaxInset: number,
-    isVertical: boolean
-): BoxBounds {
-    return isVertical
-        ? {
-              x: rect.x,
-              y: rect.y + valueMinInset,
-              width: rect.width,
-              height: rect.height - valueMinInset - valueMaxInset,
-          }
-        : {
-              x: rect.x + valueMinInset,
-              y: rect.y,
-              width: rect.width - valueMinInset - valueMaxInset,
-              height: rect.height,
-          };
-}
-
-/** Text container for a label inside its bar region: the region shrunk by the box drawn around the text. */
-export function insideBarContainer(
-    region: BoxBounds,
-    box: Required<PaddingOptions>
-): { width: number; height: number } {
-    return {
-        width: Math.max(0, region.width - box.left - box.right),
-        height: Math.max(0, region.height - box.top - box.bottom),
-    };
-}
-
-/**
- * Size of the largest axis-aligned rectangle a horizontal label can occupy centred on `anchor` inside an
- * origin-centred annular wedge. Lets a pie/donut sector label wrap/truncate to the room the wedge offers, the
- * way a bar label fits its rect. `lineHeight` seeds the width with one line's height so the first line clears
- * the arc; the returned height then bounds how many lines survive. Deliberately conservative — each boundary is
- * treated independently — so the box always fits; placement (which is not centred on the anchor for a tilted
- * wedge) is refined separately by the caller.
- */
-export function sectorLabelContainer(
-    anchor: { x: number; y: number },
-    sector: { startAngle: number; endAngle: number; innerRadius: number; outerRadius: number },
-    lineHeight: number
-): { width: number; height: number } {
-    const { startAngle, endAngle, innerRadius, outerRadius } = sector;
-    const px = Math.abs(anchor.x);
-    const py = Math.abs(anchor.y);
-    const radius = Math.hypot(px, py);
-    if (radius < 1e-6) return { width: 0, height: 0 };
-
-    const cosMid = px / radius;
-    const sinMid = py / radius;
-    const halfSpan = Math.min(Math.abs(endAngle - startAngle) / 2, Math.PI / 2);
-    const edgeDistance = radius * Math.sin(halfSpan);
-    const edges = [startAngle, endAngle].map((angle) => ({
-        sin: Math.abs(Math.sin(angle)),
-        cos: Math.abs(Math.cos(angle)),
-    }));
-
-    // Half-width the wedge allows for a box of half-height `b`: bounded by the outer arc, each straight edge
-    // (box extent along the edge normal <= its perpendicular distance) and, for a donut, the inner arc.
-    const halfWidthGiven = (b: number) => {
-        const outer = Math.sqrt(Math.max(0, outerRadius ** 2 - (py + b) ** 2)) - px;
-        const edgeLimits = edges.map((e) => (e.sin > 1e-6 ? (edgeDistance - b * e.cos) / e.sin : Infinity));
-        const inner = innerRadius > 0 && cosMid > 1e-6 ? (radius - innerRadius - b * sinMid) / cosMid : Infinity;
-        return Math.max(0, Math.min(outer, inner, ...edgeLimits));
-    };
-    const halfHeightGiven = (a: number) => {
-        const outer = Math.sqrt(Math.max(0, outerRadius ** 2 - (px + a) ** 2)) - py;
-        const edgeLimits = edges.map((e) => (e.cos > 1e-6 ? (edgeDistance - a * e.sin) / e.cos : Infinity));
-        const inner = innerRadius > 0 && sinMid > 1e-6 ? (radius - innerRadius - a * cosMid) / sinMid : Infinity;
-        return Math.max(0, Math.min(outer, inner, ...edgeLimits));
-    };
-
-    const halfHeightSeed = lineHeight / 2;
-    const halfWidth = halfWidthGiven(halfHeightSeed);
-    const halfHeight = Math.max(halfHeightSeed, halfHeightGiven(halfWidth));
-    return { width: 2 * halfWidth, height: 2 * halfHeight };
-}
-
-const oppositeSide: Record<keyof Required<PaddingOptions>, keyof Required<PaddingOptions>> = {
-    top: 'bottom',
-    bottom: 'top',
-    left: 'right',
-    right: 'left',
-};
-
-/**
- * Distance from a bar label's anchor to the bar-facing edge of its (rotated) background box — the gap
- * the placement must leave, beyond `spacing`, so the box clears the bar.
- *
- * The node renders the padded box then rotates it about its own centre. So the reach is the box's
- * half-extent along the facing axis after rotation, corrected for the anchor sitting on the glyph
- * edge (not the box centre) and for asymmetric padding shifting the box centre off the glyph centre.
- * At `rotation === 0` this reduces exactly to `padding[facing]`, leaving unrotated labels unchanged;
- * a `vertical` label (±90°) instead reaches by the box's cross-axis half-extent.
- */
-export function rotatedLabelInset(
-    facing: keyof Required<PaddingOptions>,
-    rotation: number,
-    labelWidth: number,
-    labelHeight: number,
-    padding: Required<PaddingOptions>
-): number {
-    const vertical = facing === 'top' || facing === 'bottom';
-    if (rotation === 0) return padding[facing];
-    const boxWidth = labelWidth + padding.left + padding.right;
-    const boxHeight = labelHeight + padding.top + padding.bottom;
-    const sin = Math.abs(Math.sin(rotation));
-    const cos = Math.abs(Math.cos(rotation));
-    const halfExtent = vertical
-        ? (boxWidth / 2) * sin + (boxHeight / 2) * cos
-        : (boxWidth / 2) * cos + (boxHeight / 2) * sin;
-    const glyphHalf = vertical ? labelHeight / 2 : labelWidth / 2;
-    return halfExtent - glyphHalf + (padding[facing] - padding[oppositeSide[facing]]) / 2;
-}
-
-/**
- * How far a rotated label's glyph centre drifts from where the anchor placed it. The node rotates the
- * padded box about its own centre, and asymmetric padding offsets that centre from the glyph centre by
- * `shift = ((right − left)/2, (bottom − top)/2)`; the glyph therefore lands at `glyph + (I − R(θ))·shift`.
- * Subtract this from the anchor to keep the glyph centred where the caller intended. Zero when
- * unrotated or when padding is symmetric on the rotating axis.
- */
-export function rotatedGlyphDrift(rotation: number, padding: Required<PaddingOptions>): Point {
-    const sx = (padding.right - padding.left) / 2;
-    const sy = (padding.bottom - padding.top) / 2;
-    const sin = Math.sin(rotation);
-    const cos = Math.cos(rotation);
-    return { x: sx * (1 - cos) + sy * sin, y: sy * (1 - cos) - sx * sin };
-}
-
 export interface OrientationAnchor {
     readonly x: number;
     readonly y: number;
     readonly textAlign: CanvasTextAlign;
     readonly textBaseline: CanvasTextBaseline;
-}
-
-/**
- * A bar-family label routed through {@link placeLabels} to resolve an ordered `orientation` array.
- * `target` back-references the baked label datum the chosen rotation is written onto.
- */
-export interface BarPlacedLabelDatum extends PointLabelDatum {
-    readonly target: BarLabelTarget;
-}
-
-/** The baked label datum an orientation resolution writes its chosen rotation and flush offset back onto. */
-export interface BarLabelTarget {
-    rotation: number;
-    offsetX?: number;
-    offsetY?: number;
-    /** The text fitted to the chosen candidate, when the label opted into per-candidate overflow control. */
-    fittedText?: NormalisedTextOrSegments;
-    /** Reduced font size that text was fitted at; `undefined` when it renders at the configured size. */
-    fittedFontSize?: number;
-    // Positioned-candidate writeback (placement-cascade path only): the chosen anchor and granular placement,
-    // so the label renders at the winning candidate rather than the baked first one.
-    x?: number;
-    y?: number;
-    textAlign?: CanvasTextAlign;
-    textBaseline?: CanvasTextBaseline;
-    placement?: string;
-}
-
-/**
- * The bar-specific metadata a {@link PositionedLabelCandidate} carries when it comes from a bar-family
- * label: the render anchor and granular placement written back onto the label node when the candidate
- * wins. Kept string-typed for `placement` so core does not depend on the community `BarLabelPlacement`.
- */
-interface BarPositionedCandidate extends PositionedLabelCandidate {
-    readonly anchor: OrientationAnchor;
-    readonly placement: string;
-}
-
-/**
- * True when an `orientation` array offers more than one candidate to fall through. A single value
- * (or unset) has nothing to resolve, so the series keeps its unconditional first-orientation bake
- * and never enters the placement engine — leaving existing charts byte-identical.
- */
-export function barLabelResolvesOrientation(
-    orientation: AgChartLabelOrientation | AgChartLabelOrientation[] | undefined
-): boolean {
-    return Array.isArray(orientation) && orientation.length > 1;
 }
 
 /**
@@ -775,365 +549,9 @@ export function writeLabelBoxCentre(
     return out;
 }
 
-/**
- * Axis-aligned obstacle footprint of a rendered label: its padded box centred on the glyph — the
- * renderer pivots rotation about that centre — then the rotated box's outer AABB. `padding` is the
- * per-side box extent (padding plus any border) and `rotationRad` the render rotation in radians, so
- * a series can register a baked label (one not routed through {@link placeLabels}) as a `label`
- * obstacle other series' labels must avoid. At `rotationRad === 0` the box is exact.
- */
-export function labelFootprintBox(
-    anchor: OrientationAnchor,
-    glyphWidth: number,
-    glyphHeight: number,
-    padding: Required<PaddingOptions>,
-    rotationRad: number
-): BoxBounds {
-    const boxWidth = glyphWidth + padding.left + padding.right;
-    const boxHeight = glyphHeight + padding.top + padding.bottom;
-    const glyph = labelGlyphCentre(anchor, glyphWidth, glyphHeight);
-    const cx = glyph.x + (padding.right - padding.left) / 2;
-    const cy = glyph.y + (padding.bottom - padding.top) / 2;
-    const { width, height } = getMinOuterRectSize(toDegrees(rotationRad), boxWidth, boxHeight);
-    return { x: cx - width / 2, y: cy - height / 2, width, height };
-}
-
-/**
- * Builds the {@link PointLabelDatum} routing a bar label through the placement engine: centred on its
- * glyph box, constrained to `region` (its bar rect, or `undefined` for the plot bounds), offering the
- * `orientations` candidates, avoiding the obstacle categories `collideWith` enables. The `region` doubles
- * as the label's own-shape box: it lies within the bar rect, so a `seriesItem` obstacle for the label's
- * own bar (which the region overlaps) is excluded while neighbouring bars — which the region cannot reach
- * — are still avoided.
- */
-export function buildBarLabelDatum(
-    anchor: OrientationAnchor,
-    text: NormalisedTextOrSegments,
-    width: number,
-    height: number,
-    orientations: AgChartLabelOrientation[],
-    region: BoxBounds | undefined,
-    collideWith: CollideWith,
-    threshold: number,
-    target: BarLabelTarget,
-    fit?: LabelFitDescriptor
-): BarPlacedLabelDatum {
-    const { x, y } = labelGlyphCentre(anchor, width, height);
-    return {
-        point: { x, y, size: 0 },
-        label: { text, width, height },
-        fit,
-        anchor: undefined,
-        placement: undefined,
-        orientation: orientations,
-        gap: 0,
-        neverDrop: true,
-        collideWith,
-        threshold,
-        region,
-        ownBox: region,
-        target,
-    };
-}
-
-/**
- * Builds the {@link PointLabelDatum} routing a bar label through the positioned-candidate engine path:
- * the pre-positioned `candidates` are cascaded in order (each carries its own region), avoiding other
- * labels and bars in other columns. Dropped when no candidate fits unless `alwaysShow`. Hands the
- * engine opaque boxes instead of an orientation array to resolve.
- */
-export function buildBarPositionedLabelDatum(
-    text: NormalisedTextOrSegments,
-    width: number,
-    height: number,
-    candidates: readonly PositionedLabelCandidate[],
-    target: BarLabelTarget,
-    ownBox: BoxBounds,
-    alwaysShow: boolean,
-    collideWith: CollideWith,
-    threshold: number,
-    ownBoxLabelsCollide = false,
-    fit?: LabelFitDescriptor
-): BarPlacedLabelDatum {
-    return {
-        point: { x: 0, y: 0, size: 0 },
-        label: { text, width, height },
-        fit,
-        anchor: undefined,
-        placement: undefined,
-        gap: 0,
-        // When labels are hideable (`alwaysShow: false`) a no-fit candidate is dropped so the caller
-        // can hide it; otherwise the engine keeps the least-overflowing candidate.
-        neverDrop: alwaysShow,
-        collideWith,
-        threshold,
-        positionedCandidates: candidates,
-        ownBox,
-        ownBoxLabelsCollide,
-        target,
-    };
-}
-
-/**
- * Writes each placed label's chosen orientation back as a render rotation (radians), plus the flush
- * offset that slid it inside its region, onto its target. Labels the engine dropped are absent here
- * and keep the first-orientation rotation baked at node-data time. Every datum here was produced by
- * {@link buildBarLabelDatum}, so it carries `target`.
- */
-export function applyBarLabelOrientation(placed: readonly PlacedLabel<unknown>[]): void {
-    for (const { datum, rotation, offsetX, offsetY, candidate, text, fontSize } of placed) {
-        const { target, fit } = datum as BarPlacedLabelDatum;
-        target.rotation = toRadians(rotation ?? 0);
-        target.offsetX = offsetX ?? 0;
-        target.offsetY = offsetY ?? 0;
-        // The engine fitted the text to the candidate it chose, so the node must render that rather than
-        // the unfitted source the datum was built from.
-        target.fittedText = fit == null ? undefined : text;
-        target.fittedFontSize = fit == null ? undefined : fontSize;
-        // Placement-cascade path: the engine chose a whole candidate, so also retarget the label to that
-        // candidate's anchor and granular placement.
-        if (candidate != null) {
-            const { anchor, placement } = candidate as BarPositionedCandidate;
-            target.x = anchor.x;
-            target.y = anchor.y;
-            target.textAlign = anchor.textAlign;
-            target.textBaseline = anchor.textBaseline;
-            target.placement = placement;
-        }
-    }
-}
-
-/**
- * The set of bar-label targets the engine kept (placed). A hideable label the engine dropped is absent,
- * so its series can hide the routed label whose `target` this set does not contain.
- */
-export function placedBarLabelTargets(placed: readonly PlacedLabel<unknown>[]): Set<BarLabelTarget> {
-    const targets = new Set<BarLabelTarget>();
-    for (const { datum } of placed) {
-        targets.add((datum as BarPlacedLabelDatum).target);
-    }
-    return targets;
-}
-
-/**
- * Flags each routed bar label hidden when the engine dropped it: a routed label (`candidates` set) the
- * engine kept is in `placed`, one it dropped is absent. Baked labels (no candidates) are left visible.
- * `resolveTarget` maps each element to its label object, which doubles as its {@link BarLabelTarget}.
- */
-export function applyPlacedBarLabelVisibility<T>(
-    elements: Iterable<T> | undefined,
-    placed: readonly PlacedLabel<unknown>[],
-    resolveTarget: (element: T) => (BarLabelTarget & { candidates?: unknown; hidden?: boolean }) | undefined
-): void {
-    const kept = placedBarLabelTargets(placed);
-    for (const element of elements ?? []) {
-        const target = resolveTarget(element);
-        if (target?.candidates != null) target.hidden = !kept.has(target);
-    }
-}
-
-/**
- * True when a `placement` array offers more than one candidate to cascade through. A single value (or
- * unset) has nothing to resolve, so the series keeps its unconditional first-placement bake and never
- * enters the positioned-candidate engine path — leaving existing charts byte-identical.
- */
-export function barLabelResolvesPlacement(placement: unknown): boolean {
-    return Array.isArray(placement) && placement.length > 1;
-}
-
-/**
- * Whether a bar-family label takes the positioned-candidate route rather than its unconditional
- * fast-path bake: a multi-entry placement array cascades through obstacles, a hideable label
- * (`alwaysShow: false`) routes even a single placement so a no-fit label can be dropped, and a label
- * that opted into overflow control routes so an obstacle can be answered by shrinking into the room it
- * leaves rather than by overlapping it — unless an orientation array already routes it, which resolves
- * the same fit against the bar region on the cheaper baked path.
- */
-export function barLabelUsesPositionedCandidates(
-    orientation: AgChartLabelOrientation | AgChartLabelOrientation[] | undefined,
-    placement: unknown,
-    alwaysShow: boolean,
-    fit: LabelFit | undefined
-): boolean {
-    return (
-        barLabelResolvesPlacement(placement) ||
-        !alwaysShow ||
-        (fit != null && !barLabelResolvesOrientation(orientation))
-    );
-}
-
-/**
- * Whether a bar-family label must route through the placement engine rather than take its unconditional
- * fast-path bake: an orientation array resolves against the bar region, and a placement array, a hideable
- * label or a fit policy cascades through {@link barLabelUsesPositionedCandidates}.
- */
-export function barLabelRoutesThroughEngine(
-    orientation: AgChartLabelOrientation | AgChartLabelOrientation[] | undefined,
-    placement: unknown,
-    alwaysShow: boolean,
-    fit: LabelFit | undefined
-): boolean {
-    return (
-        barLabelResolvesOrientation(orientation) || barLabelResolvesPlacement(placement) || !alwaysShow || fit != null
-    );
-}
-
-/** The label-surface fields a routing decision reads, so a caller hands over its label, not four arguments. */
-export interface BarLabelRoutingOptions extends LabelFitOptions {
-    readonly orientation?: AgChartLabelOrientation | AgChartLabelOrientation[];
-    readonly placement?: unknown;
-    readonly collision: { readonly alwaysShow: boolean };
-}
-
-/** {@link barLabelRoutesThroughEngine} for a whole label surface, resolving its own fit policy. */
-export function barLabelPropsRouteThroughEngine(label: BarLabelRoutingOptions): boolean {
-    const alwaysShow = label.collision.alwaysShow;
-    return barLabelRoutesThroughEngine(
-        label.orientation,
-        label.placement,
-        alwaysShow,
-        resolveLabelFit(label, !alwaysShow)
-    );
-}
-
-/** {@link barLabelUsesPositionedCandidates} for a whole label surface, resolving its own fit policy. */
-export function barLabelPropsUsePositionedCandidates(label: BarLabelRoutingOptions): boolean {
-    const alwaysShow = label.collision.alwaysShow;
-    return barLabelUsesPositionedCandidates(
-        label.orientation,
-        label.placement,
-        alwaysShow,
-        resolveLabelFit(label, !alwaysShow)
-    );
-}
-
 /** Measured size of a label's text or rich-text segments under the given font. */
 export function measureLabelText(text: NormalisedTextOrSegments, font: FontOptions): { width: number; height: number } {
     return isArray(text) ? measureTextSegments(text, font) : cachedTextMeasurer(font).measureLines(String(text));
-}
-
-/** A baked bar-family label paired with the label config that governs its orientation and font. */
-export interface BarLabelSource {
-    readonly label:
-        | (OrientationAnchor & { text: NormalisedTextOrSegments; region?: BoxBounds } & BarLabelTarget)
-        | undefined;
-    readonly config: FontOptions & { orientation?: AgChartLabelOrientation | AgChartLabelOrientation[] };
-    /** Pre-measured footprint (text plus box padding/border); falls back to measuring `label.text` with `config`. */
-    readonly size?: { width: number; height: number };
-    /** Resolved obstacle-category toggles for this label, stamped onto the datum. */
-    readonly collideWith: CollideWith;
-    /** Collision clearance for this label's box, stamped onto the datum. */
-    readonly threshold: number;
-    /** Per-candidate fit inputs, so each orientation gets the text refitted to the room it actually has. */
-    readonly fit?: LabelFitDescriptor;
-}
-
-/**
- * Builds the placement-engine data for a series' baked labels: for each element `resolve` yields the
- * label object and its config; single-orientation labels are skipped (nothing to resolve).
- */
-export function buildBarLabelData<T>(
-    elements: Iterable<T> | undefined,
-    resolve: (element: T) => BarLabelSource | undefined
-): BarPlacedLabelDatum[] {
-    const data: BarPlacedLabelDatum[] = [];
-    for (const element of elements ?? []) {
-        const source = resolve(element);
-        if (source?.label == null || source.label.text === '') continue;
-        const { label, config } = source;
-        const orientations = toArray(config.orientation);
-        if (orientations.length <= 1) continue;
-        const { width, height } = source.size ?? measureLabelText(label.text, config);
-        data.push(
-            buildBarLabelDatum(
-                label,
-                label.text,
-                width,
-                height,
-                orientations,
-                label.region,
-                source.collideWith,
-                source.threshold,
-                label,
-                source.fit
-            )
-        );
-    }
-    return data;
-}
-
-/** A rect-shaped node (bar, histogram bin) contributed to the obstacle index as its drawn footprint. */
-export interface RectObstacleSource {
-    readonly x: number;
-    readonly y: number;
-    readonly width: number;
-    readonly height: number;
-    readonly phantom?: boolean;
-}
-
-/**
- * Maps rect-shaped node data (bars, histogram bins) to `seriesItem` label obstacles so that labels from
- * other series route around them. Skips phantom (stacking/feather) nodes and zero-area rects.
- */
-export function rectLabelObstacles(nodeData: readonly RectObstacleSource[] | undefined): LabelObstacle[] | undefined {
-    if (nodeData == null || nodeData.length === 0) return undefined;
-    const obstacles: LabelObstacle[] = [];
-    for (const { x, y, width, height, phantom } of nodeData) {
-        if (phantom === true || width <= 0 || height <= 0) continue;
-        obstacles.push({ kind: 'rect', box: { x, y, width, height }, category: 'seriesItem' });
-    }
-    return obstacles.length > 0 ? obstacles : undefined;
-}
-
-/** A baked bar-family label paired with the config and per-side box extent that size its footprint. */
-export interface BakedLabelSource {
-    readonly label:
-        | (OrientationAnchor & { text: NormalisedTextOrSegments; rotation: number; hidden?: boolean })
-        | undefined;
-    /** Font config for glyph measurement. */
-    readonly config: FontOptions;
-    /** Per-side drawn-box extent (padding plus any border). */
-    readonly box: Required<PaddingOptions>;
-}
-
-/**
- * Builds `label` obstacles for a series' baked labels — labels drawn without routing through
- * {@link placeLabels}, so they never enter the obstacle index there. Contributing their drawn footprint
- * lets other series' labels avoid them. Skips absent, empty-text and hidden labels.
- */
-export function bakedLabelObstacles<T>(
-    elements: Iterable<T> | undefined,
-    resolve: (element: T) => BakedLabelSource | undefined
-): LabelObstacle[] | undefined {
-    const obstacles: LabelObstacle[] = [];
-    for (const element of elements ?? []) {
-        const source = resolve(element);
-        const label = source?.label;
-        if (source == null || label == null || label.text === '' || label.hidden === true) continue;
-        const { width, height } = measureLabelText(label.text, source.config);
-        const box = labelFootprintBox(label, width, height, source.box, label.rotation);
-        obstacles.push({ kind: 'rect', box, category: 'label' });
-    }
-    return obstacles.length > 0 ? obstacles : undefined;
-}
-
-/**
- * Combines a bar-family series' rendered-rect obstacles (`seriesItem`) with the footprints of its baked
- * labels (`label`) — the obstacle set other series' labels must avoid. `bakeLabels` must be false when the
- * series routes its labels through {@link placeLabels}: the engine indexes each routed label as it places
- * it, so baking them here too would double-count them (see the caller's `usesPlacedLabels` guard).
- */
-export function barLabelObstacles<T>(
-    nodeData: readonly RectObstacleSource[] | undefined,
-    labelData: Iterable<T> | undefined,
-    bakeLabels: boolean,
-    resolveBaked: (element: T) => BakedLabelSource | undefined
-): LabelObstacle[] | undefined {
-    const rects = rectLabelObstacles(nodeData);
-    if (!bakeLabels) return rects;
-    const labels = bakedLabelObstacles(labelData, resolveBaked);
-    if (labels == null) return rects;
-    return rects == null ? labels : rects.concat(labels);
 }
 
 const labelPlacements: Record<LabelPlacement, { x: -1 | 0 | 1; y: -1 | 0 | 1 }> = {
@@ -1963,7 +1381,7 @@ function compassCandidateContainer(
  * as a last resort; the truncation keeps the candidate out of the immediate-return path, so a directional
  * placement that holds the whole text still wins the cascade. `undefined` for every other candidate.
  */
-function insideMarkerContainer(
+function insideMarkerCandidateContainer(
     d: PointLabelDatum,
     placement: LabelPlacement | undefined,
     pad: Required<PaddingOptions> | undefined,
@@ -2052,8 +1470,8 @@ function sizeCandidateLabel(
     const font = candidateFontAt(style?.font ?? fit.font);
     const boxPadding = style?.boxPadding ?? fit.boxPadding;
     const container =
-        insideMarkerContainer(d, placement, boxPadding, rotation, threshold) ??
-        (fit.boundByRegion === false ? undefined : compassCandidateContainer(fitRegion, boxPadding, rotation));
+        insideMarkerCandidateContainer(d, placement, boxPadding, rotation, threshold) ??
+        (fit.boundByRegion ? compassCandidateContainer(fitRegion, boxPadding, rotation) : undefined);
     // A styled or trialled candidate re-measures the source under its own font; an unstyled one at the
     // configured size shares the cascade's single measurement.
     const source = style == null && candidateTrialFontSize == null ? fitSource : styledFitSource(fit, font);
@@ -2135,6 +1553,21 @@ function slideShrunkCandidate(rawRegion: BoxBounds, flush: boolean) {
     shrunkOffset.y = candidateBox.y - y;
 }
 
+/** Translation {@link flushCandidateBox} applied, so a caller can report the candidate's own offset. */
+const flushOffset: Point = { x: 0, y: 0 };
+
+/** Slides the candidate box flush inside `rawRegion`, leaving the translation in {@link flushOffset}. */
+function flushCandidateBox(rawRegion: BoxBounds, flush: boolean) {
+    flushOffset.x = 0;
+    flushOffset.y = 0;
+    if (!flush) return;
+    const { x, y, width, height } = candidateBox;
+    candidateBox.x = clampAxis(x, width, rawRegion.x, rawRegion.width);
+    candidateBox.y = clampAxis(y, height, rawRegion.y, rawRegion.height);
+    flushOffset.x = candidateBox.x - x;
+    flushOffset.y = candidateBox.y - y;
+}
+
 /** Containment and obstacle re-test of the candidate a shrink pass just resized and repositioned. */
 function shrunkCandidateIsClear(region: BoxBounds, inflate: number): boolean {
     const { x, y, width, height } = candidateBox;
@@ -2157,21 +1590,13 @@ function shrinkCompassCandidate(
     d: PointLabelDatum,
     style: CandidateLabelStyle | undefined,
     placement: LabelPlacement | undefined,
-    rotation: number,
-    gap: number,
-    spacing: number,
-    fitSource: { width: number; height: number } | undefined,
-    rawRegion: BoxBounds,
-    region: BoxBounds,
-    containThreshold: number,
-    inflate: number,
-    flushToRegion: boolean
+    rotation: number
 ): boolean {
     const fit = d.fit;
     if (fit == null) return false;
     // Which edges the box keeps as it shrinks, mirroring how `positionLabelBox` hangs it off the point: a
     // directional candidate is pinned to the edge facing the point, a gapless or `inside` one stays centred.
-    const vec = gap > 0 && placement != null ? labelPlacements[placement] : undefined;
+    const vec = cascadeGap > 0 && placement != null ? labelPlacements[placement] : undefined;
     // The reduction is measured on the rotated footprint, whose axes are the glyph's swapped for a
     // quarter-turned candidate.
     const upright = rotation % 180 === 0;
@@ -2179,20 +1604,22 @@ function shrinkCompassCandidate(
     const lineHeight = cachedTextMeasurer(font).lineHeight();
     const floorX = upright ? 0 : lineHeight;
     const floorY = upright ? lineHeight : 0;
-    if (!measureShrinkReduction(vec?.x ?? 0, vec?.y ?? 0, inflate, floorX, floorY)) return false;
-    const source = style == null && candidateTrialFontSize == null ? fitSource : styledFitSource(fit, font);
+    if (!measureShrinkReduction(vec?.x ?? 0, vec?.y ?? 0, cascadeInflate, floorX, floorY)) return false;
+    const source = style == null && candidateTrialFontSize == null ? cascadeFitSource : styledFitSource(fit, font);
     const reduceWidth = upright ? shrinkReduction.width : shrinkReduction.height;
     const reduceHeight = upright ? shrinkReduction.height : shrinkReduction.width;
     if (!refitCandidateShrunk(fit, font, source, style?.boxPadding ?? fit.boxPadding, reduceWidth, reduceHeight)) {
         return false;
     }
-    positionCandidate(d, placement, rotation, candidateLabel.width, candidateLabel.height, gap, spacing);
-    slideShrunkCandidate(rawRegion, flushToRegion);
+    positionCandidate(d, placement, rotation, candidateLabel.width, candidateLabel.height, cascadeGap, cascadeSpacing);
+    slideShrunkCandidate(cascadeRawRegion, cascadeFlushToRegion);
     const { x, y, width, height } = candidateBox;
     const insideRegion = insideRegionFor(d, placement, x, y, width, height);
     const containRegion =
-        insideRegion == null ? region : deflateRegion(deflatedInsideRegionBox, insideRegion, containThreshold);
-    return shrunkCandidateIsClear(containRegion, inflate);
+        insideRegion == null
+            ? cascadeRegion
+            : deflateRegion(deflatedInsideRegionBox, insideRegion, cascadeContainThreshold);
+    return shrunkCandidateIsClear(containRegion, cascadeInflate);
 }
 
 /** Which edge of a positioned candidate's box stays put as it shrinks; see {@link sideRetreats}. */
@@ -2445,18 +1872,9 @@ function cascadeCandidates(): PlacedLabel | undefined {
             }
             const { text, width, height, dropped, shrink } = candidateLabel;
             positionCandidate(d, placement, rotation, width, height, cascadeGap, cascadeSpacing);
-            let { x, y } = candidateBox;
-            const { width: cw, height: ch } = candidateBox;
-            let offsetX = 0;
-            let offsetY = 0;
-            if (cascadeFlushToRegion) {
-                const nx = clampAxis(x, cw, cascadeRawRegion.x, cascadeRawRegion.width);
-                const ny = clampAxis(y, ch, cascadeRawRegion.y, cascadeRawRegion.height);
-                offsetX = nx - x;
-                offsetY = ny - y;
-                candidateBox.x = x = nx;
-                candidateBox.y = y = ny;
-            }
+            flushCandidateBox(cascadeRawRegion, cascadeFlushToRegion);
+            const { x, y, width: cw, height: ch } = candidateBox;
+            const { x: offsetX, y: offsetY } = flushOffset;
             candidatePlacement = placement;
             const insideRegion = insideRegionFor(d, placement, x, y, cw, ch);
             const containRegion =
@@ -2513,24 +1931,7 @@ function cascadeCandidates(): PlacedLabel | undefined {
             // Obstacle-only failure: the candidate has the room, an obstacle is taking part of it. Shrinking
             // is tried last so a failed attempt can clobber the shared candidate scratch freely, and only
             // outside a trial, whose candidates can win outright but record nothing.
-            if (
-                contained &&
-                recordBest &&
-                shrinkCompassCandidate(
-                    d,
-                    style,
-                    placement,
-                    rotation,
-                    cascadeGap,
-                    cascadeSpacing,
-                    cascadeFitSource,
-                    cascadeRawRegion,
-                    cascadeRegion,
-                    cascadeContainThreshold,
-                    cascadeInflate,
-                    cascadeFlushToRegion
-                )
-            ) {
+            if (contained && recordBest && shrinkCompassCandidate(d, style, placement, rotation)) {
                 recordShrunkChoice(rotation, placement, undefined);
             }
         }
@@ -2737,20 +2138,11 @@ function placeFromPositionedCandidates(
             ({ width, height } = candidateLabel);
             resizeCandidateBox(c, width, height);
         }
-        let { x, y } = candidateBox;
-        const { width: cw, height: ch } = candidateBox;
-        let offsetX = 0;
-        let offsetY = 0;
         // Region-bound candidates are slid flush inside their region; a collision-only region is not
         // flushed, so an overflowing box is left to fail containment below.
-        if (c.region != null && c.flushToRegion !== false) {
-            const nx = clampAxis(x, cw, rawRegion.x, rawRegion.width);
-            const ny = clampAxis(y, ch, rawRegion.y, rawRegion.height);
-            offsetX = nx - x;
-            offsetY = ny - y;
-            candidateBox.x = x = nx;
-            candidateBox.y = y = ny;
-        }
+        flushCandidateBox(rawRegion, c.region != null && c.flushToRegion !== false);
+        const { x, y, width: cw, height: ch } = candidateBox;
+        const { x: offsetX, y: offsetY } = flushOffset;
         inflateBoxInto(queryBox, candidateBox, inflate);
         const rotation = c.rotation ?? 0;
         const contained = boxContains(region, x, y, cw, ch);

--- a/packages/ag-charts-core/src/utils/geometry/labelPlacementScaling.test.ts
+++ b/packages/ag-charts-core/src/utils/geometry/labelPlacementScaling.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SizedPoint } from '../../types/scene';
+import type { BoxBounds } from './boxBounds';
+import { type LabelPlacement, type PointLabelDatum, type SeriesLabels, placeLabels } from './labelPlacement';
+
+// jsdom has no canvas, so cachedTextMeasurer's real createCanvasContext throws.
+vi.mock('../canvas', () => ({
+    createCanvasContext: () => ({
+        font: '',
+        measureText(text: string) {
+            return {
+                width: [...text].length * 10,
+                fontBoundingBoxAscent: 16,
+                fontBoundingBoxDescent: 4,
+                emHeightAscent: 16,
+                emHeightDescent: 4,
+            };
+        },
+    }),
+}));
+
+const PLACEMENTS: LabelPlacement[] = ['top', 'bottom', 'left', 'right', 'top-left', 'bottom-right'];
+
+/**
+ * `count` labelled markers spread over a region scaled to keep their density constant, so the only
+ * thing growing between two fixtures is the label count.
+ */
+function densityFixture(count: number, seed0: number): { data: Map<string, SeriesLabels>; bounds: BoxBounds } {
+    let seed = seed0;
+    const next = () => {
+        seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+        return seed / 0x7fffffff;
+    };
+    const side = Math.ceil(Math.sqrt(count)) * 40;
+    const bounds: BoxBounds = { x: 0, y: 0, width: side, height: side };
+    const datums: PointLabelDatum[] = [];
+    for (let i = 0; i < count; i++) {
+        const point: SizedPoint = { x: next() * side, y: next() * side, size: 6 + next() * 8 };
+        datums.push({
+            point,
+            label: { text: `label-${i}`, width: 40 + next() * 30, height: 12 },
+            anchor: undefined,
+            placement: undefined,
+            placements: PLACEMENTS,
+            alwaysShow: false,
+        });
+    }
+    return { data: new Map([['series-0', { datums }]]), bounds };
+}
+
+/**
+ * Per-label cost of one `placeLabels` call, in ms. A single call is far too short to time reliably,
+ * so each sample runs the call repeatedly for a fixed budget; the cheapest sample is taken, being
+ * the one least disturbed by GC and the scheduler.
+ */
+function perLabelCost(count: number, samples = 3, budgetMs = 60): number {
+    const { data, bounds } = densityFixture(count, 7);
+    placeLabels(data, bounds, 5);
+    let best = Infinity;
+    for (let s = 0; s < samples; s++) {
+        let iterations = 0;
+        const start = performance.now();
+        let elapsed = 0;
+        while (elapsed < budgetMs) {
+            placeLabels(data, bounds, 5);
+            iterations++;
+            elapsed = performance.now() - start;
+        }
+        best = Math.min(best, elapsed / (iterations * count));
+    }
+    return best;
+}
+
+describe('placeLabels scaling', () => {
+    // Wall-clock is noisy, so the bound is wide enough to ignore a constant-factor change and only
+    // fail on a change in complexity: the spatial index is what keeps the per-label cost flat, and
+    // losing it (or querying every obstacle again) turns this quadratic.
+    it('keeps the per-label cost flat as the label count grows', { retry: 3 }, () => {
+        const small = perLabelCost(500);
+        const large = perLabelCost(4000);
+
+        // Eight times the labels at the same density: the per-label cost is flat today, so this
+        // passes with a wide margin and only fails if the cost picks up a term in the label count.
+        expect(large).toBeLessThan(small * 4);
+    });
+
+    it('places the same labels however many times it runs', () => {
+        const { data, bounds } = densityFixture(2000, 11);
+        const first = placeLabels(data, bounds, 5);
+        const second = placeLabels(data, bounds, 5);
+
+        const flatten = (r: Map<string, ReturnType<typeof placeLabels> extends Map<string, infer T> ? T : never>) =>
+            [...r.values()].flat().map((l) => `${l.index}@${l.x},${l.y}`);
+        expect(flatten(second)).toEqual(flatten(first));
+        // The fixture must actually exercise the index rather than trivially placing everything.
+        expect(flatten(first).length).toBeGreaterThan(0);
+        expect(flatten(first).length).toBeLessThan(2000);
+    });
+});

--- a/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/funnel/baseFunnelSeries.ts
@@ -23,14 +23,12 @@ import {
     SeriesZIndexMap,
     applyBarLabelOrientation,
     applyPlacedBarLabelVisibility,
-    barLabelObstacles,
+    barLabelPropsRouteThroughEngine,
     barLabelRoutesThroughEngine,
     buildBarPositionedLabelDatum,
-    fontWithSize,
     maxValue,
     measureLabelText,
     resolveLabelFit,
-    resolveLabelFitDescriptors,
 } from 'ag-charts-core';
 import type { AgNumericValue, PaddingOptions } from 'ag-charts-types';
 
@@ -39,6 +37,8 @@ import { FunnelConnector } from './funnelConnector';
 import { prepareConnectorAnimationFunctions, resetConnectorSelectionsFn } from './funnelUtil';
 
 const {
+    barLabelObstaclesFor,
+    barLabelDataContext,
     SeriesNodePickMode,
     valueProperty,
     keyProperty,
@@ -782,23 +782,19 @@ export abstract class BaseFunnelSeries<
     }
 
     getLabelObstacles() {
-        const { label } = this.properties;
-        const box = expandPlacementLabelBoxExtent(label);
-        return barLabelObstacles(
+        return barLabelObstaclesFor(
+            this.properties.label,
             this.contextNodeData?.nodeData,
             this.contextNodeData?.labelData,
             this.isLabelEnabled() && !this.usesPlacedLabels,
-            (labelDatum) => ({ label: labelDatum, config: fontWithSize(label, labelDatum.fittedFontSize), box })
+            (labelDatum) => labelDatum
         );
     }
 
     override getLabelData(): PointLabelDatum[] {
         const { label } = this.properties;
         if (!this.usesPlacedLabels || !label.enabled) return [];
-        const box = expandPlacementLabelBoxExtent(label);
-        const collideWith = label.collision.resolveCollideWith();
-        const threshold = label.collision.threshold ?? 0;
-        const fitFor = resolveLabelFitDescriptors(label, box, !label.collision.alwaysShow);
+        const { alwaysShow, collideWith, threshold, measureBox, fitFor } = barLabelDataContext(label);
         const stylerParams = this.labelStylerParams();
         const data: PointLabelDatum[] = [];
         for (const labelDatum of this.contextNodeData?.labelData ?? []) {
@@ -813,8 +809,7 @@ export abstract class BaseFunnelSeries<
                 'horizontal',
                 labelDatum.text
             );
-            const { width, height } = measureLabelText(labelDatum.text, label);
-            const size = styled?.size ?? { width: width + box.left + box.right, height: height + box.top + box.bottom };
+            const size = styled?.size ?? measureBox(labelDatum.text);
             const configuredFit = fitFor(labelDatum.text);
             const fit =
                 configuredFit == null || styled == null
@@ -828,7 +823,7 @@ export abstract class BaseFunnelSeries<
                     labelDatum.candidates,
                     labelDatum,
                     labelDatum.ownBox ?? { x: labelDatum.x, y: labelDatum.y, width: 0, height: 0 },
-                    label.collision.alwaysShow,
+                    alwaysShow,
                     collideWith,
                     threshold,
                     true,
@@ -846,9 +841,7 @@ export abstract class BaseFunnelSeries<
     }
 
     protected override resolveUsesPlacedLabels(): boolean {
-        const { label } = this.properties;
-        const alwaysShow = label.collision.alwaysShow;
-        return barLabelRoutesThroughEngine(undefined, label.placement, alwaysShow, resolveLabelFit(label, !alwaysShow));
+        return barLabelPropsRouteThroughEngine(this.properties.label);
     }
 
     /** The bar placement a public one maps onto, for the styled box a baked label reserves. */

--- a/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/pyramid/pyramidSeries.ts
@@ -26,7 +26,7 @@ import {
     applyBarLabelOrientation,
     applyPlacedBarLabelVisibility,
     bakedLabelObstacles,
-    barLabelRoutesThroughEngine,
+    barLabelPropsRouteThroughEngine,
     buildBarPositionedLabelDatum,
     cachedTextMeasurer,
     fontWithSize,
@@ -35,7 +35,6 @@ import {
     measureTextSegments,
     mergeDefaults,
     resolveLabelFit,
-    resolveLabelFitDescriptors,
     toNumber,
     toPlainText,
     toTextString,
@@ -60,6 +59,7 @@ import { PyramidProperties } from './pyramidProperties';
 import { applyPyramidDatum, preparePyramidAnimationFunctions } from './pyramidUtil';
 
 const {
+    barLabelDataContext,
     valueProperty,
     SeriesNodePickMode,
     createDatumId,
@@ -526,9 +526,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
     }
 
     private routesThroughEngine(): boolean {
-        const { label } = this.properties;
-        const alwaysShow = label.collision.alwaysShow;
-        return barLabelRoutesThroughEngine(undefined, label.placement, alwaysShow, resolveLabelFit(label, !alwaysShow));
+        return barLabelPropsRouteThroughEngine(this.properties.label);
     }
 
     private createLabelContext(horizontal: boolean): PyramidLabelContext {
@@ -711,10 +709,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
     override getLabelData(): PointLabelDatum[] {
         const { label } = this.properties;
         if (!this.usesPlacedLabels || !label.enabled) return [];
-        const box = expandPlacementLabelBoxExtent(label);
-        const collideWith = label.collision.resolveCollideWith();
-        const threshold = label.collision.threshold ?? 0;
-        const fitFor = resolveLabelFitDescriptors(label, box, !label.collision.alwaysShow);
+        const { alwaysShow, collideWith, threshold, measureBox, fitFor } = barLabelDataContext(label);
         const stylerParams = this.labelStylerParams();
         const data: PointLabelDatum[] = [];
         for (const labelDatum of this.contextNodeData?.labelData ?? []) {
@@ -729,8 +724,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
                 'horizontal',
                 labelDatum.text
             );
-            const { width, height } = measureLabelText(labelDatum.text, label);
-            const size = styled?.size ?? { width: width + box.left + box.right, height: height + box.top + box.bottom };
+            const size = styled?.size ?? measureBox(labelDatum.text);
             const configuredFit = fitFor(labelDatum.text);
             const fit =
                 configuredFit == null || styled == null
@@ -744,7 +738,7 @@ export class PyramidSeries extends _ModuleSupport.DataModelSeries<
                     labelDatum.candidates,
                     labelDatum,
                     labelDatum.ownBox ?? { x: labelDatum.x, y: labelDatum.y, width: 0, height: 0 },
-                    label.collision.alwaysShow,
+                    alwaysShow,
                     collideWith,
                     threshold,
                     true,

--- a/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/range-bar/rangeBarSeries.ts
@@ -30,7 +30,6 @@ import {
     applyBarLabelOrientation,
     applyPlacedBarLabelVisibility,
     areScalingEqual,
-    barLabelObstacles,
     barLabelOrientation,
     barLabelPropsRouteThroughEngine,
     barLabelResolvesOrientation,
@@ -47,7 +46,6 @@ import {
     measureLabelText,
     mergeDefaults,
     resolveLabelFit,
-    resolveLabelFitDescriptors,
     rotatedGlyphDrift,
     rotatedLabelInset,
     toArray,
@@ -63,6 +61,8 @@ import {
 import { RangeBarProperties } from './rangeBarProperties';
 
 const {
+    barLabelObstaclesFor,
+    barLabelDataContext,
     SeriesNodePickMode,
     valueProperty,
     keyProperty,
@@ -1415,27 +1415,20 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
     }
 
     getLabelObstacles() {
-        const { label } = this.properties;
-        const box = expandPlacementLabelBoxExtent(label);
         // labelData is the flattened low+high labels, so each element is itself a baked label.
-        return barLabelObstacles(
+        return barLabelObstaclesFor(
+            this.properties.label,
             this.contextNodeData?.nodeData,
             this.contextNodeData?.labelData,
             this.isLabelEnabled() && !this.usesPlacedLabels,
-            (labelDatum) => ({ label: labelDatum, config: fontWithSize(label, labelDatum.fittedFontSize), box })
+            (labelDatum) => labelDatum
         );
     }
 
     override getLabelData(): PointLabelDatum[] {
         if (!this.usesPlacedLabels || !this.properties.label.enabled) return [];
         const { label } = this.properties;
-        // Inflate the measured text by the label's drawn box (padding + border stroke) so orientation
-        // resolution avoids the box, not just the text.
-        const box = expandPlacementLabelBoxExtent(label);
-        const collideWith = label.collision.resolveCollideWith();
-        const threshold = label.collision.threshold ?? 0;
-        const alwaysShow = label.collision.alwaysShow;
-        const fitFor = resolveLabelFitDescriptors(label, box, !alwaysShow);
+        const { alwaysShow, collideWith, threshold, measureBox, fitFor } = barLabelDataContext(label);
         const resolveStyle =
             label.itemStyler == null
                 ? undefined
@@ -1463,8 +1456,7 @@ export class RangeBarSeries extends _ModuleSupport.AbstractBarSeries<RangeBarSer
                 firstOrientation,
                 labelDatum.text
             );
-            const { width, height } = measureLabelText(labelDatum.text, label);
-            const size = styled?.size ?? { width: width + box.left + box.right, height: height + box.top + box.bottom };
+            const size = styled?.size ?? measureBox(labelDatum.text);
             const configuredFit = fitFor(labelDatum.text);
             const fit =
                 configuredFit == null || styled == null

--- a/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
+++ b/packages/ag-charts-enterprise/src/series/waterfall/waterfallSeries.ts
@@ -721,7 +721,20 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
             );
 
             // Label config is item-type specific, so the fit is resolved per datum rather than hoisted.
-            const labelFit = resolveLabelFit(label, !label.collision.alwaysShow);
+            const alwaysShow = label.collision.alwaysShow;
+            const labelFit = resolveLabelFit(label, !alwaysShow);
+            const routesThroughEngine = barLabelRoutesThroughEngine(
+                label.orientation,
+                label.placement,
+                alwaysShow,
+                labelFit
+            );
+            const usesPositionedCandidates = barLabelUsesPositionedCandidates(
+                label.orientation,
+                label.placement,
+                alwaysShow,
+                labelFit
+            );
             // Array placement is accepted, but only its first candidate is honoured here.
             const placement = toArray(label.placement)[0];
             const insidePlacement = placement == null || placement.startsWith('inside');
@@ -746,22 +759,10 @@ export class WaterfallSeries extends _ModuleSupport.AbstractBarSeries<WaterfallS
                       )
                     : undefined;
             // The engine refits per orientation since a rotated label measures against the bar's other axis (see barSeries).
-            const { text: fittedLabelText, fontSize: fittedFontSize } = barLabelRoutesThroughEngine(
-                label.orientation,
-                label.placement,
-                label.collision.alwaysShow,
-                labelFit
-            )
+            const { text: fittedLabelText, fontSize: fittedFontSize } = routesThroughEngine
                 ? { text: labelText, fontSize: undefined }
                 : fitLabelToContainerAutoSize(labelText, labelFit, label, bounds?.container);
-            if (
-                barLabelUsesPositionedCandidates(
-                    label.orientation,
-                    label.placement,
-                    label.collision.alwaysShow,
-                    labelFit
-                )
-            ) {
+            if (usesPositionedCandidates) {
                 // Pre-positions a candidate per placement x orientation for the engine to cascade through until one fits.
                 const measured = measureLabelText(fittedLabelText, label);
                 const placements = toArray(label.placement);

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/series-labels-collision/benchmarkHarness.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/series-labels-collision/benchmarkHarness.ts
@@ -1,0 +1,1 @@
+../../benchmarkHarness.ts

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/series-labels-collision/benchmarkUtils.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/series-labels-collision/benchmarkUtils.ts
@@ -1,0 +1,1 @@
+../../benchmarkUtils.ts

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/series-labels-collision/data.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/series-labels-collision/data.ts
@@ -1,0 +1,52 @@
+const scatterPoints = 800;
+const barCount = 200;
+
+function sfc32(a: number, b: number, c: number, d: number) {
+    return function () {
+        a >>>= 0;
+        b >>>= 0;
+        c >>>= 0;
+        d >>>= 0;
+        let t = (a + b) | 0;
+        a = b ^ (b >>> 9);
+        b = (c + (c << 3)) | 0;
+        c = (c << 21) | (c >>> 11);
+        d = (d + 1) | 0;
+        t = (t + d) | 0;
+        c = (c + t) | 0;
+        return (t >>> 0) / 4294967296;
+    };
+}
+
+function seedRandom(seed = 1337): () => number {
+    return sfc32(0x9e3779b9, 0x243f6a88, 0xb7e15162, seed ^ 0xdeadbeef);
+}
+
+/**
+ * Clustered points, so a large share of labels genuinely compete for space: a uniform scatter
+ * places nearly every label at its first candidate and never exercises the fallback cascade.
+ */
+export function getScatterData() {
+    const random = seedRandom();
+    const clusters = 40;
+    return Array.from({ length: scatterPoints }, (_, i) => {
+        const cluster = i % clusters;
+        const cx = 10 + (cluster % 8) * 12;
+        const cy = 10 + Math.floor(cluster / 8) * 18;
+        return {
+            x: cx + (random() * 2 - 1) * 6,
+            y: cy + (random() * 2 - 1) * 9,
+            size: 4 + random() * 10,
+            name: `Point ${i}`,
+        };
+    });
+}
+
+/** Short bars alongside tall ones, so inside placements fail often enough to cascade outside. */
+export function getBarData() {
+    const random = seedRandom(4242);
+    return Array.from({ length: barCount }, (_, i) => ({
+        category: `Category ${i}`,
+        value: random() < 0.35 ? random() * 8 : 20 + random() * 180,
+    }));
+}

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/series-labels-collision/index.html
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/series-labels-collision/index.html
@@ -1,0 +1,1 @@
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/benchmarks/_examples/series-labels-collision/main.ts
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/_examples/series-labels-collision/main.ts
@@ -1,0 +1,152 @@
+// @ag-skip-fws
+/* @ag-options-extract */
+import { AgCartesianChartOptions, AgCharts, VERSION } from 'ag-charts-enterprise';
+
+import { type BenchmarkConfig, initBenchmark } from './benchmarkHarness';
+import { ChartRef, performDatumHighlight, performInitialLoad } from './benchmarkUtils';
+import { getBarData, getScatterData } from './data';
+
+(window as any).agChartsDebug = 'scene:stats:verbose';
+
+const scatterData = getScatterData();
+const barData = getBarData();
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    data: scatterData,
+    animation: { enabled: false },
+    series: [
+        {
+            type: 'bubble',
+            xKey: 'x',
+            yKey: 'y',
+            sizeKey: 'size',
+            labelKey: 'name',
+            maxRenderedItems: 10000,
+            label: {
+                enabled: true,
+                placement: ['top', 'bottom', 'right', 'left', 'top-right', 'bottom-left'],
+                collision: { alwaysShow: false },
+            },
+        },
+    ],
+};
+/* @ag-options-end */
+
+const chartRef: ChartRef = { current: AgCharts.create(options) };
+const container = document.getElementById('myChart')!;
+
+/** The same chart with the collision cascade taken away, isolating what placement itself costs. */
+function scatterOptions(label: object): typeof options {
+    return {
+        ...options,
+        series: [{ ...(options.series![0] as object), label } as any],
+    };
+}
+
+/** The same container and animation settings, re-pointed at the bar dataset. */
+function barOptions(label: object): typeof options {
+    return {
+        ...options,
+        data: barData,
+        series: [{ type: 'bar', xKey: 'category', yKey: 'value', label } as any],
+        axes: {
+            x: { type: 'category' },
+            y: { type: 'number' },
+        },
+    };
+}
+
+const LABEL_OFF = { enabled: false };
+const SCATTER_SINGLE = { enabled: true, placement: 'top' };
+const SCATTER_CASCADE = {
+    enabled: true,
+    placement: ['top', 'bottom', 'right', 'left', 'top-right', 'bottom-left'],
+    collision: { alwaysShow: false },
+};
+const BAR_SINGLE = { enabled: true, placement: 'inside-center' };
+const BAR_CASCADE = {
+    enabled: true,
+    placement: ['inside-center', 'inside-start', 'outside-end'],
+    orientation: ['horizontal', 'vertical'],
+    minimumFontSize: 6,
+    collision: { alwaysShow: false },
+};
+
+function create(opts: typeof options) {
+    return AgCharts.create(opts);
+}
+
+/** inScope */
+function getBenchmarkConfig(): BenchmarkConfig {
+    return {
+        testCases: [
+            {
+                id: 'scatter-labels',
+                label: 'Scatter Labels',
+                variants: [
+                    {
+                        params: { Labels: 'Off' },
+                        run: () => performInitialLoad(scatterOptions(LABEL_OFF), chartRef, create),
+                    },
+                    {
+                        params: { Labels: 'Single placement' },
+                        run: () => performInitialLoad(scatterOptions(SCATTER_SINGLE), chartRef, create),
+                    },
+                    {
+                        params: { Labels: 'Placement cascade' },
+                        run: () => performInitialLoad(scatterOptions(SCATTER_CASCADE), chartRef, create),
+                    },
+                ],
+            },
+            {
+                id: 'bar-labels',
+                label: 'Bar Labels',
+                variants: [
+                    {
+                        params: { Labels: 'Off' },
+                        run: () => performInitialLoad(barOptions(LABEL_OFF), chartRef, create),
+                    },
+                    {
+                        params: { Labels: 'Single placement' },
+                        run: () => performInitialLoad(barOptions(BAR_SINGLE), chartRef, create),
+                    },
+                    {
+                        params: { Labels: 'Cascade + shrink' },
+                        run: () => performInitialLoad(barOptions(BAR_CASCADE), chartRef, create),
+                    },
+                ],
+            },
+            {
+                id: 'highlight',
+                label: 'Highlight',
+                // Hover re-runs the series update, so this measures the LabelManager's cached-solve
+                // path: a regression that invalidates the cache shows up here and nowhere else.
+                variants: [
+                    {
+                        params: { Repetitions: '20x' },
+                        run: async () => {
+                            await performInitialLoad(scatterOptions(SCATTER_CASCADE), chartRef, create);
+                            return performDatumHighlight(chartRef.current!, container, 20);
+                        },
+                    },
+                ],
+            },
+        ],
+        config: {
+            updatesPerTest: 5,
+            maxCollectionTimeMs: 15000,
+            warmupUpdates: 1,
+        },
+        metadata: {
+            dataPoints: scatterData.length,
+            seriesCount: 1,
+            seriesType: 'bubble',
+            version: VERSION,
+        },
+    };
+}
+
+if (!window.location.hash.includes('e2e=true')) {
+    initBenchmark(getBenchmarkConfig());
+}

--- a/packages/ag-charts-website/src/content/docs/benchmarks/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/benchmarks/index.mdoc
@@ -155,6 +155,12 @@ Exercises the per-datum styling pipeline when `selection.enabled` is on across e
 
 {% chartExampleRunner title="Data Selection Zoom (Scatter / Bubble / Histogram)" name="data-selection-zoom-xy" type="generated" initialLoadDeferred=true /%}
 
+## Series Label Collision
+
+Exercises the cross-series label placement pass: clustered bubble labels that cascade through their fallback placements, and bar labels that cascade and shrink. Each series runs with labels off, at a single placement, and with the full cascade, so the cost of placement is separated from the cost of drawing the labels. The highlight case measures the cached-solve path a hover takes.
+
+{% chartExampleRunner title="Series Label Collision" name="series-labels-collision" type="generated" initialLoadDeferred=true /%}
+
 ## High-Frequency Data Updates
 
 Exercise incremental data update operations (append, remove, rolling window) with large datasets:


### PR DESCRIPTION
Splits the bar-family label geometry out of the placement engine and de-duplicates the wiring the bar, histogram, range-bar, waterfall, funnel and pyramid series each restated.

- `barLabelGeometry.ts` takes the bar-specific helpers (rotation, insets, regions, datum builders, obstacle builders) out of `labelPlacement.ts`, leaving the engine with the generic cascade. The move is byte-identical; the module is re-exported from core's `main.ts`, so the public surface is unchanged.
- `barLabelDataContext` and `barLabelObstaclesFor` derive the six collision/fit values and the obstacle set every bar-family `getLabelData`/`getLabelObstacles` was resolving by hand.
- Two module-level flags the engine threaded through its cascade are gone: `refittingToObstacles` becomes a `fontSearch` argument on `fitLabelToCandidate` (dropping a `try/finally` from a per-candidate path), and the flush-into-region block, previously inlined twice, becomes `flushCandidateBox`. `shrinkCompassCandidate` reads the cascade scratch it was being handed as eleven arguments.
- `LabelFitDescriptor.boundByRegion` is now required rather than defaulting to `true`, so the two construction sites state which behaviour they want.

Also adds the test and benchmark net this refactor leans on: a brute-force oracle for the positioned-candidate path, a `LabelManager` suite covering the placement cache, carry-forward and resolution order, a scaling test that fails if per-label cost picks up a term in the label count, and a `series-labels-collision` benchmark page separating placement cost from draw cost.

No behaviour change: the community and enterprise snapshot suites pass unmodified.