### PR TITLE
Invalidate axis tick-layout cache on font load

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -485,8 +485,7 @@ export abstract class Axis<
         this.cleanup.register(
             this.moduleCtx.widgets.containerWidget.addListener('mousemove', (e) => this.onMouseMove(e)),
             this.moduleCtx.widgets.containerWidget.addListener('mouseleave', () => this.endHovering()),
-            // The tick-layout cache key carries no font identity, so a late webfont load would otherwise
-            // keep label thicknesses measured against the fallback font.
+            // The tick-layout cache key carries no font identity.
             this.moduleCtx.eventsHub.on('font:load', () => this.invalidateLayoutCache())
         );
     }

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -484,7 +484,10 @@ export abstract class Axis<
         this.range = this.scale.range.slice() as [number, number];
         this.cleanup.register(
             this.moduleCtx.widgets.containerWidget.addListener('mousemove', (e) => this.onMouseMove(e)),
-            this.moduleCtx.widgets.containerWidget.addListener('mouseleave', () => this.endHovering())
+            this.moduleCtx.widgets.containerWidget.addListener('mouseleave', () => this.endHovering()),
+            // The tick-layout cache key carries no font identity, so a late webfont load would otherwise
+            // keep label thicknesses measured against the fallback font.
+            this.moduleCtx.eventsHub.on('font:load', () => this.invalidateLayoutCache())
         );
     }
 

--- a/packages/ag-charts-community/src/chart/axis/axisFontLoad.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisFontLoad.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ChartUpdateType } from 'ag-charts-core';
+import type { AgCartesianChartOptions } from 'ag-charts-types';
+
+import { createChart, setupMockCanvas, setupMockConsole, waitForChartStability } from '../test/utils';
+
+const OPTIONS: AgCartesianChartOptions = {
+    data: [
+        { month: 'Jan', value: 162 },
+        { month: 'Mar', value: 302 },
+        { month: 'May', value: 800 },
+    ],
+    series: [{ type: 'line', xKey: 'month', yKey: 'value' }],
+    axes: {
+        x: { type: 'category', position: 'bottom' },
+        y: { type: 'number', position: 'left' },
+    },
+};
+
+describe('Axis font loading', () => {
+    setupMockConsole();
+    setupMockCanvas();
+
+    let chart: Awaited<ReturnType<typeof createChart>> | undefined;
+
+    afterEach(() => {
+        chart?.destroy();
+        chart = undefined;
+    });
+
+    it('re-measures tick layouts when fonts load', async () => {
+        chart = await createChart(OPTIONS);
+        const axis = chart.axes.find((a) => a.position === 'bottom')!;
+        const calculateTickLayout = vi.spyOn(axis as any, 'calculateTickLayout');
+
+        // A layout with no domain/range change must hit the cache, or the second assertion is vacuous.
+        chart.update(ChartUpdateType.PERFORM_LAYOUT);
+        await waitForChartStability(chart);
+        expect(calculateTickLayout).not.toHaveBeenCalled();
+
+        chart.ctx.eventsHub.emit('font:load', null);
+        await waitForChartStability(chart);
+        expect(calculateTickLayout).toHaveBeenCalled();
+    });
+});

--- a/packages/ag-charts-community/src/chart/axis/axisFontLoad.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisFontLoad.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ChartUpdateType } from 'ag-charts-core';
 import type { AgCartesianChartOptions } from 'ag-charts-types';
 
+import { BBox } from '../../scene/bbox';
 import { createChart, setupMockCanvas, setupMockConsole, waitForChartStability } from '../test/utils';
 
 const OPTIONS: AgCartesianChartOptions = {
@@ -42,5 +43,25 @@ describe('Axis font loading', () => {
         chart.ctx.eventsHub.emit('font:load', null);
         await waitForChartStability(chart);
         expect(calculateTickLayout).toHaveBeenCalled();
+    });
+
+    it('keeps animating when a font load moves the layout', async () => {
+        chart = await createChart(OPTIONS);
+        const skipCurrentBatch = vi.spyOn(chart.ctx.animationManager, 'skipCurrentBatch');
+
+        const perturbAnimationRect = () => {
+            (chart as any).animationRect = new BBox(0, 0, 1, 1);
+        };
+
+        perturbAnimationRect();
+        chart.update(ChartUpdateType.PERFORM_LAYOUT);
+        await waitForChartStability(chart);
+        expect(skipCurrentBatch).toHaveBeenCalled();
+
+        skipCurrentBatch.mockClear();
+        perturbAnimationRect();
+        chart.ctx.eventsHub.emit('font:load', null);
+        await waitForChartStability(chart);
+        expect(skipCurrentBatch).not.toHaveBeenCalled();
     });
 });

--- a/packages/ag-charts-community/src/chart/axis/axisFontLoad.test.ts
+++ b/packages/ag-charts-community/src/chart/axis/axisFontLoad.test.ts
@@ -3,7 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ChartUpdateType } from 'ag-charts-core';
 import type { AgCartesianChartOptions } from 'ag-charts-types';
 
-import { BBox } from '../../scene/bbox';
 import { createChart, setupMockCanvas, setupMockConsole, waitForChartStability } from '../test/utils';
 
 const OPTIONS: AgCartesianChartOptions = {
@@ -43,25 +42,5 @@ describe('Axis font loading', () => {
         chart.ctx.eventsHub.emit('font:load', null);
         await waitForChartStability(chart);
         expect(calculateTickLayout).toHaveBeenCalled();
-    });
-
-    it('keeps animating when a font load moves the layout', async () => {
-        chart = await createChart(OPTIONS);
-        const skipCurrentBatch = vi.spyOn(chart.ctx.animationManager, 'skipCurrentBatch');
-
-        const perturbAnimationRect = () => {
-            (chart as any).animationRect = new BBox(0, 0, 1, 1);
-        };
-
-        perturbAnimationRect();
-        chart.update(ChartUpdateType.PERFORM_LAYOUT);
-        await waitForChartStability(chart);
-        expect(skipCurrentBatch).toHaveBeenCalled();
-
-        skipCurrentBatch.mockClear();
-        perturbAnimationRect();
-        chart.ctx.eventsHub.emit('font:load', null);
-        await waitForChartStability(chart);
-        expect(skipCurrentBatch).not.toHaveBeenCalled();
     });
 });

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -514,6 +514,7 @@ export abstract class Chart implements ModuleInstance, ChartService {
                 this.title.node.markDirty();
                 this.subtitle.node.markDirty();
                 this.footnote.node.markDirty();
+                this.fontLayoutCorrection = true;
                 this.update(ChartUpdateType.PERFORM_LAYOUT);
             }),
             ctx.eventsHub.on('rtl:change', () => {
@@ -1634,7 +1635,9 @@ export abstract class Chart implements ModuleInstance, ChartService {
 
         await this.performLayout(ctx);
 
-        if (oldRect && !this.animationRect?.equals(oldRect)) {
+        const fontLayoutCorrection = this.fontLayoutCorrection;
+        this.fontLayoutCorrection = false;
+        if (oldRect && !this.animationRect?.equals(oldRect) && !fontLayoutCorrection) {
             // Skip animations if the layout changed.
             this.ctx.animationManager.skipCurrentBatch();
         }
@@ -1647,6 +1650,8 @@ export abstract class Chart implements ModuleInstance, ChartService {
     public seriesRect?: BBox;
     // BBox of the chart area containing animatable elements; if this changes, we skip animations.
     protected animationRect?: BBox;
+    // A late webfont re-measure is not a layout change worth abandoning an animation for.
+    private fontLayoutCorrection = false;
 
     protected getDebugColors(): { background?: string; foreground?: string } | undefined {
         const bg = this.ctx.chartState.getValue('options', 'background').fill;

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -514,7 +514,6 @@ export abstract class Chart implements ModuleInstance, ChartService {
                 this.title.node.markDirty();
                 this.subtitle.node.markDirty();
                 this.footnote.node.markDirty();
-                this.fontLayoutCorrection = true;
                 this.update(ChartUpdateType.PERFORM_LAYOUT);
             }),
             ctx.eventsHub.on('rtl:change', () => {
@@ -1635,9 +1634,7 @@ export abstract class Chart implements ModuleInstance, ChartService {
 
         await this.performLayout(ctx);
 
-        const fontLayoutCorrection = this.fontLayoutCorrection;
-        this.fontLayoutCorrection = false;
-        if (oldRect && !this.animationRect?.equals(oldRect) && !fontLayoutCorrection) {
+        if (oldRect && !this.animationRect?.equals(oldRect)) {
             // Skip animations if the layout changed.
             this.ctx.animationManager.skipCurrentBatch();
         }
@@ -1650,8 +1647,6 @@ export abstract class Chart implements ModuleInstance, ChartService {
     public seriesRect?: BBox;
     // BBox of the chart area containing animatable elements; if this changes, we skip animations.
     protected animationRect?: BBox;
-    // A late webfont re-measure is not a layout change worth abandoning an animation for.
-    private fontLayoutCorrection = false;
 
     protected getDebugColors(): { background?: string; foreground?: string } | undefined {
         const bg = this.ctx.chartState.getValue('options', 'background').fill;

--- a/packages/ag-charts-community/src/chart/fonts/fontManager.test.ts
+++ b/packages/ag-charts-community/src/chart/fonts/fontManager.test.ts
@@ -36,6 +36,21 @@ class MockResizeObserver {
 // Install mock before importing fontManager (getResizeObserver reads globalThis)
 (globalThis as any).ResizeObserver = MockResizeObserver;
 
+function createMockAnimationManager(active = false) {
+    const listeners = new Set<() => void>();
+    return {
+        isActive: () => active,
+        addListener: (_type: string, listener: () => void) => {
+            listeners.add(listener);
+            return () => listeners.delete(listener);
+        },
+        stopAnimation() {
+            active = false;
+            for (const listener of listeners) listener();
+        },
+    };
+}
+
 function createMockDomManager(): DOMManager {
     return {
         addStyles: vi.fn(),
@@ -52,7 +67,11 @@ describe('FontManager', () => {
     it('should emit font:load on eventsHub when a font loads', () => {
         const eventsHub = new EventEmitter<EventsHubMap>();
         const domManager = createMockDomManager();
-        const fontManager = new FontManager({ domManager, eventsHub } as unknown as DynamicContext<ChartRegistry>);
+        const fontManager = new FontManager({
+            domManager,
+            eventsHub,
+            animationManager: createMockAnimationManager(),
+        } as unknown as DynamicContext<ChartRegistry>);
 
         const handler = vi.fn();
         eventsHub.on('font:load', handler);
@@ -71,7 +90,11 @@ describe('FontManager', () => {
     it('should not emit font:load when observed width is zero', () => {
         const eventsHub = new EventEmitter<EventsHubMap>();
         const domManager = createMockDomManager();
-        const fontManager = new FontManager({ domManager, eventsHub } as unknown as DynamicContext<ChartRegistry>);
+        const fontManager = new FontManager({
+            domManager,
+            eventsHub,
+            animationManager: createMockAnimationManager(),
+        } as unknown as DynamicContext<ChartRegistry>);
 
         const handler = vi.fn();
         eventsHub.on('font:load', handler);
@@ -92,6 +115,7 @@ describe('FontManager', () => {
         const fontManager = new FontManager({
             domManager: createMockDomManager(),
             eventsHub,
+            animationManager: createMockAnimationManager(),
         } as unknown as DynamicContext<ChartRegistry>);
         const handler = vi.fn();
         eventsHub.on('font:load', handler);
@@ -225,5 +249,30 @@ describe('FontManager', () => {
         await Promise.resolve();
 
         expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('holds font:load until the running animation stops', () => {
+        const eventsHub = new EventEmitter<EventsHubMap>();
+        const animationManager = createMockAnimationManager(true);
+        const fontManager = new FontManager({
+            domManager: createMockDomManager(),
+            eventsHub,
+            animationManager,
+        } as unknown as DynamicContext<ChartRegistry>);
+
+        const handler = vi.fn();
+        eventsHub.on('font:load', handler);
+
+        fontManager.updateFonts(new Set(['Pacifico']));
+        resizeObserverCallback?.(
+            [{ contentBoxSize: [{ inlineSize: 42 }] }] as unknown as ResizeObserverEntry[],
+            {} as ResizeObserver
+        );
+
+        expect(handler).not.toHaveBeenCalled();
+
+        animationManager.stopAnimation();
+
+        expect(handler).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/ag-charts-community/src/chart/fonts/fontManager.ts
+++ b/packages/ag-charts-community/src/chart/fonts/fontManager.ts
@@ -5,6 +5,8 @@ import type { ChartRegistry } from '../../module/moduleContext';
 export class FontManager {
     private observers: Array<ResizeObserver> = [];
     private destroyed = false;
+    private pendingFontLoad = false;
+    private readonly cleanup: Array<() => void> = [];
 
     // OPTIMIZATION: skips the native `check()` per streaming update. `check()` reports a spec as
     // available even with no matching `@font-face`, so a later declaration or load can make a
@@ -12,7 +14,26 @@ export class FontManager {
     private readonly confirmedFontSpecs = new Set<string>();
     private watchedFontSet?: FontFaceSet;
 
-    constructor(private readonly ctx: DynamicContext<ChartRegistry>) {}
+    constructor(private readonly ctx: DynamicContext<ChartRegistry>) {
+        this.cleanup.push(
+            ctx.animationManager.addListener('animation-stop', this.flushFontLoad),
+            ctx.eventsHub.on('update:complete', this.flushFontLoad)
+        );
+    }
+
+    // A re-measure re-lays out the chart, and a layout mid-batch costs the chart its animation, so the
+    // notification waits for the animation to finish.
+    private readonly flushFontLoad = () => {
+        if (this.destroyed || !this.pendingFontLoad || this.ctx.animationManager.isActive()) return;
+        this.pendingFontLoad = false;
+        cachedTextMeasurer.clear();
+        this.ctx.eventsHub.emit('font:load', null);
+    };
+
+    private notifyFontLoad() {
+        this.pendingFontLoad = true;
+        this.flushFontLoad();
+    }
 
     private readonly onFontSetChange = () => {
         this.confirmedFontSpecs.clear();
@@ -53,8 +74,7 @@ export class FontManager {
 
         void Promise.allSettled(pending).then(() => {
             if (this.destroyed) return;
-            cachedTextMeasurer.clear();
-            this.ctx.eventsHub.emit('font:load', null);
+            this.notifyFontLoad();
         });
     }
 
@@ -80,6 +100,10 @@ export class FontManager {
             observer.disconnect();
         }
         this.observers = [];
+        for (const off of this.cleanup) {
+            off();
+        }
+        this.cleanup.length = 0;
         this.unwatchFontSet();
     }
 
@@ -119,9 +143,7 @@ export class FontManager {
         const fontCheckObserver = new ResizeObserverCtor((entries) => {
             const width = entries?.at(0)?.contentBoxSize.at(0)?.inlineSize;
             if (width != null && width > 0) {
-                // Clear the text measurer pool to ensure the font metrics are recalculated on update
-                cachedTextMeasurer.clear();
-                this.ctx.eventsHub.emit('font:load', null);
+                this.notifyFontLoad();
             }
         });
         fontCheckObserver.observe(fontCheckElement);


### PR DESCRIPTION
The axis tick-layout cache key covers domain, range and nice bounds only, so a webfont that resolves after the first layout left label thicknesses measured against the fallback font while the labels painted in the loaded one.

Result was a bistable render: the `google-fonts` E2E snapshot has been flipping between two images 1px apart in bottom-axis thickness since March, depending on when the font resolved (four regenerations on 2026-03-03 alternating between the same two blobs; the snapshot CI regenerated in #7925 is bit-identical to the one committed then).

Axes now drop the cache on `font:load`, so the layout that follows re-measures with the loaded font.

Honouring the new metrics exposed a second problem: a relayout while an animation batch is in flight destroys that batch, so a font resolving mid-animation cost the chart its initial animation (caught by the `synchronised` E2E specs). `FontManager` now holds the notification until `animation-stop`, with `update:complete` as a second flush trigger so a skipped batch cannot strand the correction.

Supersedes #7925 — that PR just flips the baseline to the other of the two states. No baseline regeneration is needed: the fonts shard passed against the committed baseline on this branch.