### PR TITLE
SE-141 Rewrite the gallery hub's copy and family headings

### DIFF
--- a/packages/ag-charts-website/src/components/gallery/components/GalleryExampleImage.tsx
+++ b/packages/ag-charts-website/src/components/gallery/components/GalleryExampleImage.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 const optimizeAltTextForSeo = (label: string): string => {
-    if (label.toLowerCase().endsWith('chart')) {
+    if (label.toLowerCase().includes('chart')) {
         return label;
     }
 

--- a/packages/ag-charts-website/src/components/gallery/components/GalleryExampleLink.tsx
+++ b/packages/ag-charts-website/src/components/gallery/components/GalleryExampleLink.tsx
@@ -8,25 +8,17 @@ import styles from './GalleryExampleLink.module.scss';
 interface Props {
     label: string;
     exampleName: string;
-    id?: string;
     enableDprScaling: boolean;
     isModified?: boolean;
 }
 
-export const GalleryExampleLink: FunctionComponent<Props> = ({
-    label,
-    exampleName,
-    id,
-    enableDprScaling,
-    isModified,
-}) => {
+export const GalleryExampleLink: FunctionComponent<Props> = ({ label, exampleName, enableDprScaling, isModified }) => {
     return (
         <a
             className={classnames(styles.link, 'galleryExample', styles[`layout-3-col`], 'text-sm', 'text-secondary', {
                 [styles.modified]: isModified,
             })}
             href={getPageUrl(exampleName)}
-            id={id}
         >
             <div className={styles.image}>
                 <GalleryExampleImage label={label} exampleName={exampleName} enableDprScaling={enableDprScaling} />

--- a/packages/ag-charts-website/src/components/gallery/galleryCopy.ts
+++ b/packages/ag-charts-website/src/components/gallery/galleryCopy.ts
@@ -1,7 +1,17 @@
 /**
- * On-page copy for the gallery example pages. `resolveGallerySeo` composes a title, H1, meta
- * description and intro from a chart family's row here; `GALLERY_PAGE_COPY` overrides it per page.
+ * On-page copy for the gallery hub and its example pages. `resolveGallerySeo` composes an example
+ * page's title, H1, meta description and intro from a chart family's row here; `GALLERY_PAGE_COPY`
+ * overrides it per page. The hub is a single page, so its copy is written out in full.
  */
+
+/** Copy for the `/gallery/` hub, shared with its `.md` twin. */
+export const GALLERY_HUB_COPY = {
+    title: 'AG Charts Gallery - 100+ JavaScript Chart Examples | AG Charts',
+    h1: 'AG Charts Gallery - JavaScript Chart Examples',
+    description:
+        'Browse 100+ interactive chart examples built with AG Charts: bar, line, pie, area, financial, hierarchical and more. View the live demos and copy the code.',
+    intro: 'The AG Charts gallery contains over 100 live, interactive chart examples - from bar, line, pie and area charts to financial, statistical, hierarchical and specialised types. Every example runs in the browser and comes with copy-ready code for JavaScript, React, Angular and Vue.',
+} as const;
 
 /**
  * Copy shared by every example in a chart family, keyed by the family's `seriesName` in

--- a/packages/ag-charts-website/src/components/gallery/utils/gallerySeo.test.ts
+++ b/packages/ag-charts-website/src/components/gallery/utils/gallerySeo.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import galleryData from '../../../content/gallery/data.json';
-import { GALLERY_FAMILY_COPY, GALLERY_PAGE_COPY } from '../galleryCopy';
+import { GALLERY_FAMILY_COPY, GALLERY_HUB_COPY, GALLERY_PAGE_COPY } from '../galleryCopy';
 import { getGalleryExamples } from './filesData';
-import { MAX_TITLE_LENGTH, resolveGallerySeo } from './gallerySeo';
+import { MAX_TITLE_LENGTH, galleryFamilyHeading, resolveGalleryH1, resolveGallerySeo } from './gallerySeo';
 
 const EXAMPLES = getGalleryExamples({ galleryData });
 const RESOLVED = EXAMPLES.map(({ exampleName, page }) => ({ exampleName, seo: resolveGallerySeo(page) }));
@@ -87,6 +87,50 @@ describe('resolveGallerySeo', () => {
     it('resolves distinct titles per page, so no two pages compete for the same result', () => {
         const titles = RESOLVED.map(({ seo }) => seo.title);
         expect(new Set(titles).size).toBe(titles.length);
+    });
+});
+
+describe('the gallery hub copy', () => {
+    it('keeps the title within the length the formula holds the example pages to', () => {
+        expect(GALLERY_HUB_COPY.title.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    });
+
+    it('lands the meta description in the 140-155 character band', () => {
+        expect(GALLERY_HUB_COPY.description.length).toBeGreaterThanOrEqual(140);
+        expect(GALLERY_HUB_COPY.description.length).toBeLessThanOrEqual(155);
+    });
+
+    it('names the gallery in the title and the H1', () => {
+        expect(GALLERY_HUB_COPY.title).toContain('AG Charts Gallery');
+        expect(GALLERY_HUB_COPY.h1).toContain('AG Charts Gallery');
+    });
+
+    it('links more examples than the "100+" the copy claims', () => {
+        const visible = galleryData.series
+            .flat()
+            .flatMap((series) => series.examples)
+            .filter((example) => !example.hidden);
+        expect(visible.length).toBeGreaterThan(100);
+    });
+});
+
+describe('galleryFamilyHeading', () => {
+    it('pluralises a family name into a heading', () => {
+        expect(galleryFamilyHeading('Bar')).toBe('Bar Charts');
+        expect(galleryFamilyHeading('OHLC')).toBe('OHLC Charts');
+    });
+
+    it('does not repeat a family name that already says Chart', () => {
+        expect(galleryFamilyHeading('Org Chart')).toBe('Org Charts');
+        const families = galleryData.series.flat().map((series) => galleryFamilyHeading(series.title));
+        expect(families.filter((heading) => /Chart Charts/.test(heading))).toEqual([]);
+    });
+});
+
+describe('resolveGalleryH1', () => {
+    it('resolves the same H1 the page serves, for every example', () => {
+        const disagree = EXAMPLES.filter(({ page }) => resolveGalleryH1(page) !== resolveGallerySeo(page).h1);
+        expect(disagree).toEqual([]);
     });
 });
 

--- a/packages/ag-charts-website/src/components/gallery/utils/gallerySeo.ts
+++ b/packages/ag-charts-website/src/components/gallery/utils/gallerySeo.ts
@@ -59,6 +59,19 @@ function withoutSimplePrefix(title: string): string {
 }
 
 /**
+ * The H1 an example page serves, which is also its anchor text on the hub and in the `.md` twin, so
+ * that a link and its destination name the example identically.
+ */
+export function resolveGalleryH1(page: Pick<GallerySeoPage, 'title' | 'name'>): string {
+    return GALLERY_PAGE_COPY[page.name]?.seoH1 ?? `${withoutSimplePrefix(page.title)} Example`;
+}
+
+/** Heading for a chart family, from its `title` in `data.json`: `Bar` reads as `Bar Charts`. */
+export function galleryFamilyHeading(title: string): string {
+    return title.endsWith('Chart') ? `${title}s` : `${title} Charts`;
+}
+
+/**
  * Lowercase a title for use mid-sentence, leaving initialisms (`OHLC`, `SVG`) and numeric tokens
  * (`100%`) as they are.
  */
@@ -126,7 +139,7 @@ export function resolveGallerySeo(page: GallerySeoPage): GallerySeo {
     const { hook, visualises, configures, adjusts } = familyCopy(page);
 
     const displayTitle = withoutSimplePrefix(page.title);
-    const h1 = overrides.seoH1 ?? `${displayTitle} Example`;
+    const h1 = resolveGalleryH1(page);
     const prose = toProse(displayTitle);
     const article = indefiniteArticle(prose);
 

--- a/packages/ag-charts-website/src/pages-styles/gallery.module.scss
+++ b/packages/ag-charts-website/src/pages-styles/gallery.module.scss
@@ -39,13 +39,16 @@
     align-items: center;
     justify-content: space-between;
     height: 100%;
+}
 
-    h1 {
-        margin-bottom: 0px;
-        // At the full 2xl size the title wraps to two lines and overflows the toolbar
-        // band once it competes with the theme dropdown for width (below ~430px).
-        font-size: clamp(20px, 5vw, var(--text-fs-2xl));
-    }
+// A label rather than a heading: the page's H1 is in the scrolling content below.
+.toolbarTitle {
+    // At the full 2xl size the title overflows the toolbar band once it competes with
+    // the theme dropdown for width (below ~430px).
+    font-size: clamp(20px, 5vw, var(--text-fs-2xl));
+    line-height: var(--text-lh-2xl);
+    font-weight: var(--text-bold);
+    color: var(--color-fg-primary);
 }
 
 .toolbarTitleGroup {

--- a/packages/ag-charts-website/src/pages/gallery.astro
+++ b/packages/ag-charts-website/src/pages/gallery.astro
@@ -6,7 +6,9 @@ import { getPageHashUrl } from '@components/gallery/utils/urlPaths';
 import type { GalleryData, GalleryExample, GalleryExampleChartType } from '@ag-grid-types';
 import { GalleryExampleLink } from '@components/gallery/components/GalleryExampleLink';
 import { GalleryExampleThemeDropdown } from '@components/gallery/components/GalleryExampleThemeDropdown';
+import { GALLERY_HUB_COPY } from '@components/gallery/galleryCopy';
 import { GALLERY_CTAS } from '@components/gallery/galleryCtas';
+import { galleryFamilyHeading, resolveGalleryH1 } from '@components/gallery/utils/gallerySeo';
 import { DISABLE_MARKDOWN_DOCS, GALLERY_IMAGE_DPR_ENHANCEMENT } from '@constants';
 import { getModifiedGalleryExamples } from '@components/gallery/utils/modifiedExamples';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
@@ -22,15 +24,15 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/gallery
 ---
 
 <Layout
-    title="Gallery | AG Charts"
-    description="Gallery of JavaScript Charts and JavaScript Graphs created with AG Charts. View source code and interact with Charts; live edit examples with CodeSandbox and Plunker."
+    title={GALLERY_HUB_COPY.title}
+    description={GALLERY_HUB_COPY.description}
     showSearchBar={true}
     markdownUrl={markdownUrl}
 >
     <div class={styles.toolbar} data-gallery-toolbar>
         <div class:list={[styles.toolbarInner, 'layout-page-max-width']}>
             <div class={styles.toolbarTitleGroup}>
-                <h1>AG Charts Gallery</h1>
+                <span class={styles.toolbarTitle}>AG Charts Gallery</span>
                 <div class={styles.toolbarCtas}>
                     {
                         GALLERY_CTAS.map((cta) => (
@@ -70,21 +72,28 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/gallery
         </div>
 
         <div class="content">
-            <div>
+            <div class="intro text-base">
+                <h1>{GALLERY_HUB_COPY.h1}</h1>
+                <p>{GALLERY_HUB_COPY.intro}</p>
+            </div>
+
+            <div class="gallery-grid">
                 {
                     series.map((series: GalleryExampleChartType[]) => (
                         <div class="chart-type">
                             <div class="gallery-list">
-                                {series.map(({ title, seriesName, examples }) => (
+                                {series.map(({ title: familyTitle, seriesName, examples }) => (
                                     <>
+                                        <h2 id={seriesName} class="gallery-list-title">
+                                            {galleryFamilyHeading(familyTitle)}
+                                        </h2>
                                         {examples
                                             .filter(({ hidden }) => !hidden)
-                                            .map(({ title, name }: GalleryExample, i) => (
+                                            .map(({ title, name }: GalleryExample) => (
                                                 <GalleryExampleLink
                                                     client:visible
-                                                    label={title}
+                                                    label={resolveGalleryH1({ title, name })}
                                                     exampleName={name}
-                                                    id={i === 0 ? seriesName : null}
                                                     enableDprScaling={enableDprScaling}
                                                     isModified={modifiedExamples.has(name)}
                                                 />
@@ -282,15 +291,20 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/gallery
         padding-top: $spacing-size-6;
         padding-bottom: $spacing-size-24;
 
-        > div {
-            display: flex;
-            flex-wrap: wrap;
-            gap: var(--gallery-list-gap);
-        }
-
         @media screen and (min-width: $breakpoint-gallery-small) {
             padding-bottom: $spacing-size-56;
         }
+    }
+
+    .intro {
+        max-width: 70ch;
+        margin-bottom: $spacing-size-4;
+    }
+
+    .gallery-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--gallery-list-gap);
     }
 
     .chart-type,
@@ -298,9 +312,11 @@ const markdownUrl = DISABLE_MARKDOWN_DOCS ? undefined : urlWithBaseUrl('/gallery
         display: contents;
     }
 
+    // Breaks the card row it sits in, so each chart family starts on a line of its own.
     .gallery-list-title {
-        position: absolute;
-        visibility: hidden;
+        flex: 0 0 100%;
+        margin-top: $spacing-size-4;
+        margin-bottom: 0;
     }
 </style>
 

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.test.ts
@@ -7,8 +7,12 @@ describe('buildGalleryMarkdown', () => {
 
     it('emits frontmatter and the page H1', () => {
         expect(output.startsWith('---\n')).toBe(true);
-        expect(output).toContain('title: "Gallery"');
-        expect(output).toContain('\n# AG Charts Gallery');
+        expect(output).toContain('title: "AG Charts Gallery - 100+ JavaScript Chart Examples | AG Charts"');
+        expect(output).toContain('\n# AG Charts Gallery - JavaScript Chart Examples\n');
+    });
+
+    it('serves the same intro as the page', () => {
+        expect(output).toContain('The AG Charts gallery contains over 100 live, interactive chart examples');
     });
 
     it('renders the trial and pricing CTAs', () => {
@@ -18,18 +22,22 @@ describe('buildGalleryMarkdown', () => {
     });
 
     it('groups examples under a chart-type heading', () => {
-        expect(output).toContain('## Bar');
-        expect(output).toContain('## Line');
+        expect(output).toContain('## Bar Charts');
+        expect(output).toContain('## Line Charts');
+        expect(output).toContain('## Org Charts');
     });
 
     it('flags enterprise chart types in their heading', () => {
-        expect(output).toContain('## Map (Enterprise)');
-        expect(output).not.toContain('## Bar (Enterprise)');
+        expect(output).toContain('## Map Charts (Enterprise)');
+        expect(output).not.toContain('## Bar Charts (Enterprise)');
     });
 
-    it('links each example to its live gallery demo (absolute URL)', () => {
-        expect(output).toContain('- [Bar Chart](https://www.ag-grid.com/gallery/simple-bar/)');
-        expect(output).toContain('- [Stacked Bar Chart](https://www.ag-grid.com/gallery/stacked-bar/)');
+    it('anchors each example on the H1 its page serves', () => {
+        expect(output).toContain('- [Bar Chart Example](https://www.ag-grid.com/gallery/simple-bar/)');
+        expect(output).toContain('- [Stacked Bar Chart Example](https://www.ag-grid.com/gallery/stacked-bar/)');
+        expect(output).toContain(
+            '- [Horizontal Bar Chart Example](https://www.ag-grid.com/gallery/simple-horizontal-bar/)'
+        );
     });
 
     it('ends with a single trailing newline', () => {

--- a/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/buildGalleryMarkdown.ts
@@ -1,5 +1,7 @@
 import { toAbsoluteUrl } from '@ag-website-shared/markdoc/toAbsoluteUrl';
+import { GALLERY_HUB_COPY } from '@components/gallery/galleryCopy';
 import { GALLERY_CTAS } from '@components/gallery/galleryCtas';
+import { galleryFamilyHeading, resolveGalleryH1 } from '@components/gallery/utils/gallerySeo';
 import { urlWithBaseUrl } from '@utils/urlWithBaseUrl';
 
 import galleryData from '../../content/gallery/data.json';
@@ -35,25 +37,26 @@ export function buildGalleryMarkdown({ siteRoot }: { siteRoot?: string } = {}): 
 
     const frontmatter = [
         '---',
-        'title: "Gallery"',
-        'description: "Gallery of JavaScript Charts and JavaScript Graphs created with AG Charts. View source code and interact with Charts; live edit examples with CodeSandbox and Plunker."',
+        `title: ${JSON.stringify(GALLERY_HUB_COPY.title)}`,
+        `description: ${JSON.stringify(GALLERY_HUB_COPY.description)}`,
         '---',
     ].join('\n');
 
     const sections = [
         frontmatter,
-        '# AG Charts Gallery',
-        'Browse the AG Charts gallery of chart examples, grouped by chart type. Each example links to a live, interactive demo.',
+        `# ${GALLERY_HUB_COPY.h1}`,
+        GALLERY_HUB_COPY.intro,
         GALLERY_CTAS.map(
             (cta) => `[${cta.title}](${toAbsoluteUrl(urlWithBaseUrl(withDefaultFramework(cta.url)), siteRoot)})`
         ).join(' | '),
     ];
 
     for (const chartType of series.flat()) {
-        const heading = chartType.enterprise ? `${chartType.title} (Enterprise)` : chartType.title;
+        const familyHeading = galleryFamilyHeading(chartType.title);
+        const heading = chartType.enterprise ? `${familyHeading} (Enterprise)` : familyHeading;
         const links = chartType.examples
             .filter((example) => !example.hidden)
-            .map((example) => `- [${example.title}](${galleryExampleUrl(example.name, siteRoot)})`);
+            .map((example) => `- [${resolveGalleryH1(example)}](${galleryExampleUrl(example.name, siteRoot)})`);
 
         if (links.length === 0) {
             continue;


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/SE-141

The hub's title, H1, meta description and intro now resolve from a single `GALLERY_HUB_COPY` that the page and its `.md` twin both read, so the two describe the gallery identically. Each chart family renders as an H2 carrying the family's anchor id — the grid had no headings at all — and each card is anchored on the H1 its example page serves.

The rewritten H1 does not fit the fixed-height sticky toolbar, so it sits with the intro above the first card and scrolls with the page; the toolbar keeps "AG Charts Gallery" as a plain label. Two points worth a look in review: that label now reads as a near-duplicate of the H1 below it, and visible family headings reverse the AG-10044 decision to remove them.

The thumbnail alt-text guard is widened to any label that already names a chart. Without it "Bar Chart Example" would be given an alt of "Bar Chart Example Chart"; it also fixes a pre-existing case, where "Line Chart With Gaps" was already producing "Line Chart Chart with Gaps".

Fix #SE-141
