### PR TITLE
Fix benchmark site artifact unpack after download-artifact v8 bump

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -310,6 +310,10 @@ jobs:
               with:
                   pattern: site-*
                   path: ${{ runner.temp }}/sites
+                  # The action only nests each artifact in its own subdirectory when
+                  # more than one matches, and an npm base builds head alone. Flatten
+                  # instead — the two tarball names are already distinct.
+                  merge-multiple: true
 
             # A published-npm base (npm:<version>) reuses the head site with the
             # published UMD bundles swapped in. Its pages bake absolute library
@@ -320,13 +324,13 @@ jobs:
                   BASE_REF: ${{ needs.resolve.outputs.base }}
               run: |
                   mkdir -p "${RUNNER_TEMP}/site-head" "${RUNNER_TEMP}/site-base"
-                  tar -xzf "${RUNNER_TEMP}/sites/site-head/site-head.tar.gz" -C "${RUNNER_TEMP}/site-head"
+                  tar -xzf "${RUNNER_TEMP}/sites/site-head.tar.gz" -C "${RUNNER_TEMP}/site-head"
                   if [[ "${BASE_REF}" == npm:* ]] ; then
-                    tar -xzf "${RUNNER_TEMP}/sites/site-head/site-head.tar.gz" -C "${RUNNER_TEMP}/site-base"
+                    tar -xzf "${RUNNER_TEMP}/sites/site-head.tar.gz" -C "${RUNNER_TEMP}/site-base"
                     ./tools/benchmark/swap-published-lib.sh "${BASE_REF#npm:}" "${RUNNER_TEMP}/site-base"
                     echo "BASE_PORT=4601" >> $GITHUB_ENV
                   else
-                    tar -xzf "${RUNNER_TEMP}/sites/site-base/site-base.tar.gz" -C "${RUNNER_TEMP}/site-base"
+                    tar -xzf "${RUNNER_TEMP}/sites/site-base.tar.gz" -C "${RUNNER_TEMP}/site-base"
                     echo "BASE_PORT=4602" >> $GITHUB_ENV
                   fi
 


### PR DESCRIPTION
The nightly Benchmark workflow has failed on every scheduled run since the `actions/download-artifact` v4 → v8 bump in #7903, with all five shards dying at *Unpack sites*:

```
tar (child): /home/runner/work/_temp/sites/site-head/site-head.tar.gz: Cannot open: No such file or directory
```

v8 only nests each artifact in its own subdirectory when more than one matches the pattern. The schedule benchmarks against an npm base (`npm:14.1.0`), so the build matrix produces `site-head` alone and it downloaded straight into the path, not into `sites/site-head/`.

Fixed by flattening the download with `merge-multiple: true` rather than depending on the action's layout — the two tarball names are already distinct, so a git-ref base with both artifacts is handled identically.

The other `download-artifact@v8` call sites are unaffected: the shard download already sets `merge-multiple: true`, and the bare downloads in `ci.yml` and `security.yml` read their trees layout-agnostically.