### PR TITLE
Add release notes for AG Charts 14.2.0

### DIFF
--- a/packages/ag-charts-website/public/changelog/releaseVersionNotes.json
+++ b/packages/ag-charts-website/public/changelog/releaseVersionNotes.json
@@ -1,5 +1,9 @@
 [
     {
+        "release version": "14.2.0",
+        "markdown": "/releases/14_2_0.md"
+    },
+    {
         "release version": "14.1.0",
         "markdown": "/releases/14_1_0.md"
     },

--- a/packages/ag-charts-website/public/changelog/releases/14_2_0.md
+++ b/packages/ag-charts-website/public/changelog/releases/14_2_0.md
@@ -1,0 +1,1 @@
+#### 16th September 2026 - Charts v14.2.0

--- a/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14-2/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/upgrade-to-ag-charts-14-2/index.mdoc
@@ -1,0 +1,92 @@
+---
+title: 'Upgrade to AG Charts 14.2'
+description: "See what's new in AG Charts v14.2 View a full list of breaking changes, behaviour changes and deprecations. Read the release post for feature highlights."
+migrationVersion: '14.2.0'
+---
+
+## What's New
+
+See the [release post](https://www.ag-grid.com/blog/whats-new-in-ag-charts-14-2/) for feature highlights of what's new in this version.
+
+Users of integrated charting on AG Grid, should refer to this migration guide when upgrading to AG Grid {% gridVersion() %}.
+
+<!--
+Documentation to the highest patch release of the major/minor
+NOTE: This will not show if the current library version is the same as the migration version.
+DO NOT TOUCH.
+-->
+
+{% documentationArchiveSection version=migrationVersionPatch() /%}
+
+## Breaking Changes
+
+<!-- If breaking changes do *not* exist, add the following: -->
+
+There are no breaking changes in AG Charts version {% migrationVersion() %}.
+
+<!-- Otherwise -->
+<!--
+The full list of breaking changes across all features for version {% migrationVersion() %}.
+
+{% expandingSection headerText="Breaking Changes" %}
+This release includes the following breaking changes:
+
+### Breaking changes section Name
+
+- item...
+
+{% /expandingSection %}
+-->
+
+## Behaviour Changes
+
+<!-- If behaviour changes do *not* exist, add the following: -->
+
+There are no behaviour changes in AG Charts version {% migrationVersion() %}.
+
+<!-- Otherwise -->
+<!--
+The full list of behaviour changes across all features for version {% migrationVersion() %}.
+
+{% expandingSection headerText="Behaviour Changes" %}
+
+This release includes the following behaviour changes:
+
+### Behaviour Changes section Name
+
+- item...
+
+{% /expandingSection %}
+-->
+
+## Removal of Deprecated APIs
+
+<!-- If there are *no* deprecated APIs, add the following: -->
+
+There are no deprecated APIs removed in AG Charts version {% migrationVersion() %}.
+
+<!-- Otherwise: -->
+<!--
+The following APIs have been deprecated since version !PREV_x.x! and have now been removed.
+
+{% expandingSection headerText="Removed Deprecated APIs" %}
+
+### Deprecated APIs section Name
+
+- item...
+
+{% /expandingSection %}
+-->
+
+## Deprecations
+
+{% expandingSection headerText="Deprecations" %}
+
+- Cone Funnel series `label.placement` values `'before'`, `'middle'` and `'after'` are deprecated. Use `'before-center'`, `'middle-center'` and `'after-center'` instead.
+- Heatmap series `textAlign` and `verticalAlign` are deprecated. Use `label.textAlign` and `label.verticalAlign` instead.
+
+{% /expandingSection %}
+
+<!-- Changelog for the `migrationVersion` property DO NOT TOUCH -->
+
+{% changelogSection version=$migrationVersion /%}

--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -1,5 +1,24 @@
 [
     {
+        "version": "14.2.0",
+        "date": "September 16th, 2026",
+        "highlights": [
+            {
+                "text": "Quadrant Charts",
+                "path": "./quadrant-charts/"
+            },
+            {
+                "text": "Additional Click Events",
+                "path": "./events/"
+            },
+            {
+                "text": "Development-time Validation",
+                "path": "./dev-validation/"
+            }
+        ],
+        "notesPath": "./upgrade-to-ag-charts-14-2"
+    },
+    {
         "version": "14.1.0",
         "date": "August 5th, 2026",
         "highlights": [


### PR DESCRIPTION
Release notes, changelog entry, and upgrade guide for AG Charts 14.2.0 (16th September 2026).