### PR TITLE
Capture the Astro dev server log, and unblock the beta version bump

### DIFF
--- a/.github/workflows/beta-publish.yml
+++ b/.github/workflows/beta-publish.yml
@@ -75,12 +75,17 @@ jobs:
               if: ${{ github.event_name != 'schedule' || steps.release_guard.outputs.can_bump == 'true' }}
               run: ./tools/bump-versions.sh ${NEW_VERSION}
 
+            # Plain git rather than EndBug/add-and-commit: the action's git wrapper rejects the
+            # GIT_CONFIG_COUNT set above unless it is opted into, which the action exposes no way
+            # to do, and the variable cannot be unset for a single step.
             - name: Commit Changes
-              uses: EndBug/add-and-commit@v11
               if: ${{ success() && (github.event_name != 'schedule' || steps.release_guard.outputs.can_bump == 'true') }}
-              with:
-                  default_author: github_actions
-                  message: Automated package version bump to ${{ steps.next_version.outputs.version }}.
+              run: |
+                  git config user.name 'github-actions[bot]'
+                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+                  git add .
+                  git commit -m "Automated package version bump to ${NEW_VERSION}."
+                  git push
 
             - name: Tag Latest Successful Commit
               uses: EndBug/latest-tag@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -988,6 +988,26 @@ jobs:
                   ./playwright.sh --host test -u changed ${{ matrix.args }}
               timeout-minutes: 15
 
+            # playwright.sh writes the dev server's output to ${RUNNER_TEMP} and nothing else
+            # surfaces it, so a server that wedges or is OOM-killed mid-shard - every remaining
+            # test then failing with ERR_CONNECTION_REFUSED - leaves no trace in the job.
+            - name: Capture Astro Dev Server Log
+              if: always()
+              run: |
+                  mkdir -p reports
+                  cp "${RUNNER_TEMP}/ag-charts-astro-dev.log" reports/astro-dev.log 2>/dev/null \
+                    || echo "No Astro dev server log at ${RUNNER_TEMP}/ag-charts-astro-dev.log."
+                  if [ "${{ steps.test.outcome }}" != "success" ] ; then
+                    echo "::group::Astro dev server log (last 200 lines)"
+                    tail -n 200 reports/astro-dev.log 2>/dev/null || true
+                    echo "::endgroup::"
+                    # A dev server reaped by the kernel is the one death its own log cannot record.
+                    echo "::group::Kernel OOM reports and free memory"
+                    sudo dmesg 2>/dev/null | grep -iE 'out of memory|oom-kill|killed process' | tail -n 20 || true
+                    free -m || true
+                    echo "::endgroup::"
+                  fi
+
             - name: Snapshot Branch
               uses: ./.github/actions/snapshot-branch
               with:
@@ -1133,6 +1153,26 @@ jobs:
                   cd packages/ag-charts-website/
                   ./playwright.sh --host test -u changed --config playwright.cross-browser.config.ts
               timeout-minutes: 15
+
+            # playwright.sh writes the dev server's output to ${RUNNER_TEMP} and nothing else
+            # surfaces it, so a server that wedges or is OOM-killed mid-shard - every remaining
+            # test then failing with ERR_CONNECTION_REFUSED - leaves no trace in the job.
+            - name: Capture Astro Dev Server Log
+              if: always()
+              run: |
+                  mkdir -p reports
+                  cp "${RUNNER_TEMP}/ag-charts-astro-dev.log" reports/astro-dev.log 2>/dev/null \
+                    || echo "No Astro dev server log at ${RUNNER_TEMP}/ag-charts-astro-dev.log."
+                  if [ "${{ steps.test.outcome }}" != "success" ] ; then
+                    echo "::group::Astro dev server log (last 200 lines)"
+                    tail -n 200 reports/astro-dev.log 2>/dev/null || true
+                    echo "::endgroup::"
+                    # A dev server reaped by the kernel is the one death its own log cannot record.
+                    echo "::group::Kernel OOM reports and free memory"
+                    sudo dmesg 2>/dev/null | grep -iE 'out of memory|oom-kill|killed process' | tail -n 20 || true
+                    free -m || true
+                    echo "::endgroup::"
+                  fi
 
             - name: Snapshot Branch
               uses: ./.github/actions/snapshot-branch


### PR DESCRIPTION
Two CI fixes, no product code.

**Astro dev server log** (`ci.yml`, both e2e jobs) — `playwright.sh` starts the server detached with its output going to `${RUNNER_TEMP}`, and nothing surfaced that file. A server that wedges or is OOM-killed mid-shard leaves every remaining test failing with `ERR_CONNECTION_REFUSED` and no explanation in the job. The new step copies the log into the uploaded `reports/`, and on failure prints its tail plus any kernel OOM report and `free -m` — a kill by the OOM reaper being the one death the log itself cannot record.

**Beta version bump** (`beta-publish.yml`) — the `Commit Changes` step started failing with:

```
Error: Use of "GIT_CONFIG_COUNT" is not permitted without enabling allowUnsafeConfigEnvCount
```

`EndBug/add-and-commit@v11`'s git wrapper now rejects that variable, which the workflow sets for every step to keep git's background gc out of the chained shallow fetches. The action exposes no way to opt in, and a step cannot unset an inherited environment variable, so this commits with plain git instead. None of the action's outputs were consumed anywhere.