### PR TITLE
AG-14527: Align the homepage framework word with the text beside it

### DIFF
--- a/packages/ag-charts-website/src/pages-styles/homepage.module.scss
+++ b/packages/ag-charts-website/src/pages-styles/homepage.module.scss
@@ -137,8 +137,12 @@ $z-index-debug-panel: $z-index-debug-canvas + 200;
     }
 }
 
+// FrameworkTextAnimation clips the cycling word inside a `--word-height: 1.2em` box and pins
+// it to that box's bottom, so this line needs a line box of the same height or the word sits
+// low against the text beside it. The rest of the heading keeps the tighter ratio.
 .heroTopLine {
     display: flex;
+    line-height: var(--text-lh-ratio-tight);
 }
 
 .galleryScroller {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-14527

Fix #AG-14527