### PR TITLE
AG-18315: Fix on-this-page anchor links using stale pathname after SPA navigation

### DIFF
--- a/packages/ag-charts-website/src/components/pages-navigation/components/SideNavigation.tsx
+++ b/packages/ag-charts-website/src/components/pages-navigation/components/SideNavigation.tsx
@@ -1,6 +1,5 @@
 import { Icon } from '@ag-website-shared/components/icon/Icon';
-import { replaceHistoryUrl } from '@ag-website-shared/utils/historyUrl';
-import { scrollIntoViewById } from '@ag-website-shared/utils/navigation';
+import { navigate, scrollIntoViewById } from '@ag-website-shared/utils/navigation';
 import { useScrollSpy } from '@components/pages-navigation/hooks/useScrollSpy';
 import { addNonBreakingSpaceBetweenLastWords } from '@utils/addNonBreakingSpaceBetweenLastWords';
 import type { MarkdownHeading } from 'astro';
@@ -35,7 +34,11 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                                     onClick={(event) => {
                                         event.preventDefault();
                                         scrollIntoViewById(slug);
-                                        replaceHistoryUrl(`#${slug}`);
+                                        navigate({
+                                            pathname: window.location.pathname,
+                                            search: window.location.search,
+                                            hash: slug,
+                                        });
                                     }}
                                 >
                                     {addNonBreakingSpaceBetweenLastWords(displayText)}
@@ -52,7 +55,11 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                         onClick={(event) => {
                             event.preventDefault();
                             scrollIntoViewById('top');
-                            replaceHistoryUrl('#top');
+                            navigate({
+                                pathname: window.location.pathname,
+                                search: window.location.search,
+                                hash: 'top',
+                            });
                         }}
                     >
                         <Icon name="backToTop" svgClasses={styles.backToTopIcon} />

--- a/packages/ag-charts-website/src/components/pages-navigation/components/SideNavigation.tsx
+++ b/packages/ag-charts-website/src/components/pages-navigation/components/SideNavigation.tsx
@@ -1,5 +1,6 @@
 import { Icon } from '@ag-website-shared/components/icon/Icon';
-import { navigate, scrollIntoViewById } from '@ag-website-shared/utils/navigation';
+import { replaceHistoryUrl } from '@ag-website-shared/utils/historyUrl';
+import { scrollIntoViewById } from '@ag-website-shared/utils/navigation';
 import { useScrollSpy } from '@components/pages-navigation/hooks/useScrollSpy';
 import { addNonBreakingSpaceBetweenLastWords } from '@utils/addNonBreakingSpaceBetweenLastWords';
 import type { MarkdownHeading } from 'astro';
@@ -34,7 +35,7 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                                     onClick={(event) => {
                                         event.preventDefault();
                                         scrollIntoViewById(slug);
-                                        navigate({ search: window.location.search, hash: slug });
+                                        replaceHistoryUrl(`#${slug}`);
                                     }}
                                 >
                                     {addNonBreakingSpaceBetweenLastWords(displayText)}
@@ -51,7 +52,7 @@ export function SideNavigation({ headings, delayedScrollSpy }: Props) {
                         onClick={(event) => {
                             event.preventDefault();
                             scrollIntoViewById('top');
-                            navigate({ search: window.location.search, hash: 'top' });
+                            replaceHistoryUrl('#top');
                         }}
                     >
                         <Icon name="backToTop" svgClasses={styles.backToTopIcon} />


### PR DESCRIPTION
## Summary
Port of ag-grid/ag-grid#14975 to ag-charts - the docs site shares the same `SideNavigation.tsx` / `navigate()` / `replaceHistoryUrl` pattern via `external/ag-website-shared`.

- On the docs site, clicking a right-hand "On this page" anchor link (or "Back to top") after navigating client-side via the left menu kept the URL's pathname pinned to whatever page was first loaded in the session, instead of the current page.
- Root cause: `SideNavigation.tsx` used the shared `navigate()` helper, which wraps the `history` npm package's `browserHistory` singleton. Its cached `location.pathname` is only refreshed on `popstate`, which Astro's `<ClientRouter />` view-transition navigations never fire - so a partial `navigate({ search, hash })` call fell back to a stale pathname.

**Revision:** the first commit switched to `replaceHistoryUrl` (matching the grid port), but that broke `e2e/docs-page-nav.spec.ts` - the "highlights the clicked section on an API page" case failed on the "Legend Events" link. `useScrollSpy`'s effect depends on `useLocation()`'s hash (backed by `browserHistory.listen()`) to re-run `scrollspy()` on click; `replaceHistoryUrl` fires no listener, so that reactivity - which turns out to be load-bearing, not a redundant safety net - was lost.

The second commit reverts to `navigate()`, but passes `pathname: window.location.pathname` explicitly instead of relying on `browserHistory`'s stale cached location to fill it in. This fixes the original bug while keeping the scroll-spy's reactivity intact. Verified locally: both `docs-page-nav.spec.ts` cases pass with this version and the API-page case fails with `replaceHistoryUrl`.

## Test plan
- [x] `yarn nx lint ag-charts-website` passes (0 errors)
- [x] `e2e/docs-page-nav.spec.ts` passes locally (both cases) - confirmed via direct `npx playwright test`, and confirmed it fails on `replaceHistoryUrl` and passes on pre-fix `navigate()` for comparison
- [ ] Manually verify: navigate via left-hand menu to a new page, then click an "On this page" anchor link - confirm the URL updates to the current page's path + the anchor hash, not the first page loaded in the session
