### PR TITLE
Notify Slack when the ag-grid integration check recovers

### DIFF
--- a/.github/workflows/integrated-charts-test.yml
+++ b/.github/workflows/integrated-charts-test.yml
@@ -17,6 +17,12 @@ env:
     GIT_CONFIG_VALUE_1: 'false'
     NX_NO_CLOUD: true
     AG_SKIP_NATIVE_DEP_VERSION_CHECK: 1
+    # Shared by both Slack steps below; only the color/title/message differ per-step.
+    SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    SLACK_ICON: https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_192.png
+    SLACK_USERNAME: ag-charts CI
+    SLACK_FOOTER: ''
+    SLACK_CHANNEL: '#charts_teamcity_status'
 
 permissions:
     contents: read
@@ -86,26 +92,28 @@ jobs:
 
             - name: Check previous run status
               id: prev_run
-              if: always()
+              # A flaky `gh` call here must never redden a build that actually
+              # passed, so it can't trip the job-level failure() check below.
+              continue-on-error: true
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  # The current run is still in_progress, so --status completed gives us
-                  # the last finished run - i.e. the one before this one.
-                  PREV_CONCLUSION=$(gh run list \
-                    --workflow integrated-charts-test.yml \
-                    --branch ${{ github.ref_name }} \
-                    --status completed \
-                    --limit 1 \
-                    --json conclusion \
-                    --jq '.[0].conclusion // ""')
-
-                  # On a re-run, this same run is still in_progress, so the query above skips
-                  # it and answers with whatever finished *before* the failing attempt - not
-                  # the failure that triggered the re-run. There's no way to query a run's own
-                  # earlier attempt, so assume the common case: a re-run follows a failure.
                   if [[ "${GITHUB_RUN_ATTEMPT}" -ge 2 ]]; then
-                    PREV_CONCLUSION="failure"
+                    # A re-run's own earlier attempt is directly queryable, unlike
+                    # --status completed below (which only sees prior runs).
+                    PREV_CONCLUSION=$(gh api \
+                      "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/$((GITHUB_RUN_ATTEMPT - 1))" \
+                      --jq '.conclusion // ""' || true)
+                  else
+                    # --status completed also matches cancelled/skipped runs, so skip
+                    # those and take the last run that actually passed or failed.
+                    PREV_CONCLUSION=$(gh run list \
+                      --workflow integrated-charts-test.yml \
+                      --branch "${{ github.ref_name }}" \
+                      --status completed \
+                      --limit 10 \
+                      --json conclusion \
+                      --jq '[.[] | select(.conclusion == "success" or .conclusion == "failure")][0].conclusion // ""' || true)
                   fi
 
                   echo "conclusion=${PREV_CONCLUSION}" >> "$GITHUB_OUTPUT"
@@ -114,34 +122,23 @@ jobs:
               if: failure()
               uses: rtCamp/action-slack-notify@v2
               env:
-                  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
                   SLACK_COLOR: failure
-                  SLACK_ICON: https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_192.png
-                  SLACK_USERNAME: ag-charts CI
-                  SLACK_FOOTER: ''
                   SLACK_TITLE: Integrated Charts Pre-Integration Test Failed
                   SLACK_MESSAGE: >
                       The ag-grid integration build check failed. AG Charts changes
                       on the `latest` branch are likely to break the next Charts
                       Pre-Integration Build in TeamCity.
                       ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                  SLACK_CHANNEL: '#charts_teamcity_status'
 
             - name: Slack Notification (recovery)
-              # Only announce a return to green, not every routine pass - a daily
-              # "still fine" ping would just be noise. Mirrors the back-to-green gate in
-              # post-deploy-verification.yml.
+              # Only announce a return to green, not every routine pass, so a daily
+              # "still fine" ping doesn't become noise.
               if: success() && steps.prev_run.outputs.conclusion == 'failure'
               uses: rtCamp/action-slack-notify@v2
               env:
-                  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
                   SLACK_COLOR: good
-                  SLACK_ICON: https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_192.png
-                  SLACK_USERNAME: ag-charts CI
-                  SLACK_FOOTER: ''
                   SLACK_TITLE: Integrated Charts Pre-Integration Test Recovered
                   SLACK_MESSAGE: >
                       The ag-grid integration build check is passing again after a
                       previous failure.
                       ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                  SLACK_CHANNEL: '#charts_teamcity_status'

--- a/.github/workflows/integrated-charts-test.yml
+++ b/.github/workflows/integrated-charts-test.yml
@@ -20,6 +20,9 @@ env:
 
 permissions:
     contents: read
+    # read is sufficient: the only actions-scope consumer is `gh run list` below, which is
+    # read-only. `permissions:` replaces the defaults, so the scope has to be named here.
+    actions: read
 
 jobs:
     test-ag-grid-integration:
@@ -81,6 +84,32 @@ jobs:
                   ./scripts/ci/substituteAgChartsTypesScene.sh
                   yarn nx build ag-grid-enterprise --skip-nx-cache
 
+            - name: Check previous run status
+              id: prev_run
+              if: always()
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  # The current run is still in_progress, so --status completed gives us
+                  # the last finished run - i.e. the one before this one.
+                  PREV_CONCLUSION=$(gh run list \
+                    --workflow integrated-charts-test.yml \
+                    --branch ${{ github.ref_name }} \
+                    --status completed \
+                    --limit 1 \
+                    --json conclusion \
+                    --jq '.[0].conclusion // ""')
+
+                  # On a re-run, this same run is still in_progress, so the query above skips
+                  # it and answers with whatever finished *before* the failing attempt - not
+                  # the failure that triggered the re-run. There's no way to query a run's own
+                  # earlier attempt, so assume the common case: a re-run follows a failure.
+                  if [[ "${GITHUB_RUN_ATTEMPT}" -ge 2 ]]; then
+                    PREV_CONCLUSION="failure"
+                  fi
+
+                  echo "conclusion=${PREV_CONCLUSION}" >> "$GITHUB_OUTPUT"
+
             - name: Slack Notification (failure)
               if: failure()
               uses: rtCamp/action-slack-notify@v2
@@ -95,5 +124,24 @@ jobs:
                       The ag-grid integration build check failed. AG Charts changes
                       on the `latest` branch are likely to break the next Charts
                       Pre-Integration Build in TeamCity.
+                      ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  SLACK_CHANNEL: '#charts_teamcity_status'
+
+            - name: Slack Notification (recovery)
+              # Only announce a return to green, not every routine pass - a daily
+              # "still fine" ping would just be noise. Mirrors the back-to-green gate in
+              # post-deploy-verification.yml.
+              if: success() && steps.prev_run.outputs.conclusion == 'failure'
+              uses: rtCamp/action-slack-notify@v2
+              env:
+                  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+                  SLACK_COLOR: good
+                  SLACK_ICON: https://avatars.slack-edge.com/2020-11-25/1527503386626_319578f21381f9641cd8_192.png
+                  SLACK_USERNAME: ag-charts CI
+                  SLACK_FOOTER: ''
+                  SLACK_TITLE: Integrated Charts Pre-Integration Test Recovered
+                  SLACK_MESSAGE: >
+                      The ag-grid integration build check is passing again after a
+                      previous failure.
                       ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
                   SLACK_CHANNEL: '#charts_teamcity_status'


### PR DESCRIPTION
The `Integrated Charts Test` workflow (daily canary that builds ag-charts and does a real ag-grid integration build against it) only ever posted to Slack on failure, so a fix landing after a red run produced no signal that things were green again — including a transient re-run (e.g. an npm registry 503, as happened on the run that prompted this).

Adds a "back-to-green" Slack step, gated on the previous run having failed, so routine daily passes stay silent. Mirrors the existing pattern in `post-deploy-verification.yml` (same target channel).

The "check previous run" step queries the run's own prior attempt directly via the GitHub Actions API on a re-run (rather than assuming a re-run always follows a failure, which isn't true — GitHub allows re-running a green run too), and is `continue-on-error: true` so a flaky `gh` call can't manufacture a false failure alert on a build that actually passed.