### PR TITLE
AG-3390 Fix Firefox dev-server bare-specifier errors on example pages

### DIFF
--- a/packages/ag-charts-website/astro.config.mjs
+++ b/packages/ag-charts-website/astro.config.mjs
@@ -22,6 +22,7 @@ import agAutoRedirect from './plugins/agAutoRedirect';
 import agCssAsString from './plugins/agCssAsString';
 import agDemosStatic from './plugins/agDemosStatic';
 import agDevCsp from './plugins/agDevCsp';
+import agDevImportMapOrder from './plugins/agDevImportMapOrder';
 import agDevMarkdownNegotiation from './plugins/agDevMarkdownNegotiation';
 import agGallerySeoChecker from './plugins/agGallerySeoChecker';
 import agHotModuleReload from './plugins/agHotModuleReload';
@@ -94,6 +95,7 @@ const plugins = [
     agHotModuleReload(),
     agAutoRedirect(['/javascript', '/react', '/vue', '/angular', '/gallery']),
     agDevCsp(),
+    agDevImportMapOrder(),
     agDemosStatic(),
     agDevMarkdownNegotiation(),
 ];

--- a/packages/ag-charts-website/plugins/agDevImportMapOrder.ts
+++ b/packages/ag-charts-website/plugins/agDevImportMapOrder.ts
@@ -1,0 +1,80 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Plugin, ViteDevServer } from 'vite';
+
+import { moveImportMapBeforeHeadScripts } from '../src/utils/example-modules/moveImportMapBeforeHeadScripts';
+import { EXAMPLES_PATH_REGEXP } from '../src/utils/htaccess/cspRules';
+
+const toBuffer = (chunk: unknown, encoding?: BufferEncoding): Buffer => {
+    if (Buffer.isBuffer(chunk)) {
+        return chunk;
+    }
+    // Astro's response stream yields plain Uint8Array chunks (not Node Buffer instances) --
+    // String(chunk) would join their byte values with commas instead of decoding them.
+    if (ArrayBuffer.isView(chunk)) {
+        return Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+    }
+    return Buffer.from(String(chunk), encoding);
+};
+
+/**
+ * Buffers an example-runner document's response so its complete body can be rewritten by
+ * moveImportMapBeforeHeadScripts before it reaches the browser. Non-HTML responses under the same
+ * paths (the example's own .js/.css assets) are re-serialised unchanged.
+ */
+function bufferAndFixImportMapOrder(req: IncomingMessage, res: ServerResponse, next: () => void) {
+    if (!EXAMPLES_PATH_REGEXP.test(req.url ?? '')) {
+        return next();
+    }
+
+    const chunks: Buffer[] = [];
+    const originalWrite = res.write.bind(res);
+    const originalEnd = res.end.bind(res);
+
+    res.write = ((chunk: unknown, encoding?: BufferEncoding | (() => void)) => {
+        chunks.push(toBuffer(chunk, typeof encoding === 'string' ? encoding : undefined));
+        return true;
+    }) as ServerResponse['write'];
+
+    res.end = ((chunk?: unknown, encoding?: BufferEncoding | (() => void)) => {
+        if (chunk !== undefined && typeof chunk !== 'function') {
+            chunks.push(toBuffer(chunk, typeof encoding === 'string' ? encoding : undefined));
+        }
+
+        // Node's ServerResponse#end(chunk) calls `this.write(chunk)` internally, which would
+        // re-enter these shims instead of flushing -- restore the real methods first.
+        res.write = originalWrite;
+        res.end = originalEnd;
+
+        const contentType = res.getHeader('content-type');
+        const isHtml = typeof contentType === 'string' && contentType.includes('text/html');
+        const body = Buffer.concat(chunks);
+
+        if (!isHtml || body.length === 0) {
+            return res.end(body);
+        }
+
+        // Headers are already flushed by the time this runs, so Content-Length (when Astro sets
+        // one) can no longer be corrected for the rewritten body's new length -- only strip it
+        // while that is still possible; these HTML responses are otherwise unset (chunked).
+        if (!res.headersSent) {
+            res.removeHeader('Content-Length');
+        }
+        return res.end(moveImportMapBeforeHeadScripts(body.toString('utf-8')));
+    }) as ServerResponse['end'];
+
+    next();
+}
+
+/**
+ * Fixes a Firefox-only dev-server failure where example pages fail to resolve bare specifiers
+ * ("was a bare specifier, but was not remapped to anything"). See
+ * moveImportMapBeforeHeadScripts for the root cause and fix.
+ */
+export default function agDevImportMapOrder(): Plugin {
+    return {
+        name: 'ag-dev-importmap-order',
+        configureServer(server: ViteDevServer) {
+            server.middlewares.use(bufferAndFixImportMapOrder);
+        },
+    };
+}

--- a/packages/ag-charts-website/src/utils/example-modules/moveImportMapBeforeHeadScripts.test.ts
+++ b/packages/ag-charts-website/src/utils/example-modules/moveImportMapBeforeHeadScripts.test.ts
@@ -1,0 +1,54 @@
+import { moveImportMapBeforeHeadScripts } from './moveImportMapBeforeHeadScripts';
+
+describe('moveImportMapBeforeHeadScripts', () => {
+    it('moves a body-level importmap to the start of head, ahead of an existing module script', () => {
+        const html = [
+            '<!DOCTYPE html>',
+            '<html>',
+            '<head><script type="module" src="/@vite/client"></script></head>',
+            '<body>',
+            '<script src="/example-runner.js"></script>',
+            '<script type="importmap">',
+            '{',
+            '    "imports": { "react": "https://esm.sh/react@19.2.4" }',
+            '}',
+            '</script>',
+            '<script>agExampleRunner.setUpPage();</script>',
+            '<script type="module" src="/index.js"></script>',
+            '</body>',
+            '</html>',
+        ].join('\n');
+
+        const result = moveImportMapBeforeHeadScripts(html);
+
+        const headIndex = result.indexOf('<head');
+        const importMapIndex = result.indexOf('<script type="importmap">');
+        const viteClientIndex = result.indexOf('<script type="module" src="/@vite/client">');
+        const entryModuleIndex = result.indexOf('<script type="module" src="/index.js">');
+
+        expect(importMapIndex).toBeGreaterThan(headIndex);
+        expect(importMapIndex).toBeLessThan(viteClientIndex);
+        expect(importMapIndex).toBeLessThan(entryModuleIndex);
+        expect(result).toContain('"react": "https://esm.sh/react@19.2.4"');
+        // Only one copy of the importmap remains
+        expect(result.match(/<script type="importmap">/g)).toHaveLength(1);
+    });
+
+    it('is a no-op when there is no importmap script', () => {
+        const html = '<html><head></head><body><script type="module" src="/index.js"></script></body></html>';
+
+        expect(moveImportMapBeforeHeadScripts(html)).toBe(html);
+    });
+
+    it('handles attributes on the head tag', () => {
+        const html =
+            '<html><head data-foo="bar"><title>t</title></head>' +
+            '<body><script type="importmap">{"imports":{}}</script></body></html>';
+
+        const result = moveImportMapBeforeHeadScripts(html);
+
+        expect(result.indexOf('<script type="importmap">')).toBe(
+            result.indexOf('<head data-foo="bar">') + '<head data-foo="bar">'.length
+        );
+    });
+});

--- a/packages/ag-charts-website/src/utils/example-modules/moveImportMapBeforeHeadScripts.ts
+++ b/packages/ag-charts-website/src/utils/example-modules/moveImportMapBeforeHeadScripts.ts
@@ -1,0 +1,25 @@
+const IMPORT_MAP_SCRIPT_REGEXP = /\s*<script type="importmap">[\s\S]*?<\/script>/;
+const HEAD_OPEN_TAG_REGEXP = /<head[^>]*>/i;
+
+/**
+ * Relocates a document's `<script type="importmap">` (wherever it appears, typically in `<body>`
+ * per `ExampleModules`) to immediately follow the opening `<head>` tag.
+ *
+ * Astro's dev server injects `<script type="module" src="/@vite/client">` as the first element of
+ * `<head>` on every page. Per the HTML spec, a document's ability to register an import map closes
+ * once any module script's fetch has started -- so an import map declared later, in `<body>`, is
+ * already too late once that happens. Chrome tolerates the misordering; Firefox enforces the spec
+ * and fails every bare-specifier resolution in the entry module ("was a bare specifier, but was not
+ * remapped to anything"). Moving the import map ahead of `/@vite/client` fixes the registration
+ * order for both. Production serves no such dev-only script, so it never needs this.
+ */
+export function moveImportMapBeforeHeadScripts(html: string): string {
+    const match = html.match(IMPORT_MAP_SCRIPT_REGEXP);
+    if (!match) {
+        return html;
+    }
+
+    const [importMapScript] = match;
+    const withoutOriginal = html.replace(importMapScript, '');
+    return withoutOriginal.replace(HEAD_OPEN_TAG_REGEXP, (headOpenTag) => `${headOpenTag}${importMapScript}`);
+}


### PR DESCRIPTION
## Summary
- Framework example pages (React/Angular/Vue/TypeScript) fail to load on the dev server in Firefox with `The specifier "react" was a bare specifier, but was not remapped to anything.` Chrome and production (staging/prod builds) are unaffected; only vanilla examples (which use classic UMD scripts, not modules) worked in Firefox dev.
- Root cause: Astro's dev server injects `<script type="module" src="/@vite/client">` as the first element of `<head>`, ahead of the example page's own `<script type="importmap">` in `<body>`. Per spec, a document's import-map registration window closes once any module script's fetch has started. Firefox enforces this strictly and fails every bare-specifier resolution in the entry module; Chrome tolerates the misordering. Production serves no such dev-only script, so it's unaffected there.
- Adds a dev-only Vite plugin (`agDevImportMapOrder`) that buffers example-page HTML responses and relocates the importmap to the very start of `<head>`, ahead of `/@vite/client`, fixing registration order for both browsers.

## Test plan
- [x] Added `moveImportMapBeforeHeadScripts.test.ts` covering: reordering ahead of an existing module script, no-op when there's no importmap, and head-tag-with-attributes handling.
- [x] Verified manually against the running dev server: fetched the React `axis-position-basic` example page before/after the fix and confirmed the importmap now appears as the first child of `<head>`, before `/@vite/client`, with exactly one copy and the entry module script intact.
- [x] Verified the vanilla (`javascript`) example page and the example's own `.js` asset response are byte-for-byte unaffected (no importmap present / non-HTML passthrough).
- [x] `yarn nx format`, `yarn nx lint ag-charts-website`, `yarn nx test ag-charts-website` (pre-existing, unrelated failure in `markdownPages.test.ts` requires a full site build and is not affected by this change).