### PR TITLE
AG-17613 Omit an axis with no visible series from event coordinates

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/generateTicks.ts
+++ b/packages/ag-charts-community/src/chart/axis/generateTicks.ts
@@ -282,6 +282,7 @@ function calculateRawTicks<TScale extends Scale<TDatum, number, TickInterval<TSc
     if (
         tickGenerationType === TickGenerationType.CREATE_SECONDARY &&
         primaryTickCount != null &&
+        domain.length > 0 &&
         ContinuousScale.is(scale)
     ) {
         secondaryAxisTicks = calculateNiceSecondaryAxis(scale, domain, primaryTickCount, reverse, visibleRange);

--- a/packages/ag-charts-community/src/chart/chart.test.ts
+++ b/packages/ag-charts-community/src/chart/chart.test.ts
@@ -1322,6 +1322,46 @@ describe('Chart', () => {
             expect(coordinates.x.value).toBeDefined();
             expect(coordinates.x.groupPercentage).toBeUndefined();
         });
+
+        describe('axis with no visible series', () => {
+            const DUAL_AXIS_DATA = [
+                { month: 'Jan', unitsSold: 120, revenue: 18000 },
+                { month: 'Feb', unitsSold: 145, revenue: 21500 },
+                { month: 'Mar', unitsSold: 132, revenue: 19800 },
+            ];
+
+            const dualAxisOptions = (hidden?: 'y' | 'y2'): AgCartesianChartOptions => ({
+                data: DUAL_AXIS_DATA,
+                axes: {
+                    x: { type: 'category', position: 'bottom' },
+                    y: { type: 'number', position: 'left' },
+                    y2: { type: 'number', position: 'right' },
+                },
+                series: [
+                    { type: 'bar', xKey: 'month', yKey: 'unitsSold', visible: hidden !== 'y' },
+                    { type: 'line', xKey: 'month', yKey: 'revenue', yKeyAxis: 'y2', visible: hidden !== 'y2' },
+                ],
+            });
+
+            it('reports every axis while both series are visible', async () => {
+                await createChartWithClickListener(dualAxisOptions());
+                await clickAtEmptyPlot();
+
+                const [{ coordinates }] = popClickEvents();
+                expect(Object.keys(coordinates).sort((a, b) => a.localeCompare(b))).toEqual(['x', 'y', 'y2']);
+            });
+
+            it.each(['y', 'y2'] as const)('omits the %s axis when its only series is hidden', async (hidden) => {
+                await createChartWithClickListener(dualAxisOptions(hidden));
+                await clickAtEmptyPlot();
+
+                const [{ coordinates }] = popClickEvents();
+                // Absent, not present-and-undefined: consumers branch on `axisId in coordinates`.
+                expect(hidden in coordinates).toBe(false);
+                const stillVisible = hidden === 'y' ? 'y2' : 'y';
+                expect(coordinates[stillVisible].value).toEqual(expect.any(Number));
+            });
+        });
     });
 
     describe('AG-16337 listeners undefined update', () => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-17613

Toggling off the only series bound to a secondary axis left `coordinates` still reporting that axis, with `value: NaN`, `domain: [NaN, NaN]` and `index: -1`. The same action on a primary axis omitted it entirely, so the two directions disagreed.

An axis whose every series is hidden has an empty domain. A primary axis keeps that empty domain, so `scale.invert` returns null and `Axis.pickValue` bails out. A secondary axis additionally runs `calculateNiceSecondaryAxis` to align its ticks to the primary tick count, and there `findMinMax([])` returns `[]`: the destructured bounds are undefined and the arithmetic fabricates a [NaN, NaN] domain. That domain is not null, so it passes `pickValue`'s guard and reaches the listener.

Skip the alignment when the domain is empty. A secondary axis in this state then behaves exactly like a primary one - no ticks, and its key absent from `coordinates` rather than present with NaN values.

The tests hide each y axis in turn and assert the two behave identically. They check `axisId in coordinates` is false rather than merely undefined, since consumers branch on key presence, and that the axis still holding a visible series continues to resolve.