### PR TITLE
AG-18353 Refactor: clickedOn→type, allClickParams→allMatchedParams

### DIFF
--- a/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
@@ -6,6 +6,7 @@ import type {
     AgCartesianCrossLineLabelOptions,
     AgCartesianCrossLineOptions,
     AgCrossLineClickEvent,
+    AgCrossLineClickParams,
     AgCrossLineLabelPosition,
     AgCrossLineListeners,
 } from 'ag-charts-types';
@@ -1784,8 +1785,8 @@ describe('CrossLine', () => {
 
             expect(crossLineClick).toHaveBeenCalled();
             const [event] = crossLineClick.mock.lastCall as [AgCrossLineClickEvent];
-            return event.allClickParams
-                .filter((params) => params.clickedOn === 'cross-line')
+            return event.allHitParams
+                .filter((params): params is AgCrossLineClickParams => params.type === 'crossLineClick')
                 .map(({ crossLineId }) => crossLineId)
                 .sort((a, b) => a.localeCompare(b));
         };

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
@@ -778,7 +778,7 @@ describe('CrossLine', () => {
             expect(click).not.toHaveBeenCalled();
         });
 
-        describe('overlapping crosslines allClickParams', () => {
+        describe('overlapping crosslines allHitParams', () => {
             let chartClick: ViFn;
             let chartCrossLineClick: ViFn;
             let chartCrossLineDoubleClick: ViFn;
@@ -832,7 +832,7 @@ describe('CrossLine', () => {
                         direction: 'x',
                         value: 'May',
                         // TODO: add AG-17613 `coordinated`
-                        allClickParams: [
+                        allHitParams: [
                             expect.objectContaining({
                                 type: 'crossLineClick',
                                 crossLineId: 'blue-line',
@@ -862,17 +862,17 @@ describe('CrossLine', () => {
                 expect(chartSeriesNodeClick).toHaveBeenCalledTimes(0);
                 expect(seriesSeriesNodeClick).toHaveBeenCalledTimes(0);
             });
-            test('TC7: a double-click root uses the double-click type, its entries the click type', async () => {
+            test('TC7: a double-click brands the root and every entry with the double-click type', async () => {
                 await doubleClickAction(505, 130)(chart);
                 expect(chartCrossLineDoubleClick).toHaveBeenCalledWith(
                     expect.objectContaining({
-                        // The discriminant marks the kind of element, so entries stay on the click value.
+                        // Entries track `event.type`, so they read `crossLineDoubleClick` here, not `crossLineClick`.
                         type: 'crossLineDoubleClick',
                         crossLineId: 'blue-line',
-                        allClickParams: [
-                            expect.objectContaining({ type: 'crossLineClick', crossLineId: 'blue-line' }),
-                            expect.objectContaining({ type: 'crossLineClick', crossLineId: 'grey-range' }),
-                            expect.objectContaining({ type: 'crossLineClick', crossLineId: 'CrossLine-3' }),
+                        allHitParams: [
+                            expect.objectContaining({ type: 'crossLineDoubleClick', crossLineId: 'blue-line' }),
+                            expect.objectContaining({ type: 'crossLineDoubleClick', crossLineId: 'grey-range' }),
+                            expect.objectContaining({ type: 'crossLineDoubleClick', crossLineId: 'CrossLine-3' }),
                         ],
                     })
                 );
@@ -885,7 +885,7 @@ describe('CrossLine', () => {
                         // The cross line still wins the event, so it carries the root params.
                         type: 'crossLineClick',
                         crossLineId: 'blue-line',
-                        allClickParams: [
+                        allHitParams: [
                             expect.objectContaining({
                                 type: 'crossLineClick',
                                 crossLineId: 'blue-line',
@@ -996,7 +996,7 @@ describe('CrossLine', () => {
                     // The series node still wins the event, so it carries the root params.
                     type: 'seriesNodeClick',
                     datum: { x: 'May', y: 3 },
-                    allClickParams: [
+                    allHitParams: [
                         expect.objectContaining({
                             type: 'seriesNodeClick',
                             datum: { x: 'May', y: 3 },
@@ -1017,7 +1017,7 @@ describe('CrossLine', () => {
                 expect(chartSeriesNodeClick).toHaveBeenCalledWith(expected);
                 // TC7: no entry carries the old `clickedOn` discriminant.
                 const [event] = seriesSeriesNodeClick.mock.calls[0];
-                for (const params of [event, ...event.allClickParams]) {
+                for (const params of [event, ...event.allHitParams]) {
                     expect(params).not.toHaveProperty('clickedOn');
                 }
             });
@@ -1026,7 +1026,7 @@ describe('CrossLine', () => {
                 const expected = expect.objectContaining({
                     type: 'seriesNodeClick',
                     datum: { x: 'Jan', y: 8 },
-                    allClickParams: [expect.objectContaining({ type: 'seriesNodeClick', datum: { x: 'Jan', y: 8 } })],
+                    allHitParams: [expect.objectContaining({ type: 'seriesNodeClick', datum: { x: 'Jan', y: 8 } })],
                 });
                 expect(seriesSeriesNodeClick).toHaveBeenCalledWith(expected);
                 expect(chartSeriesNodeClick).toHaveBeenCalledWith(expected);

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
@@ -781,11 +781,13 @@ describe('CrossLine', () => {
         describe('overlapping crosslines allClickParams', () => {
             let chartClick: ViFn;
             let chartCrossLineClick: ViFn;
+            let chartCrossLineDoubleClick: ViFn;
             let chartSeriesNodeClick: ViFn;
             let seriesSeriesNodeClick: ViFn;
             beforeEach(async () => {
                 chartClick = vi.fn();
                 chartCrossLineClick = vi.fn();
+                chartCrossLineDoubleClick = vi.fn();
                 chartSeriesNodeClick = vi.fn();
                 seriesSeriesNodeClick = vi.fn();
                 chart = await createChart({
@@ -816,6 +818,7 @@ describe('CrossLine', () => {
                     listeners: {
                         click: chartClick,
                         crossLineClick: chartCrossLineClick,
+                        crossLineDoubleClick: chartCrossLineDoubleClick,
                         seriesNodeClick: chartSeriesNodeClick,
                     },
                 });
@@ -831,21 +834,21 @@ describe('CrossLine', () => {
                         // TODO: add AG-17613 `coordinated`
                         allClickParams: [
                             expect.objectContaining({
-                                clickedOn: 'cross-line',
+                                type: 'crossLineClick',
                                 crossLineId: 'blue-line',
                                 axisId: 'myX',
                                 direction: 'x',
                                 value: 'May',
                             }),
                             expect.objectContaining({
-                                clickedOn: 'cross-line',
+                                type: 'crossLineClick',
                                 crossLineId: 'grey-range',
                                 axisId: 'myX',
                                 direction: 'x',
                                 range: ['Mar', 'Jul'],
                             }),
                             expect.objectContaining({
-                                clickedOn: 'cross-line',
+                                type: 'crossLineClick',
                                 crossLineId: 'CrossLine-3',
                                 axisId: 'myY',
                                 direction: 'y',
@@ -859,27 +862,42 @@ describe('CrossLine', () => {
                 expect(chartSeriesNodeClick).toHaveBeenCalledTimes(0);
                 expect(seriesSeriesNodeClick).toHaveBeenCalledTimes(0);
             });
+            test('TC7: a double-click root uses the double-click type, its entries the click type', async () => {
+                await doubleClickAction(505, 130)(chart);
+                expect(chartCrossLineDoubleClick).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        // The discriminant marks the kind of element, so entries stay on the click value.
+                        type: 'crossLineDoubleClick',
+                        crossLineId: 'blue-line',
+                        allClickParams: [
+                            expect.objectContaining({ type: 'crossLineClick', crossLineId: 'blue-line' }),
+                            expect.objectContaining({ type: 'crossLineClick', crossLineId: 'grey-range' }),
+                            expect.objectContaining({ type: 'crossLineClick', crossLineId: 'CrossLine-3' }),
+                        ],
+                    })
+                );
+            });
             test('AC4i: a cross-line win reports the series node it covers', async () => {
                 // The May bar sits under the blue line and inside the grey range band.
                 await clickAction(505, 470)(chart);
                 expect(chartCrossLineClick).toHaveBeenCalledWith(
                     expect.objectContaining({
                         // The cross line still wins the event, so it carries the root params.
-                        clickedOn: 'cross-line',
+                        type: 'crossLineClick',
                         crossLineId: 'blue-line',
                         allClickParams: [
                             expect.objectContaining({
-                                clickedOn: 'cross-line',
+                                type: 'crossLineClick',
                                 crossLineId: 'blue-line',
                                 value: 'May',
                             }),
                             expect.objectContaining({
-                                clickedOn: 'cross-line',
+                                type: 'crossLineClick',
                                 crossLineId: 'grey-range',
                                 range: ['Mar', 'Jul'],
                             }),
                             expect.objectContaining({
-                                clickedOn: 'series-node',
+                                type: 'seriesNodeClick',
                                 datum: { x: 'May', y: 3 },
                             }),
                         ],
@@ -976,20 +994,20 @@ describe('CrossLine', () => {
                 await clickAction(505, 470)(chart);
                 const expected = expect.objectContaining({
                     // The series node still wins the event, so it carries the root params.
-                    clickedOn: 'series-node',
+                    type: 'seriesNodeClick',
                     datum: { x: 'May', y: 3 },
                     allClickParams: [
                         expect.objectContaining({
-                            clickedOn: 'series-node',
+                            type: 'seriesNodeClick',
                             datum: { x: 'May', y: 3 },
                         }),
                         expect.objectContaining({
-                            clickedOn: 'cross-line',
+                            type: 'crossLineClick',
                             crossLineId: 'blue-line',
                             value: 'May',
                         }),
                         expect.objectContaining({
-                            clickedOn: 'cross-line',
+                            type: 'crossLineClick',
                             crossLineId: 'grey-range',
                             range: ['Mar', 'Jul'],
                         }),
@@ -997,13 +1015,18 @@ describe('CrossLine', () => {
                 });
                 expect(seriesSeriesNodeClick).toHaveBeenCalledWith(expected);
                 expect(chartSeriesNodeClick).toHaveBeenCalledWith(expected);
+                // TC7: no entry carries the old `clickedOn` discriminant.
+                const [event] = seriesSeriesNodeClick.mock.calls[0];
+                for (const params of [event, ...event.allClickParams]) {
+                    expect(params).not.toHaveProperty('clickedOn');
+                }
             });
             test('AC4ii: a series-node click clear of any cross line reports only itself', async () => {
                 await clickAction(140, 255)(chart);
                 const expected = expect.objectContaining({
-                    clickedOn: 'series-node',
+                    type: 'seriesNodeClick',
                     datum: { x: 'Jan', y: 8 },
-                    allClickParams: [expect.objectContaining({ clickedOn: 'series-node', datum: { x: 'Jan', y: 8 } })],
+                    allClickParams: [expect.objectContaining({ type: 'seriesNodeClick', datum: { x: 'Jan', y: 8 } })],
                 });
                 expect(seriesSeriesNodeClick).toHaveBeenCalledWith(expected);
                 expect(chartSeriesNodeClick).toHaveBeenCalledWith(expected);

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.test.ts
@@ -779,7 +779,7 @@ describe('CrossLine', () => {
             expect(click).not.toHaveBeenCalled();
         });
 
-        describe('overlapping crosslines allHitParams', () => {
+        describe('overlapping crosslines allMatchedParams', () => {
             let chartClick: ViFn;
             let chartCrossLineClick: ViFn;
             let chartCrossLineDoubleClick: ViFn;
@@ -833,7 +833,7 @@ describe('CrossLine', () => {
                         direction: 'x',
                         value: 'May',
                         // TODO: add AG-17613 `coordinated`
-                        allHitParams: [
+                        allMatchedParams: [
                             expect.objectContaining({
                                 type: 'crossLineClick',
                                 crossLineId: 'blue-line',
@@ -870,7 +870,7 @@ describe('CrossLine', () => {
                         // Entries track `event.type`, so they read `crossLineDoubleClick` here, not `crossLineClick`.
                         type: 'crossLineDoubleClick',
                         crossLineId: 'blue-line',
-                        allHitParams: [
+                        allMatchedParams: [
                             expect.objectContaining({ type: 'crossLineDoubleClick', crossLineId: 'blue-line' }),
                             expect.objectContaining({ type: 'crossLineDoubleClick', crossLineId: 'grey-range' }),
                             expect.objectContaining({ type: 'crossLineDoubleClick', crossLineId: 'CrossLine-3' }),
@@ -886,7 +886,7 @@ describe('CrossLine', () => {
                         // The cross line still wins the event, so it carries the root params.
                         type: 'crossLineClick',
                         crossLineId: 'blue-line',
-                        allHitParams: [
+                        allMatchedParams: [
                             expect.objectContaining({
                                 type: 'crossLineClick',
                                 crossLineId: 'blue-line',
@@ -997,7 +997,7 @@ describe('CrossLine', () => {
                     // The series node still wins the event, so it carries the root params.
                     type: 'seriesNodeClick',
                     datum: { x: 'May', y: 3 },
-                    allHitParams: [
+                    allMatchedParams: [
                         expect.objectContaining({
                             type: 'seriesNodeClick',
                             datum: { x: 'May', y: 3 },
@@ -1018,7 +1018,7 @@ describe('CrossLine', () => {
                 expect(chartSeriesNodeClick).toHaveBeenCalledWith(expected);
                 // TC7: no entry carries the old `clickedOn` discriminant.
                 const [event] = seriesSeriesNodeClick.mock.calls[0];
-                for (const params of [event, ...event.allHitParams]) {
+                for (const params of [event, ...event.allMatchedParams]) {
                     expect(params).not.toHaveProperty('clickedOn');
                 }
             });
@@ -1027,7 +1027,7 @@ describe('CrossLine', () => {
                 const expected = expect.objectContaining({
                     type: 'seriesNodeClick',
                     datum: { x: 'Jan', y: 8 },
-                    allHitParams: [expect.objectContaining({ type: 'seriesNodeClick', datum: { x: 'Jan', y: 8 } })],
+                    allMatchedParams: [expect.objectContaining({ type: 'seriesNodeClick', datum: { x: 'Jan', y: 8 } })],
                 });
                 expect(seriesSeriesNodeClick).toHaveBeenCalledWith(expected);
                 expect(chartSeriesNodeClick).toHaveBeenCalledWith(expected);
@@ -1785,7 +1785,7 @@ describe('CrossLine', () => {
 
             expect(crossLineClick).toHaveBeenCalled();
             const [event] = crossLineClick.mock.lastCall as [AgCrossLineClickEvent];
-            return event.allHitParams
+            return event.allMatchedParams
                 .filter((params): params is AgCrossLineClickParams => params.type === 'crossLineClick')
                 .map(({ crossLineId }) => crossLineId)
                 .sort((a, b) => a.localeCompare(b));

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.ts
@@ -2,12 +2,12 @@ import type { BoxBounds, CanvasPoint, ChartAxisDirection, Forbid, RequireOptiona
 import { callWithContext } from 'ag-charts-core';
 import type {
     AgBaseCrossLineLabelOptions,
-    AgClickParams,
     AgCrossLineClickEvent,
     AgCrossLineClickParams,
     AgCrossLineDoubleClickEvent,
     AgCrossLineLabelPosition,
     AgCrossLineListeners,
+    AgHitParams,
     AgTimeInterval,
     AgTimeIntervalUnit,
 } from 'ag-charts-types';
@@ -33,11 +33,11 @@ interface PendingCallback {
 }
 
 export type PendingCrossLineCallbackParam =
-    | Forbid<AgCrossLineClickEvent, 'allClickParams'>
-    | Forbid<AgCrossLineDoubleClickEvent, 'allClickParams'>;
+    | Forbid<AgCrossLineClickEvent, 'allHitParams'>
+    | Forbid<AgCrossLineDoubleClickEvent, 'allHitParams'>;
 
 export interface PendingCrossLineCallbacks {
-    allClickParams: AgCrossLineClickParams[];
+    allHitParams: AgCrossLineClickParams[];
     chart?: PendingCallback;
     axes: Map<string, PendingCallback>;
     crossLines: Map<string, PendingCallback>;
@@ -67,25 +67,25 @@ export function validateCrossLineValue(crossLine: ICrossLine, scale: Scale<any, 
     }
 }
 
-function firePendingCrossLineCallback(allClickParams: AgClickParams<unknown>[], callback: PendingCallback): void {
+function firePendingCrossLineCallback(allHitParams: AgHitParams<unknown>[], callback: PendingCallback): void {
     const { callers, fn, params } = callback;
-    callWithContext(callers, fn, { ...params, allClickParams });
+    callWithContext(callers, fn, { ...params, allHitParams });
 }
 
 export function fireAllPendingCrossLineCallbacks(
     pending: PendingCrossLineCallbacks,
-    otherClickParams: AgClickParams<unknown>[]
+    otherHitParams: AgHitParams<unknown>[]
 ): void {
-    const allClickParams: AgClickParams<unknown>[] =
-        otherClickParams.length > 0 ? [...pending.allClickParams, ...otherClickParams] : pending.allClickParams;
+    const allHitParams: AgHitParams<unknown>[] =
+        otherHitParams.length > 0 ? [...pending.allHitParams, ...otherHitParams] : pending.allHitParams;
     for (const crossLine of pending.crossLines.values()) {
-        firePendingCrossLineCallback(allClickParams, crossLine);
+        firePendingCrossLineCallback(allHitParams, crossLine);
     }
     for (const axis of pending.axes.values()) {
-        firePendingCrossLineCallback(allClickParams, axis);
+        firePendingCrossLineCallback(allHitParams, axis);
     }
     if (pending.chart) {
-        firePendingCrossLineCallback(allClickParams, pending.chart);
+        firePendingCrossLineCallback(allHitParams, pending.chart);
     }
 }
 

--- a/packages/ag-charts-community/src/chart/crossline/crossLine.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLine.ts
@@ -7,7 +7,7 @@ import type {
     AgCrossLineDoubleClickEvent,
     AgCrossLineLabelPosition,
     AgCrossLineListeners,
-    AgHitParams,
+    AgMatchedParams,
     AgTimeInterval,
     AgTimeIntervalUnit,
 } from 'ag-charts-types';
@@ -33,11 +33,11 @@ interface PendingCallback {
 }
 
 export type PendingCrossLineCallbackParam =
-    | Forbid<AgCrossLineClickEvent, 'allHitParams'>
-    | Forbid<AgCrossLineDoubleClickEvent, 'allHitParams'>;
+    | Forbid<AgCrossLineClickEvent, 'allMatchedParams'>
+    | Forbid<AgCrossLineDoubleClickEvent, 'allMatchedParams'>;
 
 export interface PendingCrossLineCallbacks {
-    allHitParams: AgCrossLineClickParams[];
+    allMatchedParams: AgCrossLineClickParams[];
     chart?: PendingCallback;
     axes: Map<string, PendingCallback>;
     crossLines: Map<string, PendingCallback>;
@@ -67,25 +67,25 @@ export function validateCrossLineValue(crossLine: ICrossLine, scale: Scale<any, 
     }
 }
 
-function firePendingCrossLineCallback(allHitParams: AgHitParams<unknown>[], callback: PendingCallback): void {
+function firePendingCrossLineCallback(allMatchedParams: AgMatchedParams<unknown>[], callback: PendingCallback): void {
     const { callers, fn, params } = callback;
-    callWithContext(callers, fn, { ...params, allHitParams });
+    callWithContext(callers, fn, { ...params, allMatchedParams });
 }
 
 export function fireAllPendingCrossLineCallbacks(
     pending: PendingCrossLineCallbacks,
-    otherHitParams: AgHitParams<unknown>[]
+    otherHitParams: AgMatchedParams<unknown>[]
 ): void {
-    const allHitParams: AgHitParams<unknown>[] =
-        otherHitParams.length > 0 ? [...pending.allHitParams, ...otherHitParams] : pending.allHitParams;
+    const allMatchedParams: AgMatchedParams<unknown>[] =
+        otherHitParams.length > 0 ? [...pending.allMatchedParams, ...otherHitParams] : pending.allMatchedParams;
     for (const crossLine of pending.crossLines.values()) {
-        firePendingCrossLineCallback(allHitParams, crossLine);
+        firePendingCrossLineCallback(allMatchedParams, crossLine);
     }
     for (const axis of pending.axes.values()) {
-        firePendingCrossLineCallback(allHitParams, axis);
+        firePendingCrossLineCallback(allMatchedParams, axis);
     }
     if (pending.chart) {
-        firePendingCrossLineCallback(allHitParams, pending.chart);
+        firePendingCrossLineCallback(allMatchedParams, pending.chart);
     }
 }
 

--- a/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
@@ -97,7 +97,7 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
         for (const crossLine of matches) {
             const { type: crossLineType, range, value } = crossLine;
             const crossLineId = crossLine.id ?? crossLine.internalId;
-            result.push({ clickedOn: 'cross-line', axisId, direction, crossLineId, crossLineType, range, value });
+            result.push({ type: 'crossLineClick', axisId, direction, crossLineId, crossLineType, range, value });
         }
         return result satisfies AgCrossLineClickEvent<unknown>['allClickParams'];
     }
@@ -117,10 +117,11 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
             callbacks.allClickParams.push(...allParamsOnThisAxis);
 
             // Use `Forbid` to ensure that allClickParams and rootLevelParams do have conflicting keys,
-            // otherwise the `...` spreading could silently and unintentionally override something.
+            // otherwise the `...` spreading could silently and unintentionally override something. `type` is
+            // exempt: the params carry the element kind, which the root event type deliberately overrides.
             type ParamType = (typeof allParamsOnThisAxis)[number];
             type EventType = PendingCrossLineCallbackParam;
-            const rootLevelParams: Forbid<EventType, keyof ParamType> = {
+            const rootLevelParams: Forbid<EventType, Exclude<keyof ParamType, 'type'>> = {
                 event: event.sourceEvent,
                 type: isClick ? 'crossLineClick' : 'crossLineDoubleClick',
             };

--- a/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
@@ -104,7 +104,7 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
             const crossLineId = crossLine.id ?? crossLine.internalId;
             result.push({ type, axisId, direction, crossLineId, crossLineType, range, value });
         }
-        return result satisfies AgCrossLineClickEvent<unknown>['allHitParams'];
+        return result satisfies AgCrossLineClickEvent<unknown>['allMatchedParams'];
     }
 
     private onSeriesAreaContextMenu(event: SeriesAreaContextMenuEvent): void {
@@ -123,9 +123,9 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
                 [],
                 isClick ? 'crossLineClick' : 'crossLineDoubleClick'
             );
-            callbacks.allHitParams.push(...allParamsOnThisAxis);
+            callbacks.allMatchedParams.push(...allParamsOnThisAxis);
 
-            // Use `Forbid` to ensure that allHitParams and rootLevelParams do have conflicting keys,
+            // Use `Forbid` to ensure that allMatchedParams and rootLevelParams do have conflicting keys,
             // otherwise the `...` spreading could silently and unintentionally override something. `type` is
             // exempt: an entry carries the same event type as the root, so overriding it is intentional.
             type ParamType = (typeof allParamsOnThisAxis)[number];
@@ -135,7 +135,7 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
                 type: isClick ? 'crossLineClick' : 'crossLineDoubleClick',
             };
             const params: CallbackParamRules<EventType> = {
-                allHitParams: undefined,
+                allMatchedParams: undefined,
                 ...allParamsOnThisAxis[0],
                 ...rootLevelParams,
             };

--- a/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
+++ b/packages/ag-charts-community/src/chart/crossline/crossLinesPlugin.ts
@@ -92,19 +92,24 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
         return result;
     }
 
-    private toParamsArray(matches: CrossLine[], result: CrossLineValuePick[]): CrossLineValuePick[] {
+    private toParamsArray(
+        matches: CrossLine[],
+        result: CrossLineValuePick[],
+        // Each entry reports the event this Cross Line would deliver for the interaction that hit it.
+        type: CrossLineValuePick['type']
+    ): CrossLineValuePick[] {
         const { userAxisId: axisId, direction } = this.axisCtx;
         for (const crossLine of matches) {
             const { type: crossLineType, range, value } = crossLine;
             const crossLineId = crossLine.id ?? crossLine.internalId;
-            result.push({ type: 'crossLineClick', axisId, direction, crossLineId, crossLineType, range, value });
+            result.push({ type, axisId, direction, crossLineId, crossLineType, range, value });
         }
-        return result satisfies AgCrossLineClickEvent<unknown>['allClickParams'];
+        return result satisfies AgCrossLineClickEvent<unknown>['allHitParams'];
     }
 
     private onSeriesAreaContextMenu(event: SeriesAreaContextMenuEvent): void {
         const picks = this.pickCrosslines(event);
-        this.toParamsArray(picks, event.crossLine);
+        this.toParamsArray(picks, event.crossLine, 'crossLineContextMenuAction');
     }
 
     private onSeriesAreaCanvasClick(event: SeriesAreaCanvasClickEvent): void {
@@ -113,12 +118,16 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
             const callbacks = event.pendingCrossLineCallbacks;
             const isClick = event.type === 'click';
 
-            const allParamsOnThisAxis = this.toParamsArray(picks, []);
-            callbacks.allClickParams.push(...allParamsOnThisAxis);
+            const allParamsOnThisAxis = this.toParamsArray(
+                picks,
+                [],
+                isClick ? 'crossLineClick' : 'crossLineDoubleClick'
+            );
+            callbacks.allHitParams.push(...allParamsOnThisAxis);
 
-            // Use `Forbid` to ensure that allClickParams and rootLevelParams do have conflicting keys,
+            // Use `Forbid` to ensure that allHitParams and rootLevelParams do have conflicting keys,
             // otherwise the `...` spreading could silently and unintentionally override something. `type` is
-            // exempt: the params carry the element kind, which the root event type deliberately overrides.
+            // exempt: an entry carries the same event type as the root, so overriding it is intentional.
             type ParamType = (typeof allParamsOnThisAxis)[number];
             type EventType = PendingCrossLineCallbackParam;
             const rootLevelParams: Forbid<EventType, Exclude<keyof ParamType, 'type'>> = {
@@ -126,7 +135,7 @@ export class CrossLinesPlugin extends AbstractModuleInstance implements AxisPlug
                 type: isClick ? 'crossLineClick' : 'crossLineDoubleClick',
             };
             const params: CallbackParamRules<EventType> = {
-                allClickParams: undefined,
+                allHitParams: undefined,
                 ...allParamsOnThisAxis[0],
                 ...rootLevelParams,
             };

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -42,8 +42,8 @@ import {
 import type {
     AgActiveItemState,
     AgChartLabelFormatterParams,
-    AgClickParams,
     AgDrawingMode,
+    AgHitParams,
     AgInitialStateLegendOptions,
     AgNodeClickEvent,
     AgNodeClickParams,
@@ -1256,17 +1256,20 @@ export abstract class Series<
     }
 
     createNodeContextMenuActionEvent(opts: FireNodeEventParams): AgNodeContextMenuActionEvent {
-        // `createNodeEvent` overwrites the params' `type` with the event type, so nothing to strip here.
         return this.createNodeEvent('nodeContextMenuAction', opts);
     }
 
     // Do not override. Override createNodeParams instead.
     createNodeEvent<T extends NodeEventType>(type: T, opts: FireNodeEventParams) {
-        const { event, datums, winner, coordinates, otherClickParams } = opts;
-        const nodeParams: AgNodeClickParams<unknown>[] = datums.map((d) => d.series.createNodeParams(d));
-        // Series nodes lead, so `winner` still indexes `allClickParams`.
-        const allClickParams: AgClickParams<unknown>[] =
-            otherClickParams != null && otherClickParams.length > 0 ? [...nodeParams, ...otherClickParams] : nodeParams;
+        const { event, datums, winner, coordinates, otherHitParams } = opts;
+        // Each entry reports the event its own kind would deliver, so every series node takes this event's type.
+        const nodeParams: AgNodeClickParams<unknown>[] = datums.map((d) => ({
+            ...d.series.createNodeParams(d),
+            type,
+        }));
+        // Series nodes lead, so `winner` still indexes `allHitParams`.
+        const allHitParams: AgHitParams<unknown>[] =
+            otherHitParams != null && otherHitParams.length > 0 ? [...nodeParams, ...otherHitParams] : nodeParams;
 
         let defaultPrevented = false;
         return {
@@ -1274,7 +1277,7 @@ export abstract class Series<
             type,
             event,
             coordinates,
-            allClickParams,
+            allHitParams,
             get defaultPrevented() {
                 return defaultPrevented;
             },
@@ -1284,10 +1287,10 @@ export abstract class Series<
         };
     }
 
-    createNodeParams(datum: TDatum): AgNodeClickParams<unknown> {
+    // The caller brands these with the event type, so `type` is deliberately absent here.
+    createNodeParams(datum: TDatum): Omit<AgNodeClickParams<unknown>, 'type'> {
         const dataIdKey = this.data?.dataIdKey;
         return {
-            type: 'seriesNodeClick',
             datum: datum.datum,
             datums: datum.datums,
             totalValue: datum.totalValue,

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -43,8 +43,8 @@ import type {
     AgActiveItemState,
     AgChartLabelFormatterParams,
     AgDrawingMode,
-    AgHitParams,
     AgInitialStateLegendOptions,
+    AgMatchedParams,
     AgNodeClickEvent,
     AgNodeClickParams,
     AgNodeContextMenuActionEvent,
@@ -1267,8 +1267,8 @@ export abstract class Series<
             ...d.series.createNodeParams(d),
             type,
         }));
-        // Series nodes lead, so `winner` still indexes `allHitParams`.
-        const allHitParams: AgHitParams<unknown>[] =
+        // Series nodes lead, so `winner` still indexes `allMatchedParams`.
+        const allMatchedParams: AgMatchedParams<unknown>[] =
             otherHitParams != null && otherHitParams.length > 0 ? [...nodeParams, ...otherHitParams] : nodeParams;
 
         let defaultPrevented = false;
@@ -1277,7 +1277,7 @@ export abstract class Series<
             type,
             event,
             coordinates,
-            allHitParams,
+            allMatchedParams,
             get defaultPrevented() {
                 return defaultPrevented;
             },

--- a/packages/ag-charts-community/src/chart/series/series.ts
+++ b/packages/ag-charts-community/src/chart/series/series.ts
@@ -1256,10 +1256,8 @@ export abstract class Series<
     }
 
     createNodeContextMenuActionEvent(opts: FireNodeEventParams): AgNodeContextMenuActionEvent {
-        const event = this.createNodeEvent('nodeContextMenuAction', opts);
-        // `delete` rather than a rest-spread, which would freeze the live `defaultPrevented` getter.
-        delete (event as { clickedOn?: unknown }).clickedOn;
-        return event;
+        // `createNodeEvent` overwrites the params' `type` with the event type, so nothing to strip here.
+        return this.createNodeEvent('nodeContextMenuAction', opts);
     }
 
     // Do not override. Override createNodeParams instead.
@@ -1289,7 +1287,7 @@ export abstract class Series<
     createNodeParams(datum: TDatum): AgNodeClickParams<unknown> {
         const dataIdKey = this.data?.dataIdKey;
         return {
-            clickedOn: 'series-node',
+            type: 'seriesNodeClick',
             datum: datum.datum,
             datums: datum.datums,
             totalValue: datum.totalValue,

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -6,8 +6,8 @@ import type {
     AgChartDoubleClickEvent,
     AgContextMenuItemShowOn,
     AgCoordinates,
-    AgHitParams,
     AgInitialFocus,
+    AgMatchedParams,
 } from 'ag-charts-types';
 
 import type {
@@ -673,7 +673,7 @@ export class SeriesAreaManager extends BaseManager {
 
         if (isSeriesWidget) {
             // Cross-line-only here, and populated whether or not any cross-line listener exists.
-            const clicked = this.checkSeriesNodeClick(event, pendingCrossLineCallbacks.allHitParams);
+            const clicked = this.checkSeriesNodeClick(event, pendingCrossLineCallbacks.allMatchedParams);
             if (clicked) {
                 if (clicked.defaultPrevented) return;
                 this.emitSeriesAreaClickEvent(event, true, clicked.node, clicked.target);
@@ -709,7 +709,7 @@ export class SeriesAreaManager extends BaseManager {
             canvasY,
             sourceEvent,
             pendingCrossLineCallbacks: {
-                allHitParams: [],
+                allMatchedParams: [],
                 axes: new Map(),
                 crossLines: new Map(),
             },
@@ -896,15 +896,15 @@ export class SeriesAreaManager extends BaseManager {
     }
 
     private checkCrossLineClick(event: ClickLikeEvent, pendingCallbacks: PendingCrossLineCallbacks): boolean {
-        const { allHitParams, axes, crossLines } = pendingCallbacks;
+        const { allMatchedParams, axes, crossLines } = pendingCallbacks;
         const chartListener =
             event.type === 'click'
                 ? this.chart.ctx.chartService.listeners.crossLineClick
                 : this.chart.ctx.chartService.listeners.crossLineDoubleClick;
-        return allHitParams.length > 0 && (axes.size > 0 || crossLines.size > 0 || chartListener != null);
+        return allMatchedParams.length > 0 && (axes.size > 0 || crossLines.size > 0 || chartListener != null);
     }
 
-    private pickSeriesNodeHitParams(event: ClickLikeEvent): AgHitParams<unknown>[] {
+    private pickSeriesNodeHitParams(event: ClickLikeEvent): AgMatchedParams<unknown>[] {
         const pickedNodes = this.pickNodes({ x: event.currentX, y: event.currentY }, 'event');
         if (pickedNodes == null || pickedNodes.matches.length === 0) return [];
         const { matches, target } = pickedNodes;
@@ -918,7 +918,7 @@ export class SeriesAreaManager extends BaseManager {
 
     private checkSeriesNodeClick(
         event: ClickLikeEvent & { preventZoomDblClick?: boolean },
-        crossLineParams: AgHitParams<unknown>[]
+        crossLineParams: AgMatchedParams<unknown>[]
     ): SeriesNodeClickCheck | undefined {
         const pickedNodes = this.pickNodes({ x: event.currentX, y: event.currentY }, 'event');
         const updated = this.pickManager.onPickedNodesTooltip(pickedNodes);

--- a/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesAreaManager.ts
@@ -4,9 +4,9 @@ import type {
     AgActiveItemState,
     AgChartClickEvent,
     AgChartDoubleClickEvent,
-    AgClickParams,
     AgContextMenuItemShowOn,
     AgCoordinates,
+    AgHitParams,
     AgInitialFocus,
 } from 'ag-charts-types';
 
@@ -666,14 +666,14 @@ export class SeriesAreaManager extends BaseManager {
         const clickedCrossLine = this.checkCrossLineClick(event, pendingCrossLineCallbacks);
         if (clickedCrossLine) {
             // The cross line wins the event, but still reports the series nodes it covered.
-            const nodeParams = isSeriesWidget ? this.pickSeriesNodeClickParams(event) : [];
+            const nodeParams = isSeriesWidget ? this.pickSeriesNodeHitParams(event) : [];
             fireAllPendingCrossLineCallbacks(pendingCrossLineCallbacks, nodeParams);
             return; // dodge chart-level / series-level user callbacks.
         }
 
         if (isSeriesWidget) {
             // Cross-line-only here, and populated whether or not any cross-line listener exists.
-            const clicked = this.checkSeriesNodeClick(event, pendingCrossLineCallbacks.allClickParams);
+            const clicked = this.checkSeriesNodeClick(event, pendingCrossLineCallbacks.allHitParams);
             if (clicked) {
                 if (clicked.defaultPrevented) return;
                 this.emitSeriesAreaClickEvent(event, true, clicked.node, clicked.target);
@@ -709,7 +709,7 @@ export class SeriesAreaManager extends BaseManager {
             canvasY,
             sourceEvent,
             pendingCrossLineCallbacks: {
-                allClickParams: [],
+                allHitParams: [],
                 axes: new Map(),
                 crossLines: new Map(),
             },
@@ -896,27 +896,29 @@ export class SeriesAreaManager extends BaseManager {
     }
 
     private checkCrossLineClick(event: ClickLikeEvent, pendingCallbacks: PendingCrossLineCallbacks): boolean {
-        const { allClickParams, axes, crossLines } = pendingCallbacks;
+        const { allHitParams, axes, crossLines } = pendingCallbacks;
         const chartListener =
             event.type === 'click'
                 ? this.chart.ctx.chartService.listeners.crossLineClick
                 : this.chart.ctx.chartService.listeners.crossLineDoubleClick;
-        return allClickParams.length > 0 && (axes.size > 0 || crossLines.size > 0 || chartListener != null);
+        return allHitParams.length > 0 && (axes.size > 0 || crossLines.size > 0 || chartListener != null);
     }
 
-    private pickSeriesNodeClickParams(event: ClickLikeEvent): AgClickParams<unknown>[] {
+    private pickSeriesNodeHitParams(event: ClickLikeEvent): AgHitParams<unknown>[] {
         const pickedNodes = this.pickNodes({ x: event.currentX, y: event.currentY }, 'event');
         if (pickedNodes == null || pickedNodes.matches.length === 0) return [];
         const { matches, target } = pickedNodes;
         // A dedicated control (e.g. the org-chart expander) owns its clicks outright and never reaches the user's
         // node click listeners, so it must not surface through a cross-line event either.
         if (!matches[0].series.firesUserClickListeners(target)) return [];
-        return matches.map((d) => d.series.createNodeParams(d));
+        // A cross line won the event, so these nodes still report the node event this interaction would deliver.
+        const type = event.type === 'click' ? 'seriesNodeClick' : 'seriesNodeDoubleClick';
+        return matches.map((d) => ({ ...d.series.createNodeParams(d), type }));
     }
 
     private checkSeriesNodeClick(
         event: ClickLikeEvent & { preventZoomDblClick?: boolean },
-        crossLineParams: AgClickParams<unknown>[]
+        crossLineParams: AgHitParams<unknown>[]
     ): SeriesNodeClickCheck | undefined {
         const pickedNodes = this.pickNodes({ x: event.currentX, y: event.currentY }, 'event');
         const updated = this.pickManager.onPickedNodesTooltip(pickedNodes);
@@ -939,7 +941,7 @@ export class SeriesAreaManager extends BaseManager {
             datums: matches,
             winner: matches.indexOf(updated.active),
             coordinates,
-            otherClickParams: crossLineParams,
+            otherHitParams: crossLineParams,
         };
 
         if (event.type === 'click') {

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -13,8 +13,8 @@ import type {
 } from 'ag-charts-core';
 import type {
     AgActiveItemState,
-    AgClickParams,
     AgCoordinates,
+    AgHitParams,
     AgNodeClickParams,
     AgNodeContextMenuActionEvent,
     AgNumericValue,
@@ -105,13 +105,13 @@ export type FireNodeEventParams = {
     /**
      * Index into `datums` of the node whose params are flattened onto the event root. Historically, click events only
      * ever reported 1 series-node at most. Nowadays, left/right click events report all series-nodes that overlap at
-     * this click-point (`allNodesParams` / `allShowOnParams` ). The `winner` is that series-node for backward
+     * this click-point (`allHitParams` / `allShowOnParams` ). The `winner` is that series-node for backward
      * compatibility.
      */
     winner: number;
     coordinates: AgCoordinates | undefined;
     // Params for elements of other kinds picked at the same point (e.g. currently cross lines
-    otherClickParams?: AgClickParams<unknown>[];
+    otherHitParams?: AgHitParams<unknown>[];
 };
 
 export interface ISeriesProperties {
@@ -149,7 +149,7 @@ export interface ISeries<TDatum extends SeriesNodeDatum, TProps extends ISeriesP
     fireNodeClickEvent(opts: FireNodeEventParams): boolean;
     fireNodeDoubleClickEvent(opts: FireNodeEventParams): boolean;
     createNodeContextMenuActionEvent(opts: FireNodeEventParams): AgNodeContextMenuActionEvent;
-    createNodeParams(datum: TDatum): AgNodeClickParams<unknown>;
+    createNodeParams(datum: TDatum): Omit<AgNodeClickParams<unknown>, 'type'>;
     getLegendData<T extends ChartLegendType>(legendType: T): ChartLegendDatum<T>[];
     getLegendData(legendType: ChartLegendType): ChartLegendDatum<ChartLegendType>[];
     getLabelData(): PointLabelDatum[];

--- a/packages/ag-charts-community/src/chart/series/seriesTypes.ts
+++ b/packages/ag-charts-community/src/chart/series/seriesTypes.ts
@@ -14,7 +14,7 @@ import type {
 import type {
     AgActiveItemState,
     AgCoordinates,
-    AgHitParams,
+    AgMatchedParams,
     AgNodeClickParams,
     AgNodeContextMenuActionEvent,
     AgNumericValue,
@@ -105,13 +105,13 @@ export type FireNodeEventParams = {
     /**
      * Index into `datums` of the node whose params are flattened onto the event root. Historically, click events only
      * ever reported 1 series-node at most. Nowadays, left/right click events report all series-nodes that overlap at
-     * this click-point (`allHitParams` / `allShowOnParams` ). The `winner` is that series-node for backward
+     * this click-point (`allMatchedParams` / `allShowOnParams` ). The `winner` is that series-node for backward
      * compatibility.
      */
     winner: number;
     coordinates: AgCoordinates | undefined;
     // Params for elements of other kinds picked at the same point (e.g. currently cross lines
-    otherHitParams?: AgHitParams<unknown>[];
+    otherHitParams?: AgMatchedParams<unknown>[];
 };
 
 export interface ISeriesProperties {

--- a/packages/ag-charts-types/src/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-types/src/chart/contextMenuOptions.ts
@@ -208,7 +208,7 @@ export interface AgContextMenuShowOnParamsSeriesArea<_TDatumReserved = never, TC
 }
 
 export interface AgContextMenuShowOnParamsSeriesNode<TDatum = DatumDefault, TContext = ContextDefault> extends Omit<
-    Omit<AgNodeContextMenuActionEvent<TDatum, TContext>, 'allHitParams'>,
+    Omit<AgNodeContextMenuActionEvent<TDatum, TContext>, 'allMatchedParams'>,
     GetItemsParamsOmissions
 > {
     /** Which clicked element this menu item should be shown for. */

--- a/packages/ag-charts-types/src/chart/contextMenuOptions.ts
+++ b/packages/ag-charts-types/src/chart/contextMenuOptions.ts
@@ -208,7 +208,7 @@ export interface AgContextMenuShowOnParamsSeriesArea<_TDatumReserved = never, TC
 }
 
 export interface AgContextMenuShowOnParamsSeriesNode<TDatum = DatumDefault, TContext = ContextDefault> extends Omit<
-    Omit<AgNodeContextMenuActionEvent<TDatum, TContext>, 'allClickParams'>,
+    Omit<AgNodeContextMenuActionEvent<TDatum, TContext>, 'allHitParams'>,
     GetItemsParamsOmissions
 > {
     /** Which clicked element this menu item should be shown for. */

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -28,7 +28,11 @@ interface AgCoordinatedEvent {
 }
 
 export interface AgBaseNodeClickEvent<TEvent extends string, TDatum, TContext = ContextDefault>
-    extends AgChartEvent<TEvent, TContext>, AgPreventableEvent, AgCoordinatedEvent, AgNodeClickParams<TDatum> {
+    extends
+        AgChartEvent<TEvent, TContext>,
+        AgPreventableEvent,
+        AgCoordinatedEvent,
+        Omit<AgNodeClickParams<TDatum>, 'type'> {
     /** Event type. */
     type: TEvent;
 }
@@ -43,14 +47,18 @@ export interface AgNodeClickEvent<
 }
 
 /**
- * One element identified at a click point, discriminated by its `clickedOn` field. This is the element type of
+ * One element identified at a click point, discriminated by its `type` field. This is the element type of
  * `allClickParams`, letting one listener see everything under the cursor — for example a series node drawn over a
  * Cross Line. Entries are grouped by kind, with the kind that won the event first; the winning element itself is
  * included but not necessarily at index 0, so identify it by comparing ids against the event root.
  *
  * A list rather than a map keyed by kind, because one kind can match more than once at a single click point:
- * overlapping markers each contribute their own `'series-node'` entry, and Cross Lines on different axes each
- * contribute their own `'cross-line'` entry.
+ * overlapping markers each contribute their own `'seriesNodeClick'` entry, and Cross Lines on different axes
+ * each contribute their own `'crossLineClick'` entry.
+ *
+ * The discriminant identifies the kind of element, so it always uses the single-click value — a double-click
+ * event's entries are still `'seriesNodeClick'` and `'crossLineClick'`, while the event root carries
+ * `'seriesNodeDoubleClick'` or `'crossLineDoubleClick'`.
  */
 export type AgClickParams<TDatum> = AgNodeClickParams<TDatum> | AgCrossLineClickParams;
 
@@ -59,8 +67,8 @@ export type AgClickParams<TDatum> = AgNodeClickParams<TDatum> | AgCrossLineClick
  * event-delivery fields. Most fields are optional, because each series type only sets the properties applicable to it.
  */
 export interface AgNodeClickParams<TDatum> {
-    /** Which kind of element these params describe. */
-    clickedOn: 'series-node';
+    /** Which kind of element these params describe, in the same value space as `event.type`. */
+    type: 'seriesNodeClick';
     /** Series ID, as specified in `series.id` (or generated if not specified) */
     seriesId: string;
     /** The unique identifier of the picked datum. */
@@ -274,8 +282,8 @@ export interface AgAxisListeners<TContext = ContextDefault> {
 
 /** Identifies the Cross Line an event refers to, along with the axis that owns it. */
 export interface AgCrossLineClickParams {
-    /** Which kind of element these params describe. */
-    clickedOn: 'cross-line';
+    /** Which kind of element these params describe, in the same value space as `event.type`. */
+    type: 'crossLineClick';
     /** Cross Line ID (generated if not specified). */
     crossLineId: string;
     /** ID of the axis the Cross Line belongs to, as specified in `axes`. */
@@ -298,14 +306,17 @@ interface AgAllCrossLineClickParams {
 export interface AgCrossLineContextMenuActionEvent<TContext = ContextDefault>
     extends
         AgChartEvent<'crossLineContextMenuAction', TContext>,
-        Omit<AgCrossLineClickParams, 'clickedOn'>,
+        Omit<AgCrossLineClickParams, 'type'>,
         AgCoordinatedEvent {}
 
 export interface AgCrossLineClickEvent<TContext = ContextDefault>
-    extends AgChartEvent<'crossLineClick', TContext>, AgCrossLineClickParams, AgAllCrossLineClickParams {}
+    extends AgChartEvent<'crossLineClick', TContext>, Omit<AgCrossLineClickParams, 'type'>, AgAllCrossLineClickParams {}
 
 export interface AgCrossLineDoubleClickEvent<TContext = ContextDefault>
-    extends AgChartEvent<'crossLineDoubleClick', TContext>, AgCrossLineClickParams, AgAllCrossLineClickParams {}
+    extends
+        AgChartEvent<'crossLineDoubleClick', TContext>,
+        Omit<AgCrossLineClickParams, 'type'>,
+        AgAllCrossLineClickParams {}
 
 export interface AgCaptionContextMenuActionEvent<TContext = ContextDefault> extends AgChartEvent<
     'captionContextMenuAction',
@@ -334,10 +345,10 @@ export interface AgCaptionListeners<TContext = ContextDefault> {
     doubleClick?: Listener<AgCaptionClickEvent<'doubleClick', TContext>>;
 }
 
-export interface AgNodeContextMenuActionEvent<TDatum = DatumDefault, TContext = ContextDefault> extends Omit<
-    AgNodeClickEvent<'nodeContextMenuAction', TDatum, TContext>,
-    'clickedOn'
-> {}
+export interface AgNodeContextMenuActionEvent<
+    TDatum = DatumDefault,
+    TContext = ContextDefault,
+> extends AgNodeClickEvent<'nodeContextMenuAction', TDatum, TContext> {}
 
 export interface AgBaseChartListeners<TDatum, TContext = ContextDefault> {
     /** The listener to call when a node (marker, column, bar, tile or a pie sector) in any series is clicked.

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -43,12 +43,12 @@ export interface AgNodeClickEvent<
     TContext = ContextDefault,
 > extends AgBaseNodeClickEvent<TEvent, TDatum, TContext> {
     /** Every element hit at this point, including the winning element carried by these root params. */
-    allHitParams: AgHitParams<TDatum>[];
+    allMatchedParams: AgMatchedParams<TDatum>[];
 }
 
 /**
  * One element identified at the point an interaction hit, discriminated by its `type` field. This is the element
- * type of `allHitParams`, letting one listener see everything under the cursor — for example a series node drawn
+ * type of `allMatchedParams`, letting one listener see everything under the cursor — for example a series node drawn
  * over a Cross Line. Entries are grouped by kind, with the kind that won the event first; the winning element
  * itself is included but not necessarily at index 0, so identify it by comparing ids against the event root.
  *
@@ -61,7 +61,7 @@ export interface AgNodeClickEvent<
  * the event rather than the kind of element on its own, so a test for one kind must cover every interaction's
  * value.
  */
-export type AgHitParams<TDatum> = AgNodeClickParams<TDatum> | AgCrossLineClickParams;
+export type AgMatchedParams<TDatum> = AgNodeClickParams<TDatum> | AgCrossLineClickParams;
 
 /**
  * Everything a node event reports about the picked datum itself, i.e. an {@link AgNodeClickEvent} minus the
@@ -301,7 +301,7 @@ export interface AgCrossLineClickParams {
 
 interface AgAllCrossLineClickParams {
     /** Every element that matched at the click point, including the winning element carried by these root params. */
-    allHitParams: AgHitParams<DatumDefault>[];
+    allMatchedParams: AgMatchedParams<DatumDefault>[];
 }
 
 export interface AgCrossLineContextMenuActionEvent<TContext = ContextDefault>

--- a/packages/ag-charts-types/src/chart/eventOptions.ts
+++ b/packages/ag-charts-types/src/chart/eventOptions.ts
@@ -42,33 +42,34 @@ export interface AgNodeClickEvent<
     TDatum,
     TContext = ContextDefault,
 > extends AgBaseNodeClickEvent<TEvent, TDatum, TContext> {
-    /** Every element that matched at the click point, including the winning element carried by these root params. */
-    allClickParams: AgClickParams<TDatum>[];
+    /** Every element hit at this point, including the winning element carried by these root params. */
+    allHitParams: AgHitParams<TDatum>[];
 }
 
 /**
- * One element identified at a click point, discriminated by its `type` field. This is the element type of
- * `allClickParams`, letting one listener see everything under the cursor — for example a series node drawn over a
- * Cross Line. Entries are grouped by kind, with the kind that won the event first; the winning element itself is
- * included but not necessarily at index 0, so identify it by comparing ids against the event root.
+ * One element identified at the point an interaction hit, discriminated by its `type` field. This is the element
+ * type of `allHitParams`, letting one listener see everything under the cursor — for example a series node drawn
+ * over a Cross Line. Entries are grouped by kind, with the kind that won the event first; the winning element
+ * itself is included but not necessarily at index 0, so identify it by comparing ids against the event root.
  *
- * A list rather than a map keyed by kind, because one kind can match more than once at a single click point:
- * overlapping markers each contribute their own `'seriesNodeClick'` entry, and Cross Lines on different axes
- * each contribute their own `'crossLineClick'` entry.
+ * A list rather than a map keyed by kind, because one kind can match more than once at a single point: overlapping
+ * markers each contribute their own series-node entry, and Cross Lines on different axes each contribute their own
+ * Cross Line entry.
  *
- * The discriminant identifies the kind of element, so it always uses the single-click value — a double-click
- * event's entries are still `'seriesNodeClick'` and `'crossLineClick'`, while the event root carries
- * `'seriesNodeDoubleClick'` or `'crossLineDoubleClick'`.
+ * `type` reports the event each element would deliver for this interaction, so it tracks `event.type` — a
+ * double-click event's entries are `'seriesNodeDoubleClick'` and `'crossLineDoubleClick'`. It therefore identifies
+ * the event rather than the kind of element on its own, so a test for one kind must cover every interaction's
+ * value.
  */
-export type AgClickParams<TDatum> = AgNodeClickParams<TDatum> | AgCrossLineClickParams;
+export type AgHitParams<TDatum> = AgNodeClickParams<TDatum> | AgCrossLineClickParams;
 
 /**
  * Everything a node event reports about the picked datum itself, i.e. an {@link AgNodeClickEvent} minus the
  * event-delivery fields. Most fields are optional, because each series type only sets the properties applicable to it.
  */
 export interface AgNodeClickParams<TDatum> {
-    /** Which kind of element these params describe, in the same value space as `event.type`. */
-    type: 'seriesNodeClick';
+    /** The event this series node would deliver for the interaction that hit it; tracks `event.type`. */
+    type: 'seriesNodeClick' | 'seriesNodeDoubleClick' | 'nodeContextMenuAction';
     /** Series ID, as specified in `series.id` (or generated if not specified) */
     seriesId: string;
     /** The unique identifier of the picked datum. */
@@ -282,8 +283,8 @@ export interface AgAxisListeners<TContext = ContextDefault> {
 
 /** Identifies the Cross Line an event refers to, along with the axis that owns it. */
 export interface AgCrossLineClickParams {
-    /** Which kind of element these params describe, in the same value space as `event.type`. */
-    type: 'crossLineClick';
+    /** The event this Cross Line would deliver for the interaction that hit it; tracks `event.type`. */
+    type: 'crossLineClick' | 'crossLineDoubleClick' | 'crossLineContextMenuAction';
     /** Cross Line ID (generated if not specified). */
     crossLineId: string;
     /** ID of the axis the Cross Line belongs to, as specified in `axes`. */
@@ -300,7 +301,7 @@ export interface AgCrossLineClickParams {
 
 interface AgAllCrossLineClickParams {
     /** Every element that matched at the click point, including the winning element carried by these root params. */
-    allClickParams: AgClickParams<DatumDefault>[];
+    allHitParams: AgHitParams<DatumDefault>[];
 }
 
 export interface AgCrossLineContextMenuActionEvent<TContext = ContextDefault>


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-18353
* Rename `allClickParams` to a more neural name `allMatchedParams`
* Brand hit objects using `event.type` instead of context-menu `showOn`