### PR TITLE
AG-17743: hook documentation example dark mode into website CSS

### DIFF
--- a/external/ag-website-shared/src/components/example-runner/styles/example-chart-theme.css
+++ b/external/ag-website-shared/src/components/example-runner/styles/example-chart-theme.css
@@ -1,0 +1,34 @@
+/**
+ * Colour scheme for documentation example charts. The generated dark-mode snippet points the
+ * default theme's colour parameters at these variables, and AG Charts resolves them against the
+ * chart container and watches them for changes - so an example paints in the right scheme on
+ * first render and repaints itself when the site toggles `data-dark-mode`, with no `chart.update()`.
+ *
+ * The values are the `ag-default` / `ag-default-dark` parameters as resolved by the theme,
+ * covering only those the dark theme actually retunes. To refresh them, read the
+ * `--ag-charts-*` properties AG Charts writes onto a chart's root element under each theme
+ * (`DOMManager.setThemeParameters`) - see `chart/themes/{chartTheme,darkTheme}.ts` for the source.
+ */
+:root {
+    --ag-example-chart-axis-line-color: #dcdddd;
+    --ag-example-chart-background-color: #ffffff;
+    --ag-example-chart-border-color: #dcdddd;
+    --ag-example-chart-chrome-background-color: #fafafb;
+    --ag-example-chart-crosshair-label-background-color: #181d1f;
+    --ag-example-chart-foreground-color: #181d1f;
+    --ag-example-chart-grid-line-color: #e8e9e9;
+    --ag-example-chart-grouped-category-line-color: #d8d9d9;
+    --ag-example-chart-subtle-text-color: #707374;
+}
+
+:root[data-dark-mode='true'] {
+    --ag-example-chart-axis-line-color: #c3c5c9;
+    --ag-example-chart-background-color: #192232;
+    --ag-example-chart-border-color: #4b525e;
+    --ag-example-chart-chrome-background-color: #293140;
+    --ag-example-chart-crosshair-label-background-color: #afb2b7;
+    --ag-example-chart-foreground-color: #fff;
+    --ag-example-chart-grid-line-color: #545b67;
+    --ag-example-chart-grouped-category-line-color: #7e838c;
+    --ag-example-chart-subtle-text-color: #7c818a;
+}

--- a/packages/ag-charts-community/src/chart/themes/cssVariableParams.test.ts
+++ b/packages/ag-charts-community/src/chart/themes/cssVariableParams.test.ts
@@ -5,13 +5,20 @@ import type { AgCartesianChartOptions, AgChartThemeParams } from 'ag-charts-type
 import { AgCharts } from '../../api/agCharts';
 import type { ChartOrProxy } from '../test/utils';
 import { setupMockCanvas, setupMockConsole, waitForChartStability } from '../test/utils';
+import { ChartTheme } from './chartTheme';
+import { DarkTheme } from './darkTheme';
 
 /**
- * The colour parameters the documentation examples source from CSS variables, so that an example
- * adopts the site's dark mode through CSS rather than a theme swap (AG-17743), and the
- * `ag-default-dark` values those variables carry. Mirrors
- * `external/ag-website-shared/src/components/example-runner/styles/example-chart-theme.css`.
+ * The documentation examples adopt the site's dark mode through CSS rather than a theme swap
+ * (AG-17743): the generated snippet points the default theme's colour parameters at the variables in
+ * `external/ag-website-shared/src/components/example-runner/styles/example-chart-theme.css`, and AG
+ * Charts re-resolves them when the site toggles `data-dark-mode`.
+ *
+ * That only works for colours a theme *parameter* can carry. These two tests fence off both halves
+ * of that claim, so a change to either theme fails here rather than silently mis-colouring examples.
  */
+
+/** The `ag-default-dark` parameter values the CSS variables carry. Keep in step with that file. */
 const DARK_MODE_PARAMS: AgChartThemeParams = {
     axisLineColor: '#c3c5c9',
     backgroundColor: '#192232',
@@ -27,7 +34,28 @@ const DARK_MODE_PARAMS: AgChartThemeParams = {
 /** Neither is a plain colour, so neither can travel through a CSS variable. */
 const UNMAPPABLE_PROPERTIES = ['--ag-charts-popup-shadow', '--ag-charts-focus-color'];
 
-describe("the documentation examples' dark mode parameters", () => {
+/**
+ * The palette entries `ag-default-dark` retunes. None can be driven from CSS - `theme.palette`
+ * takes no option for the hierarchy or sequential colours, and supplying `strokes`/`up`/`down`/
+ * `neutral` would change `paletteType` and so change light mode too - so the examples whose series
+ * read them stay on the theme-name swap, listed as `PALETTE_SENSITIVE_TYPES` in
+ * `plugins/ag-charts-generate-example-files/.../getDarkModeSnippet.ts`. If this set changes, that
+ * list needs revisiting.
+ */
+const DARK_PALETTE_KEYS = [
+    'altDown',
+    'altNeutral',
+    'altUp',
+    'down',
+    'hierarchyColors',
+    'neutral',
+    'secondHierarchyColors',
+    'secondSequentialColors',
+    'strokes',
+    'up',
+];
+
+describe("the documentation examples' dark mode", () => {
     setupMockConsole();
     setupMockCanvas();
 
@@ -69,10 +97,21 @@ describe("the documentation examples' dark mode parameters", () => {
         return properties;
     };
 
-    test('reproduce the dark theme on top of the default one', async () => {
+    test('parameters reproduce the dark theme on top of the default one', async () => {
         const fromParams = await getThemeProperties({ baseTheme: 'ag-default', params: DARK_MODE_PARAMS });
         const fromDarkTheme = await getThemeProperties('ag-default-dark');
 
         expect(fromParams).toEqual(fromDarkTheme);
+    });
+
+    test('only the known palette entries fall outside the parameters', () => {
+        const light: Record<string, unknown> = ChartTheme.getDefaultColors();
+        const dark: Record<string, unknown> = new DarkTheme().getDefaultColors();
+
+        const differing = Object.keys(light)
+            .filter((key) => JSON.stringify(light[key]) !== JSON.stringify(dark[key]))
+            .sort((a, b) => a.localeCompare(b));
+
+        expect(differing).toEqual(DARK_PALETTE_KEYS);
     });
 });

--- a/packages/ag-charts-community/src/chart/themes/cssVariableParams.test.ts
+++ b/packages/ag-charts-community/src/chart/themes/cssVariableParams.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test } from 'vitest';
+
+import type { AgCartesianChartOptions, AgChartThemeParams } from 'ag-charts-types';
+
+import { AgCharts } from '../../api/agCharts';
+import type { ChartOrProxy } from '../test/utils';
+import { setupMockCanvas, setupMockConsole, waitForChartStability } from '../test/utils';
+
+/**
+ * The colour parameters the documentation examples source from CSS variables, so that an example
+ * adopts the site's dark mode through CSS rather than a theme swap (AG-17743), and the
+ * `ag-default-dark` values those variables carry. Mirrors
+ * `external/ag-website-shared/src/components/example-runner/styles/example-chart-theme.css`.
+ */
+const DARK_MODE_PARAMS: AgChartThemeParams = {
+    axisLineColor: '#c3c5c9',
+    backgroundColor: '#192232',
+    borderColor: '#4b525e',
+    chromeBackgroundColor: '#293140',
+    crosshairLabelBackgroundColor: '#afb2b7',
+    foregroundColor: '#fff',
+    gridLineColor: '#545b67',
+    groupedCategoryLineColor: '#7e838c',
+    subtleTextColor: '#7c818a',
+};
+
+/** Neither is a plain colour, so neither can travel through a CSS variable. */
+const UNMAPPABLE_PROPERTIES = ['--ag-charts-popup-shadow', '--ag-charts-focus-color'];
+
+describe("the documentation examples' dark mode parameters", () => {
+    setupMockConsole();
+    setupMockCanvas();
+
+    let charts: ChartOrProxy[] = [];
+
+    afterEach(async () => {
+        for (const chart of charts) {
+            await waitForChartStability(chart);
+            chart.destroy();
+        }
+        charts = [];
+    });
+
+    const getThemeProperties = async (theme: AgCartesianChartOptions['theme']) => {
+        const container = document.body.appendChild(document.createElement('div'));
+        const chart = AgCharts.create({
+            theme,
+            width: 400,
+            height: 300,
+            container,
+            data: [{ x: 'a', y: 1 }],
+            series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+        } as AgCartesianChartOptions);
+        charts.push(chart);
+        await waitForChartStability(chart);
+
+        // The resolved parameters are published as custom properties on the chart's root element.
+        const root = container.querySelector<HTMLElement>('[class*="ag-charts-theme-"]');
+        if (root == null) throw new Error('no chart root element found');
+
+        const { style } = root;
+        const properties: Record<string, string> = {};
+        for (let i = 0; i < style.length; i++) {
+            const name = style[i];
+            if (name.startsWith('--ag-charts') && !UNMAPPABLE_PROPERTIES.includes(name)) {
+                properties[name] = style.getPropertyValue(name);
+            }
+        }
+        return properties;
+    };
+
+    test('reproduce the dark theme on top of the default one', async () => {
+        const fromParams = await getThemeProperties({ baseTheme: 'ag-default', params: DARK_MODE_PARAMS });
+        const fromDarkTheme = await getThemeProperties('ag-default-dark');
+
+        expect(fromParams).toEqual(fromDarkTheme);
+    });
+});

--- a/packages/ag-charts-website/playwright.sh
+++ b/packages/ag-charts-website/playwright.sh
@@ -54,6 +54,28 @@ function warm_astro_index {
   ) >/dev/null 2>&1 </dev/null &
 }
 
+# A generated test's title embeds the exact page URL it will load (see `should load ${url}`
+# in examples-util.ts), and `--list` recovers those titles without a browser. Hitting each
+# one serially before the real (parallel) run means the first-ever compile of a heavy shared
+# dependency graph - e.g. the zoom examples all pulling in a wide slice of ag-charts-enterprise
+# - happens once, not once per worker at the same time. Left to the parallel run, that pile-up
+# has been enough to exhaust the Astro dev server's heap and crash it outright.
+#
+# The page itself is cheap: Astro serves its shell without touching the example's chart code,
+# which only loads once a browser requests the entry script the shell references. So fetch the
+# page, then also fetch the `index.js`/`main.js` it points at - that's what actually pulls in
+# ag-charts-enterprise and pays the compile cost this warm-up exists to de-duplicate.
+function warm_test_urls {
+  local urls
+  urls=$(npx playwright test --list "$@" 2>/dev/null | grep -oE 'should load https?://[^[:space:]]+' | sed 's/^should load //' | sort -u)
+  for url in ${urls} ; do
+    local html script
+    html=$(curl -fs --max-time 30 "${url%%#*}") || continue
+    script=$(echo "${html}" | grep -oE 'src="[^"]+/(index|main)\.js"' | head -1 | sed 's/^src="//;s/"$//')
+    [ -n "${script}" ] && curl -fs -o /dev/null --max-time 30 "${script}" || true
+  done
+}
+
 # Spawns the Astro dev server, recording it in ${astro_pid}. Pass --detached to send
 # its output to ${astro_log_file} so the calling shell (a CI step) can exit at once.
 #
@@ -252,4 +274,5 @@ for attempt in $(seq 1 600) ; do
   sleep 0.25
 done
 echo "Connected to ${PUBLIC_SITE_URL}!"
+warm_test_urls $@
 npx playwright $@

--- a/packages/ag-charts-website/src/components/example-runner/components/FrameworkTemplate.astro
+++ b/packages/ag-charts-website/src/components/example-runner/components/FrameworkTemplate.astro
@@ -11,6 +11,7 @@ import AngularTemplate from '../framework-templates/AngularTemplate.astro';
 import PostInitMessageScript from '@components/example-runner/components/PostInitMessageScript.astro';
 import { toTitle } from '@utils/toTitle';
 import { E2E_STYLE_START, E2E_STYLE_END } from '@components/example-runner/constants';
+import { getExampleDarkModeInitFragment } from '@components/example-runner/getExampleDarkModeInitScript';
 import { EXAMPLE_STYLE_FILE_NAME } from '@constants';
 
 interface Props {
@@ -84,7 +85,12 @@ const externalExampleStyles = `
     }
 </style>
 `;
-const headFragment = (addExternalExampleStyles ? externalExampleStyles : '') + (files?.['head.html'] ?? '');
+// Ahead of the example's own head, so it stays render-blocking even for an example that pins its
+// own CSP, and `data-dark-mode` is settled before the chart is created.
+const headFragment =
+    (addExternalExampleStyles ? externalExampleStyles : '') +
+    getExampleDarkModeInitFragment({ ignoreDarkMode }) +
+    (files?.['head.html'] ?? '');
 const appLocation = relativePath ? '' : exampleUrl;
 
 const timeNow = Date.now();
@@ -176,14 +182,6 @@ const title = `${toTitle(pageName)} - ${toTitle(exampleName)}`;
         />
     )
 }
-
-<script define:vars={{
-    ignoreDarkMode
-}} nonce="123123">
-    if (ignoreDarkMode) {
-        document.documentElement.dataset.ignoreDarkMode = 'true';
-    }
-</script>
 
 {
     addE2ECheckScript && (

--- a/packages/ag-charts-website/src/components/example-runner/getExampleDarkModeInitScript.ts
+++ b/packages/ag-charts-website/src/components/example-runner/getExampleDarkModeInitScript.ts
@@ -1,0 +1,38 @@
+/**
+ * Source of the example document's `data-dark-mode`, which `example-chart-theme.css` turns into the
+ * chart theme's colour variables. Runs render-blocking in the example's `<head>` so the attribute is
+ * set before the chart is created, and keeps it in step with the site's toggle afterwards.
+ */
+export const getExampleDarkModeInitFragment = ({ ignoreDarkMode }: { ignoreDarkMode?: boolean }) =>
+    ignoreDarkMode
+        ? ''
+        : `<script nonce="123123">
+(function () {
+    const htmlEl = document.documentElement;
+
+    let storedDarkmode;
+    try {
+        storedDarkmode = localStorage['documentation:darkmode'];
+    } catch (e) {
+        /* Storage can be unavailable, in which case the OS preference stands in. */
+    }
+
+    const setDarkmode = (darkmode) => {
+        htmlEl.dataset.darkMode = String(darkmode === true);
+    };
+
+    setDarkmode((storedDarkmode ?? String(matchMedia('(prefers-color-scheme: dark)').matches)) === 'true');
+
+    // Two delivery channels, each read from the property its own channel provides: a real
+    // postMessage when this example runs inside the example-runner iframe, and a same-page
+    // CustomEvent when it is embedded directly in the docs page.
+    const onColorSchemeChange = (data) => {
+        if (data?.type === 'color-scheme-change') {
+            setDarkmode(data.darkmode);
+        }
+    };
+
+    window.addEventListener('message', (event) => onColorSchemeChange(event.data));
+    window.addEventListener('ag-color-scheme-change', (event) => onColorSchemeChange(event.detail));
+})();
+</script>`;

--- a/packages/ag-charts-website/src/components/gallery/components/GalleryFrameworkTemplate.astro
+++ b/packages/ag-charts-website/src/components/gallery/components/GalleryFrameworkTemplate.astro
@@ -25,6 +25,10 @@ interface Props {
      */
     addExternalExampleStyles?: boolean;
     /**
+     * Ignore dark mode (always use light mode)
+     */
+    ignoreDarkMode?: boolean;
+    /**
      * Override to be used for generated contents
      */
     generatedContents?: GeneratedContents;
@@ -36,6 +40,7 @@ const {
     addInitMessageScript,
     addE2ECheckScript,
     addExternalExampleStyles,
+    ignoreDarkMode,
     generatedContents: generatedContentsOverride,
 } = Astro.props as Props;
 
@@ -72,4 +77,5 @@ const displayExampleName = getExampleName({
     addInitMessageScript={addInitMessageScript}
     addE2ECheckScript={addE2ECheckScript}
     addExternalExampleStyles={addExternalExampleStyles}
+    ignoreDarkMode={ignoreDarkMode}
 />

--- a/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName]/codesandbox.astro
+++ b/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName]/codesandbox.astro
@@ -34,4 +34,5 @@ const ignoreModuleLoader = isReactInternalFramework(internalFramework);
     ignoreModuleLoader={ignoreModuleLoader}
     transpileInBrowser={!ignoreModuleLoader}
     addExternalExampleStyles={true}
+    ignoreDarkMode={true}
 />

--- a/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName]/plunkr.astro
+++ b/packages/ag-charts-website/src/pages/[internalFramework]/[pageName]/examples/[exampleName]/plunkr.astro
@@ -29,4 +29,5 @@ const { internalFramework, pageName, exampleName } = Astro.params;
     relativePath={true}
     transpileInBrowser={true}
     addExternalExampleStyles={true}
+    ignoreDarkMode={true}
 />

--- a/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/codesandbox.astro
+++ b/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/codesandbox.astro
@@ -19,4 +19,9 @@ export const partial = !getHmrEnabled();
 const { exampleName } = Astro.params;
 ---
 
-<GalleryFrameworkTemplate exampleName={exampleName!} relativePath={true} addExternalExampleStyles={true} />
+<GalleryFrameworkTemplate
+    exampleName={exampleName!}
+    relativePath={true}
+    addExternalExampleStyles={true}
+    ignoreDarkMode={true}
+/>

--- a/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/plunkr.astro
+++ b/packages/ag-charts-website/src/pages/gallery/examples/[exampleName]/plunkr.astro
@@ -19,4 +19,9 @@ export const partial = !getHmrEnabled();
 const { exampleName } = Astro.params;
 ---
 
-<GalleryFrameworkTemplate exampleName={exampleName!} relativePath={true} addExternalExampleStyles={true} />
+<GalleryFrameworkTemplate
+    exampleName={exampleName!}
+    relativePath={true}
+    addExternalExampleStyles={true}
+    ignoreDarkMode={true}
+/>

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/examplesGenerator.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/examplesGenerator.ts
@@ -161,7 +161,9 @@ export const getGeneratedContents = async (params: GeneratedContentParams): Prom
         let transformedEntryFile = entryFile;
         // Add website dark mode handling code to doc examples - this code is later striped out from the code viewer / plunker
         if (!ignoreDarkMode) {
-            transformedEntryFile = transformedEntryFile + '\n' + getDarkModeSnippet({ chartAPI, fixedTheme });
+            // Prepended: the options mutation has to be in place before the example creates its
+            // chart, so that the very first render resolves the dark mode variables.
+            transformedEntryFile = getDarkModeSnippet({ chartAPI, fixedTheme }) + '\n' + transformedEntryFile;
             transformedEntryFile = transformedEntryFile + '\n' + getE2ETestThemeSnippet({ chartAPI });
         }
 

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/frameworkFilesGenerator.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/frameworkFilesGenerator.ts
@@ -127,6 +127,12 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
         // Strip ModuleRegistry calls (including multi-line) - vanilla uses UMD bundle with pre-registered modules
         let mainJs = readAsJsFile(entryFile).replace(/ModuleRegistry\.registerModules\([\s\S]*?\);/m, '');
 
+        // Before the UMD globals are unpacked below, so that the injected snippets - which a plain
+        // script cannot hoist over - end up beneath the declarations they reference.
+        if (transformEntryFile) {
+            mainJs = transformEntryFile({ entryFile: mainJs, chartAPI: 'AgCharts' });
+        }
+
         const localeImports = typedBindings.imports
             .filter((i: any) => i.module.includes('ag-charts-locale'))
             .flatMap((imp) => imp.imports);
@@ -146,10 +152,6 @@ export const frameworkFilesGenerator: Record<InternalFramework, ConfigGenerator>
 
         if (localeImports.length > 0 || chartImports.length > 0) {
             mainJs = '\n' + mainJs;
-        }
-
-        if (transformEntryFile) {
-            mainJs = transformEntryFile({ entryFile: mainJs, chartAPI: 'AgCharts' });
         }
 
         if (!isDev) {

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
@@ -1,26 +1,82 @@
-// NOTE: This is duplicated from `external/ag-website-shared/src/utils/getDarkModeSnippet.ts`
+// NOTE: The homepage gallery keeps its own copy of this plumbing in
+// `packages/ag-charts-website/src/utils/getDarkModeSnippet.ts`.
 export const DARK_MODE_START = '/** DARK MODE START **/';
 export const DARK_MODE_END = '/** DARK MODE END **/';
 
+/**
+ * Points the default theme at the colour variables `example-chart-theme.css` flips with
+ * `data-dark-mode`. AG Charts resolves `var()` colours against the chart container and watches them
+ * for changes, so an example paints in the right scheme first time and repaints itself on a toggle.
+ *
+ * Only the parameters `ag-default-dark` retunes are listed; the rest are `$ref`s onto these and
+ * follow. Any other theme - a preset's included - also differs by palette, which no parameter can
+ * carry, so it keeps resolving the `-dark` theme name and still needs an explicit re-render.
+ */
 const THEME_MUTATION = `
-const getDarkmodeTheme = (theme = 'ag-default', preset) => {
-    const baseTheme = preset === 'price-volume' ? 'ag-financial' : theme.replace(/-dark$/, '');
-    return darkmode ? baseTheme + '-dark' : baseTheme;
+const DEFAULT_THEME_PARAMS = {
+    axisLineColor: 'var(--ag-example-chart-axis-line-color)',
+    backgroundColor: 'var(--ag-example-chart-background-color)',
+    borderColor: 'var(--ag-example-chart-border-color)',
+    chromeBackgroundColor: 'var(--ag-example-chart-chrome-background-color)',
+    crosshairLabelBackgroundColor: 'var(--ag-example-chart-crosshair-label-background-color)',
+    foregroundColor: 'var(--ag-example-chart-foreground-color)',
+    gridLineColor: 'var(--ag-example-chart-grid-line-color)',
+    groupedCategoryLineColor: 'var(--ag-example-chart-grouped-category-line-color)',
+    subtleTextColor: 'var(--ag-example-chart-subtle-text-color)',
 };
 
+const isDarkmode = () => document.documentElement.dataset.darkMode === 'true';
+
+const getDarkmodeTheme = (theme = 'ag-default', preset) => {
+    const baseTheme = preset === 'price-volume' ? 'ag-financial' : theme.replace(/-dark$/, '');
+    return isDarkmode() ? baseTheme + '-dark' : baseTheme;
+};
+
+let hasSwappedTheme = false;
+
 __chartAPI.optionsMutationFn = function update(options, preset) {
-    const nextOptions = { ...options };
     const theme = options.theme;
-    if (isAgThemeOrUndefined(theme)) {
-        nextOptions.theme = getDarkmodeTheme(theme, preset);
-    } else if (typeof theme === 'object' && isAgThemeOrUndefined(theme.baseTheme)) {
-        nextOptions.theme = {
-            ...options.theme,
-            baseTheme: getDarkmodeTheme(theme.baseTheme, preset),
+    const isThemeObject = typeof theme === 'object' && theme != null;
+    const baseTheme = isThemeObject ? theme.baseTheme : theme;
+    const params = isThemeObject ? theme.params : undefined;
+
+    if (!isAgThemeOrUndefined(baseTheme)) return options;
+
+    // Every other colour is derived from these two, so an example setting either has a scheme of
+    // its own that these variables would only half-overwrite.
+    const setsOwnScheme = params?.backgroundColor != null || params?.foregroundColor != null;
+    const isDefaultTheme = baseTheme == null || baseTheme.replace(/-dark$/, '') === 'ag-default';
+
+    if (preset == null && isDefaultTheme && !setsOwnScheme) {
+        return {
+            ...options,
+            theme: {
+                ...(isThemeObject ? theme : null),
+                baseTheme: 'ag-default',
+                params: { ...DEFAULT_THEME_PARAMS, ...params },
+            },
         };
     }
-    return nextOptions;
+
+    hasSwappedTheme = true;
+    return {
+        ...options,
+        theme: isThemeObject
+            ? { ...theme, baseTheme: getDarkmodeTheme(baseTheme, preset) }
+            : getDarkmodeTheme(baseTheme, preset),
+    };
 };
+
+// The page shell owns the example document's \`data-dark-mode\`, setting it before this runs and
+// keeping it in step with the site's toggle.
+new MutationObserver(() => {
+    if (!hasSwappedTheme) return;
+    document.querySelectorAll('[data-ag-charts]').forEach((element) => {
+        const chart = __chartAPI.getInstance(element.parentElement);
+        if (chart == null) return;
+        chart.update(chart.getOptions());
+    });
+}).observe(document.documentElement, { attributeFilter: ['data-dark-mode'] });
 `;
 
 /** `fixedTheme` pins the example to the theme it configures; `data-dark-mode` still tracks the site. */
@@ -32,52 +88,8 @@ ${
         : `const __chartAPI = ${chartAPI};`
 }
 
-const ignoreDarkMode = document.documentElement.dataset.ignoreDarkMode === 'true';
-let darkmode = !ignoreDarkMode &&
-    (localStorage['documentation:darkmode'] || String(matchMedia('(prefers-color-scheme: dark)').matches)) === 'true';
-
 const isAgThemeOrUndefined = (theme) => {
     return theme == null || (typeof theme === 'string' && theme.startsWith('ag-'));
 };
-
 ${fixedTheme ? '' : THEME_MUTATION}
-const applyDarkmode = () => {
-    document.documentElement.setAttribute('data-dark-mode', darkmode);
-    const charts = document.querySelectorAll('[data-ag-charts]');
-    charts.forEach((element) => {
-        const chart = __chartAPI.getInstance(element.parentElement);
-        if (chart == null) return;
-        // This is just needed to trigger the theme update
-        chart.update(chart.getOptions());
-    });
-    return charts.length !== 0;
-};
-
-if (darkmode) {
-    if (!applyDarkmode()) {
-        /* React defers updates. Rather than try and hook into the API, just wait until the darkmode is applied. */
-        const observer = new MutationObserver(() => {
-            if (applyDarkmode()) {
-                observer.disconnect();
-            }
-        });
-        observer.observe(document.body, {
-            attributes: true,
-            childList: true,
-            subtree: true,
-        });
-    }
-}
-const onColorSchemeChange = (data) => {
-    if (data?.type === 'color-scheme-change') {
-        darkmode = data.darkmode;
-        applyDarkmode();
-    }
-};
-
-// Two delivery channels, each read from the property its own channel provides: a real
-// postMessage when this example runs inside the example-runner iframe, and a same-page
-// CustomEvent when it is embedded directly in the docs page.
-window.addEventListener('message', (event) => onColorSchemeChange(event.data));
-window.addEventListener('ag-color-scheme-change', (event) => onColorSchemeChange(event.detail));
 ${DARK_MODE_END}`;

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
@@ -9,10 +9,36 @@ export const DARK_MODE_END = '/** DARK MODE END **/';
  * for changes, so an example paints in the right scheme first time and repaints itself on a toggle.
  *
  * Only the parameters `ag-default-dark` retunes are listed; the rest are `$ref`s onto these and
- * follow. Any other theme - a preset's included - also differs by palette, which no parameter can
- * carry, so it keeps resolving the `-dark` theme name and still needs an explicit re-render.
+ * follow. What no parameter can carry is the palette, and `ag-default-dark` retunes that too - so
+ * the series listed in `PALETTE_SENSITIVE_TYPES`, and every non-default theme and preset, keep
+ * resolving the `-dark` theme name and still need an explicit re-render.
  */
 const THEME_MUTATION = `
+/**
+ * Series whose visible colours come from the parts of the palette that differ between
+ * \`ag-default\` and \`ag-default-dark\` - marker and candle strokes, the hierarchy ramp, and the
+ * second sequential colours. A CSS variable cannot reach any of them: \`theme.palette\` takes no
+ * option for the hierarchy or sequential colours, and supplying \`strokes\` would flip
+ * \`paletteType\` to \`user-indexed\`, which changes how ~8 series types render in light mode too.
+ */
+const PALETTE_SENSITIVE_TYPES = new Set([
+    'scatter',
+    'bubble',
+    'candlestick',
+    'ohlc',
+    'treemap',
+    'cone-funnel',
+    'radial-gauge',
+    'linear-gauge',
+    'map-shape-background',
+    'map-line-background',
+]);
+
+const isPaletteSensitive = (options) => {
+    if (PALETTE_SENSITIVE_TYPES.has(options.type)) return true;
+    return (options.series ?? []).some((series) => PALETTE_SENSITIVE_TYPES.has(series?.type));
+};
+
 const DEFAULT_THEME_PARAMS = {
     axisLineColor: 'var(--ag-example-chart-axis-line-color)',
     backgroundColor: 'var(--ag-example-chart-background-color)',
@@ -47,7 +73,7 @@ __chartAPI.optionsMutationFn = function update(options, preset) {
     const setsOwnScheme = params?.backgroundColor != null || params?.foregroundColor != null;
     const isDefaultTheme = baseTheme == null || baseTheme.replace(/-dark$/, '') === 'ag-default';
 
-    if (preset == null && isDefaultTheme && !setsOwnScheme) {
+    if (preset == null && isDefaultTheme && !setsOwnScheme && !isPaletteSensitive(options)) {
         return {
             ...options,
             theme: {

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
@@ -10,8 +10,9 @@ export const DARK_MODE_END = '/** DARK MODE END **/';
  *
  * Only the parameters `ag-default-dark` retunes are listed; the rest are `$ref`s onto these and
  * follow. What no parameter can carry is the palette, and `ag-default-dark` retunes that too - so
- * the series listed in `PALETTE_SENSITIVE_TYPES`, and every non-default theme and preset, keep
- * resolving the `-dark` theme name and still need an explicit re-render.
+ * the series listed in `PALETTE_SENSITIVE_TYPES`, every non-default theme and preset, and any
+ * container the variables cannot reach, keep resolving the `-dark` theme name and still need an
+ * explicit re-render.
  */
 const THEME_MUTATION = `
 /**
@@ -53,6 +54,12 @@ const DEFAULT_THEME_PARAMS = {
 
 const isDarkmode = () => document.documentElement.dataset.darkMode === 'true';
 
+// A container that is detached, or out of the stylesheet's reach, has no value to read - such an
+// example keeps the theme-name swap and its re-render on toggle.
+const canResolveVars = (container) =>
+    container != null &&
+    getComputedStyle(container).getPropertyValue('--ag-example-chart-background-color').trim() !== '';
+
 const getDarkmodeTheme = (theme = 'ag-default', preset) => {
     const baseTheme = preset === 'price-volume' ? 'ag-financial' : theme.replace(/-dark$/, '');
     return isDarkmode() ? baseTheme + '-dark' : baseTheme;
@@ -73,7 +80,14 @@ __chartAPI.optionsMutationFn = function update(options, preset) {
     const setsOwnScheme = params?.backgroundColor != null || params?.foregroundColor != null;
     const isDefaultTheme = baseTheme == null || baseTheme.replace(/-dark$/, '') === 'ag-default';
 
-    if (preset == null && isDefaultTheme && !setsOwnScheme && !isPaletteSensitive(options)) {
+    const useCSSVariables =
+        preset == null &&
+        isDefaultTheme &&
+        !setsOwnScheme &&
+        !isPaletteSensitive(options) &&
+        canResolveVars(options.container);
+
+    if (useCSSVariables) {
         return {
             ...options,
             theme: {

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getDarkModeSnippet.ts
@@ -1,7 +1,9 @@
-// NOTE: The homepage gallery keeps its own copy of this plumbing in
+// The markers the code viewer and the Plunker/CodeSandbox exports strip this snippet by, via
+// `DARK_MODE_REGEX` in `external/ag-website-shared/src/utils/extraCodeSnippets.ts` - the values have
+// to match that file. The homepage gallery keeps its own copy of this plumbing in
 // `packages/ag-charts-website/src/utils/getDarkModeSnippet.ts`.
-export const DARK_MODE_START = '/** DARK MODE START **/';
-export const DARK_MODE_END = '/** DARK MODE END **/';
+const DARK_MODE_START = '/** DARK MODE START **/';
+const DARK_MODE_END = '/** DARK MODE END **/';
 
 /**
  * Points the default theme at the colour variables `example-chart-theme.css` flips with
@@ -65,7 +67,9 @@ const getDarkmodeTheme = (theme = 'ag-default', preset) => {
     return isDarkmode() ? baseTheme + '-dark' : baseTheme;
 };
 
-let hasSwappedTheme = false;
+// Per container, not per document: a chart on the CSS path must not be re-rendered because a
+// sibling in the same example needed the swap.
+const swappedContainers = new WeakSet();
 
 __chartAPI.optionsMutationFn = function update(options, preset) {
     const theme = options.theme;
@@ -98,7 +102,8 @@ __chartAPI.optionsMutationFn = function update(options, preset) {
         };
     }
 
-    hasSwappedTheme = true;
+    if (options.container != null) swappedContainers.add(options.container);
+
     return {
         ...options,
         theme: isThemeObject
@@ -110,9 +115,10 @@ __chartAPI.optionsMutationFn = function update(options, preset) {
 // The page shell owns the example document's \`data-dark-mode\`, setting it before this runs and
 // keeping it in step with the site's toggle.
 new MutationObserver(() => {
-    if (!hasSwappedTheme) return;
     document.querySelectorAll('[data-ag-charts]').forEach((element) => {
-        const chart = __chartAPI.getInstance(element.parentElement);
+        const container = element.parentElement;
+        if (!swappedContainers.has(container)) return;
+        const chart = __chartAPI.getInstance(container);
         if (chart == null) return;
         chart.update(chart.getOptions());
     });

--- a/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getStyleFiles.ts
+++ b/plugins/ag-charts-generate-example-files/src/executors/generate/generator/utils/getStyleFiles.ts
@@ -5,8 +5,10 @@ import type { InternalFramework } from '../types';
 import { getFileList } from './fileUtils';
 
 // Relative to root
-const EXAMPLE_STYLES_FILE_PATH =
-    './external/ag-website-shared/src/components/example-runner/styles/example-controls.css';
+const EXAMPLE_STYLES_FILE_PATHS = [
+    './external/ag-website-shared/src/components/example-runner/styles/example-chart-theme.css',
+    './external/ag-website-shared/src/components/example-runner/styles/example-controls.css',
+];
 const EXAMPLE_STYLE_FILE_NAME = 'ag-example-styles.css';
 
 export const filterStyleFiles = (fileList: string[]) => {
@@ -23,8 +25,8 @@ export const getStyleFiles = async ({
     folderPath: string;
     sourceFileList: string[];
 }) => {
-    const exampleControlsStyles = fs.readFileSync(EXAMPLE_STYLES_FILE_PATH, 'utf-8');
-    const exampleStyle = exampleControlsStyles + getFrameworkStyles(internalFramework);
+    const sharedStyles = EXAMPLE_STYLES_FILE_PATHS.map((filePath) => fs.readFileSync(filePath, 'utf-8')).join('\n');
+    const exampleStyle = sharedStyles + getFrameworkStyles(internalFramework);
     const exampleStyleContents = {
         [EXAMPLE_STYLE_FILE_NAME]: exampleStyle,
     };


### PR DESCRIPTION
Documentation example charts now adopt the site's dark mode through CSS instead of the load-then-swap workaround.

Three separate concerns:

- `example-chart-theme.css` (new, folded into every example's `ag-example-styles.css`) declares the nine colour parameters `ag-default-dark` retunes, keyed off `:root[data-dark-mode='true']`.
- The page shell owns `data-dark-mode` on the example document via a render-blocking `<head>` script, and keeps it in step with the site toggle.
- The injected snippet points the default theme's params at those variables. AG Charts resolves `var()` colours against the container and watches them, so first paint is correct and a toggle re-resolves them with no `chart.update()`.

The snippet is now prepended rather than appended, so the theme is settled before the chart is created.

**Palette-sensitive series keep the theme-name swap.** `ag-default-dark` also retunes the palette (stroke set, hierarchy ramp, second sequential colours), and none of it can be driven from CSS: `theme.palette` takes no option for the hierarchy or sequential colours (validation rejects them), and supplying `strokes`/`up`/`down`/`neutral` would flip `paletteType` and change how ~8 series types render in light mode too. Scatter, bubble, candlestick, ohlc, treemap, cone-funnel, the gauges and the map backgrounds therefore stay on the swap, which — being prepended — still gets their first paint right; only their toggle costs a re-render.

Examples that set their own `backgroundColor`/`foregroundColor` keep today's behaviour, and Plunker/CodeSandbox exports get none of this plumbing.

### Acceptance criteria

- **AC1** (correct dark colours on first paint) — met for every default-theme example, both paths.
- **AC2** (toggle without `chart.update()`) — met except for the palette-sensitive series above, which re-render. Closing that fully needs a product change: extending `AgChartThemePalette` with the hierarchy/sequential colours, or reworking `paletteType` so injected palette values don't trip the `user-indexed`/`user-full` branches.

### Verification

Browser-tested on the docs site with `optionsMutationFn` instrumented to record what each example resolved:

| example | dark first paint | toggle light→dark |
| --- | --- | --- |
| bar, pie | `ag-default` + var params, `#192232` | `rgb(25,34,50)`, 0 extra mutation calls |
| scatter, treemap, candlestick | `ag-default-dark`, `#192232` | `#192232`, re-rendered |

Light first paint correct in all five. `cssVariableParams.test.ts` pins both halves of the design: that the nine params reproduce `ag-default-dark`'s parameters, and the exact set of palette entries the dark theme retunes — so a change to either theme fails here rather than silently mis-colouring examples.

`nx run-many -t lint test -p ag-charts-generate-example-files ag-charts-community` passes.

Out of scope: annotation colour persistence (AG-11798 / AG-12484).
