### PR TITLE
AG-18348: Fix anchor links using a stale pathname after SPA navigation

### DIFF
--- a/external/ag-website-shared/src/components/tabs/TabsWithHtmlChildren.astro
+++ b/external/ag-website-shared/src/components/tabs/TabsWithHtmlChildren.astro
@@ -112,7 +112,16 @@ const { tabItemIdPrefix, headerLinks, snippetTabs } = Astro.props as Props;
                     this.updateTabs();
 
                     const tabId = getTabId({ id: this.selected.id, prefix: this.tabItemIdPrefix });
-                    navigate(`#${tabId}`);
+                    // Pass the whole location: a bare hash is resolved against the `history`
+                    // package's cached location, which Astro's `<ClientRouter />` never
+                    // refreshes, leaving the pathname on whichever page loaded first. Keep
+                    // `navigate` rather than `replaceHistoryUrl` - the `browserHistory`
+                    // listener above syncs sibling tab groups, and only a push fires it.
+                    navigate({
+                        pathname: window.location.pathname,
+                        search: window.location.search,
+                        hash: tabId,
+                    });
                 });
             });
         }

--- a/external/ag-website-shared/src/utils/navigation.ts
+++ b/external/ag-website-shared/src/utils/navigation.ts
@@ -1,7 +1,6 @@
 import type { Location, To, Update } from 'history';
 import { createBrowserHistory } from 'history';
-import { useCallback, useEffect, useState } from 'react';
-import type { MouseEventHandler } from 'react';
+import { useEffect, useState } from 'react';
 
 export const browserHistory = import.meta.env.SSR ? null : createBrowserHistory();
 
@@ -13,19 +12,6 @@ export function useLocation() {
     const [location, setLocation] = useState<Location | null>(browserHistory?.location ?? null);
     useHistory(({ location }) => setLocation(location));
     return location;
-}
-
-export function useScrollToAnchor() {
-    const handleScroll: MouseEventHandler<HTMLAnchorElement> = useCallback((event) => {
-        event.preventDefault();
-        navigate(event.currentTarget.href);
-        const href = event.currentTarget.getAttribute('href');
-        if (href?.startsWith('#')) {
-            scrollIntoViewById(href.substring(1));
-        }
-    }, []);
-
-    return handleScroll;
 }
 
 export function navigate(to: To, options?: { state?: any; replace?: boolean }) {

--- a/packages/ag-charts-website/src/components/api-documentation/components/Properties.tsx
+++ b/packages/ag-charts-website/src/components/api-documentation/components/Properties.tsx
@@ -1,7 +1,6 @@
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { LinkIcon } from '@ag-website-shared/components/link-icon/LinkIcon';
 import styles from '@ag-website-shared/components/reference-documentation/ApiReference.module.scss';
-import { useScrollToAnchor } from '@ag-website-shared/utils/navigation';
 import classnames from 'classnames';
 import type { AllHTMLAttributes, FunctionComponent, ReactNode } from 'react';
 
@@ -30,8 +29,6 @@ export function PropertyTitle({
     isExpandable,
     childPropsOnClick,
 }: PropertyTitleOptions) {
-    const scrollToAnchor = useScrollToAnchor();
-
     const propName =
         hasChildProps || isExpandable ? (
             <span className={styles.propNameExpander} onClick={childPropsOnClick}>
@@ -52,12 +49,7 @@ export function PropertyTitle({
 
             {required && <span className={styles.required}>required</span>}
 
-            <LinkIcon
-                href={`#${anchorId}`}
-                onClick={scrollToAnchor}
-                className={styles.linkIcon}
-                aria-label={`Link to ${name} property`}
-            />
+            <LinkIcon href={`#${anchorId}`} className={styles.linkIcon} aria-label={`Link to ${name} property`} />
         </div>
     );
 }


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-18348

Fix #AG-18348

Tab clicks passed a bare hash to `navigate()`, so the `history` package filled the
pathname in from its own cached location, which Astro's `<ClientRouter />` only
refreshes on `popstate`. After a client-side navigation the URL kept the pathname of
the page loaded first. The full location is now passed explicitly - the same shape
#7948 settled on for `SideNavigation.tsx`. `navigate()` is kept rather than
`replaceHistoryUrl` because only a push fires the `browserHistory` listener that keeps
sibling tab groups in sync, and that the scroll spy depends on.

The ticket's second issue asked for the property reference anchor links to migrate to
`replaceHistoryUrl`. That migration is already in place by another route: `LinkIcon`
spreads incoming props before setting its own `onClick`, so the `useScrollToAnchor`
handler passed to it was overridden and never ran, and `LinkIcon`'s handler already
calls `replaceHistoryUrl`. That is why the reported symptoms do not occur on `latest` -
repeated property anchor clicks leave `history.length` unchanged and Astro's
`history.state` keys intact. The dead prop and the now-unreachable hook are removed
instead of migrating code that never executed.

`e2e/docs-page-nav.spec.ts` passes on this branch.