### PR TITLE
AG-18378 Fire chart-level click on axis areas without a listener

### DIFF
--- a/packages/ag-charts-community/src/chart/test/findTarget.ts
+++ b/packages/ag-charts-community/src/chart/test/findTarget.ts
@@ -1,5 +1,4 @@
 import type { BoxBounds, CanvasPoint } from 'ag-charts-core';
-import { boxContains } from 'ag-charts-core';
 import { CANVAS_HEIGHT, CANVAS_WIDTH, Caster, type MockEvent, makeMockEvent } from 'ag-charts-test';
 
 import { BBox } from '../../scene/bbox';
@@ -75,6 +74,15 @@ function initBoundingClientRect(widgets: WidgetSet) {
     }
 }
 
+/**
+ * A DOM box occupies the half-open interval `[x, x + width)`, so a point on its far edge belongs to
+ * whatever element abuts it. `boxContains` is inclusive at both edges, which would let an axis proxy
+ * claim the first row/column of the series area it sits against.
+ */
+function boxContainsExclusive(b: BoxBounds, x: number, y: number): boolean {
+    return x >= b.x && x < b.x + b.width && y >= b.y && y < b.y + b.height;
+}
+
 function isClickable(widget: Widget | undefined): widget is Widget {
     if (widget == null) return false;
     const style = widget.getElement().style;
@@ -148,38 +156,29 @@ function findNavigatorTarget(navigatorModule: unknown, clientX: number, clientY:
     return undefined;
 }
 
-function findZoomTarget(
-    zoomModule: unknown,
-    axisDOMProxyModule: unknown,
-    clientX: number,
-    clientY: number
-): MockEvent | undefined {
-    if (zoomModule === undefined) return undefined;
+/**
+ * An axis proxy element covers its axis area whenever any axis feature has requested one — zoom,
+ * the scrollbar, or the context menu, which is enabled by default. `.ag-charts-proxy-elem` sets
+ * `pointer-events: auto`, so a click there lands on the proxy rather than on the chart container,
+ * and `isClickable` covers the cases where it does not (hidden, or pointer events disabled because
+ * the axis overlaps the series area).
+ */
+function findAxisTarget(axisDOMProxyModule: unknown, clientX: number, clientY: number): MockEvent | undefined {
+    if (axisDOMProxyModule === undefined) return undefined;
 
-    const zoomCaster = new Caster(zoomModule);
-    const zoom = zoomCaster.accessProperty('opts').findBoolean('enabled').findBoolean('enableAxisDragging').value;
-    const hasZooming: boolean = zoom.enabled && zoom.enableAxisDragging;
+    const domProxy = new Caster(axisDOMProxyModule)
+        .findProperty('axes')
+        .castProperty('axes', Array)
+        .findArrayElementProperties('axes', 'div')
+        .castArrayElementProperties('axes', 'div', NativeWidget).value;
 
-    const axisDOMProxyCaster = new Caster(axisDOMProxyModule);
-    const hasClickListeners: boolean = !!axisDOMProxyCaster
-        .findProperty('hasClickListeners')
-        .callProperty('hasClickListeners').value;
-
-    if (hasZooming || hasClickListeners) {
-        const domProxy = axisDOMProxyCaster
-            .findProperty('axes')
-            .castProperty('axes', Array)
-            .findArrayElementProperties('axes', 'div')
-            .castArrayElementProperties('axes', 'div', NativeWidget).value;
-
-        for (const axis of domProxy.axes) {
-            const bbox = axis.div.getBounds();
-            if (isClickable(axis.div) && boxContains(bbox, clientX, clientY)) {
-                const offsetX = clientX - bbox.x;
-                const offsetY = clientY - bbox.y;
-                const target = axis.div.getElement();
-                return makeMockEvent({ target, offsetX, offsetY, clientX, clientY });
-            }
+    for (const axis of domProxy.axes) {
+        const bbox = axis.div.getBounds();
+        if (isClickable(axis.div) && boxContainsExclusive(bbox, clientX, clientY)) {
+            const offsetX = clientX - bbox.x;
+            const offsetY = clientY - bbox.y;
+            const target = axis.div.getElement();
+            return makeMockEvent({ target, offsetX, offsetY, clientX, clientY });
         }
     }
 
@@ -210,7 +209,7 @@ export function findChartTarget(chart: Chart, clientX: number, clientY: number):
     return (
         findLegendTarget(getModule('legend'), clientX, clientY) ??
         findNavigatorTarget(getModule('navigator'), clientX, clientY) ??
-        findZoomTarget(getModule('zoom'), getModule('axis-dom-proxy'), clientX, clientY) ??
+        findAxisTarget(getModule('axis-dom-proxy'), clientX, clientY) ??
         findSeriesAreaTarget(chart, widgets, clientX, clientY)
     );
 }

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -916,6 +916,34 @@ describe('AxisDOMProxy', () => {
             expect(chartClick).toHaveBeenCalledTimes(1);
         });
 
+        // A listener for one event type must not suppress the fallback for the other: the dispatch below
+        // picks its listener by event type, so the unmatched event would otherwise reach nothing at all.
+        test('a click-only axis listener leaves doubleClick to the chart', async () => {
+            chart = await createChart({ axes: { x: { listeners: { click } }, y: {} } });
+
+            await doubleClickAction(...X_AXIS_AREA)(chart);
+            await waitForChartStability(chart);
+
+            expect(click).toHaveBeenCalledTimes(2);
+            expect(chartClick).not.toHaveBeenCalled();
+            expect(chartDoubleClick.mock.calls).toMatchObject([[expect.objectContaining({ type: 'doubleClick' })]]);
+        });
+
+        test('a doubleClick-only axis listener leaves click to the chart', async () => {
+            const doubleClick = vi.fn();
+            chart = await createChart({ axes: { x: { listeners: { doubleClick } }, y: {} } });
+
+            await doubleClickAction(...X_AXIS_AREA)(chart);
+            await waitForChartStability(chart);
+
+            expect(doubleClick).toHaveBeenCalledTimes(1);
+            expect(chartDoubleClick).not.toHaveBeenCalled();
+            expect(chartClick.mock.calls).toMatchObject([
+                [expect.objectContaining({ type: 'click' })],
+                [expect.objectContaining({ type: 'click' })],
+            ]);
+        });
+
         test('zoom owns the axis, so nothing is handed back to the chart', async () => {
             chart = await createChart({ zoom: { enabled: true, enableDoubleClickToReset: true } });
 

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.test.ts
@@ -4,7 +4,14 @@
 // explicitly set the original padding in the chart options where applicable.
 import { vi } from 'vitest';
 
-import { Chart, clickAction, setupMockCanvas, waitForChartStability } from 'ag-charts-community-test';
+import type { AgCartesianChartOptions } from 'ag-charts-community';
+import {
+    Chart,
+    clickAction,
+    doubleClickAction,
+    setupMockCanvas,
+    waitForChartStability,
+} from 'ag-charts-community-test';
 import { closeToBigInt, closeToDate, setupMockConsole } from 'ag-charts-test';
 
 import { createEnterpriseChart } from '../../test/utils';
@@ -341,12 +348,13 @@ describe('AxisDOMProxy', () => {
         // The end labels '0' and '1000' hide themselves to avoid overflowing, but their ticks and label
         // data still exist, so a click at either end reports the hidden label rather than skipping it.
         test('click - value/index match', async () => {
-            await clickAction(800, 560)(chart); // far right, where '1000' hid itself
+            // 799, not 800: the axis spans x 25..800 of an 800px canvas, so 800 is off the element.
+            await clickAction(799, 560)(chart); // far right, where '1000' hid itself
             await clickAction(25, 560)(chart); // far left, where '0' hid itself
             await waitForChartStability(chart);
 
             expect(click.mock.calls).toMatchObject([
-                [expect.objectContaining({ value: 1000, index: 5 })],
+                [expect.objectContaining({ value: expect.closeTo(998.71), index: 5 })],
                 [expect.objectContaining({ value: 0, index: 0 })],
             ]);
         });
@@ -839,6 +847,87 @@ describe('AxisDOMProxy', () => {
                 [expect.objectContaining({ value: 0, index: 0 })],
                 [expect.objectContaining({ value: 1, index: 2 })],
             ]);
+        });
+    });
+
+    // Co-ordinates sit inside the measured proxy bounds: x axis {x:48,y:555,w:732,h:25}, y {x:20,y:13,w:28,h:549}.
+    describe('chart-level click fallback', () => {
+        const X_AXIS_AREA: [number, number] = [400, 565];
+        const Y_AXIS_AREA: [number, number] = [30, 300];
+        let chartClick: ReturnType<typeof vi.fn>;
+        let chartDoubleClick: ReturnType<typeof vi.fn>;
+
+        type ChartOverrides = Pick<AgCartesianChartOptions, 'axes' | 'zoom'>;
+
+        async function createChart(overrides: ChartOverrides = {}) {
+            const options: AgCartesianChartOptions = {
+                data: [
+                    { x: 'A', y: 1 },
+                    { x: 'B', y: 2 },
+                ],
+                series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
+                listeners: { click: chartClick, doubleClick: chartDoubleClick },
+                ...overrides,
+            };
+            return createEnterpriseChart(options);
+        }
+
+        beforeEach(() => {
+            chartClick = vi.fn();
+            chartDoubleClick = vi.fn();
+        });
+
+        test('fires for a click on either axis area', async () => {
+            chart = await createChart();
+
+            await clickAction(...X_AXIS_AREA)(chart);
+            await clickAction(...Y_AXIS_AREA)(chart);
+            await waitForChartStability(chart);
+
+            expect(chartClick.mock.calls).toMatchObject([
+                [expect.objectContaining({ type: 'click' })],
+                [expect.objectContaining({ type: 'click' })],
+            ]);
+        });
+
+        test('fires doubleClick for a double-click on the axis area', async () => {
+            chart = await createChart();
+
+            await doubleClickAction(...X_AXIS_AREA)(chart);
+            await waitForChartStability(chart);
+
+            expect(chartDoubleClick.mock.calls).toMatchObject([[expect.objectContaining({ type: 'doubleClick' })]]);
+        });
+
+        test('an axis listener consumes the click, and only for its own axis', async () => {
+            chart = await createChart({ axes: { x: { listeners: { click } }, y: {} } });
+
+            await clickAction(...X_AXIS_AREA)(chart);
+            await waitForChartStability(chart);
+
+            expect(click).toHaveBeenCalledTimes(1);
+            expect(chartClick).not.toHaveBeenCalled();
+
+            // The y axis has no listener of its own, so it still falls back to the chart-level one.
+            await clickAction(...Y_AXIS_AREA)(chart);
+            await waitForChartStability(chart);
+
+            expect(click).toHaveBeenCalledTimes(1);
+            expect(chartClick).toHaveBeenCalledTimes(1);
+        });
+
+        test('zoom owns the axis, so nothing is handed back to the chart', async () => {
+            chart = await createChart({ zoom: { enabled: true, enableDoubleClickToReset: true } });
+
+            await doubleClickAction(...X_AXIS_AREA)(chart);
+            await waitForChartStability(chart);
+
+            // A proxy is present, so nothing fired because it was suppressed rather than because the
+            // click missed the axis. Selected by property: jsdom does not reflect `role` to the attribute.
+            const proxies = Array.from(document.querySelectorAll('.ag-charts-proxy-elem'));
+            expect(proxies.some((el) => (el as HTMLElement).role === 'region')).toBe(true);
+            expect(chartClick).not.toHaveBeenCalled();
+            expect(chartDoubleClick).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -12,13 +12,18 @@ type ProxyAxis = {
     bounds?: _ModuleSupport.BBox;
 };
 
+function hasAxisListener(
+    chartService: _ModuleSupport.ChartService,
+    axisCtx: _ModuleSupport.AxisContext,
+    isDoubleClick: boolean
+): boolean {
+    return isDoubleClick
+        ? chartService.listeners.axisDoubleClick != null || axisCtx.listeners?.doubleClick != null
+        : chartService.listeners.axisClick != null || axisCtx.listeners?.click != null;
+}
+
 function hasAxisClickListener(chartService: _ModuleSupport.ChartService, axisCtx: _ModuleSupport.AxisContext): boolean {
-    return (
-        chartService.listeners.axisClick != null ||
-        chartService.listeners.axisDoubleClick != null ||
-        axisCtx.listeners?.click != null ||
-        axisCtx.listeners?.doubleClick != null
-    );
+    return hasAxisListener(chartService, axisCtx, false) || hasAxisListener(chartService, axisCtx, true);
 }
 
 function hasDraggableAxes(ctx: DynamicContext<_ModuleSupport.ChartRegistry>): boolean {
@@ -322,13 +327,17 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         const div = this.axes.find((axis) => axis.axisId === axisId)?.div;
         if (!div) return;
 
+        const isDoubleClick = widgetEvent.type === 'dblclick';
         const axisCtx = this.ctx.axisManager.getAxisIdContext(axisId);
         // AG-18378: An axis proxy covers the axis area even when only the context menu needs it, so a click no axis
         // listener wants is handed back to the chart-level listener - unless zoom owns the axis interaction.
-        if (axisCtx != null && !hasAxisClickListener(this.ctx.chartService, axisCtx)) {
+        if (axisCtx != null && !hasAxisListener(this.ctx.chartService, axisCtx, isDoubleClick)) {
             if (!this.enabled.get('zoom')) {
-                const type = widgetEvent.type === 'dblclick' ? 'doubleClick' : 'click';
-                this.ctx.chartService.callListener({ type, event: widgetEvent.sourceEvent, coordinates: undefined });
+                this.ctx.chartService.callListener({
+                    type: isDoubleClick ? 'doubleClick' : 'click',
+                    event: widgetEvent.sourceEvent,
+                    coordinates: undefined,
+                });
             }
             return;
         }
@@ -336,7 +345,6 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         const pick = axisCtx?.pickValue(this.toCanvasPoint(div, widgetEvent));
         if (!axisCtx || !pick) return;
 
-        const isDoubleClick = widgetEvent.type === 'dblclick';
         const { direction, boundSeries, domain, value, index, depth, groupPercentage } = pick;
         const params = {
             event: widgetEvent.sourceEvent,

--- a/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
+++ b/packages/ag-charts-enterprise/src/features/axis-dom-proxy/axisDomProxy.ts
@@ -323,6 +323,16 @@ export class AxisDOMProxy extends AbstractModuleInstance {
         if (!div) return;
 
         const axisCtx = this.ctx.axisManager.getAxisIdContext(axisId);
+        // AG-18378: An axis proxy covers the axis area even when only the context menu needs it, so a click no axis
+        // listener wants is handed back to the chart-level listener - unless zoom owns the axis interaction.
+        if (axisCtx != null && !hasAxisClickListener(this.ctx.chartService, axisCtx)) {
+            if (!this.enabled.get('zoom')) {
+                const type = widgetEvent.type === 'dblclick' ? 'doubleClick' : 'click';
+                this.ctx.chartService.callListener({ type, event: widgetEvent.sourceEvent, coordinates: undefined });
+            }
+            return;
+        }
+
         const pick = axisCtx?.pickValue(this.toCanvasPoint(div, widgetEvent));
         if (!axisCtx || !pick) return;
 
@@ -445,7 +455,7 @@ export class AxisDOMProxy extends AbstractModuleInstance {
             this.ctx.eventsHub.emit('axis-dom-proxy:drag-end', { axisId, direction, event });
         });
         dragInterpretation.on('dblclick', (event) => {
-            if (this.hasClickListeners()) this.dispatchAxisClick(axisId, event);
+            this.dispatchAxisClick(axisId, event);
             if (!this.isEnabled() || !this.isEnabledDoubleClick()) return;
             this.ctx.eventsHub.emit('axis-dom-proxy:dblclick', { axisId, direction, event });
         });
@@ -464,7 +474,6 @@ export class AxisDOMProxy extends AbstractModuleInstance {
             this.ctx.eventsHub.emit('axis-dom-proxy:wheel', { axisId, direction, event });
         });
         dragInterpretation.on('click', (event) => {
-            if (!this.hasClickListeners()) return;
             this.dispatchAxisClick(axisId, event);
         });
         div.addListener('contextmenu', (event) => {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-18378

An axis proxy element covers the axis area whenever any axis feature asks for one, and the context menu is enabled by default, so every enterprise cartesian chart has a proxy over each axis. Chart-level click/doubleClick is dispatched from the chart container and requires an exact target match, so a click landing on a proxy was dropped - the listener fired in community but not in enterprise.

-   Hand a click that no axis listener wants back to the chart-level
    click/doubleClick listener, checked per axis so an axis without a listener
    still falls back when a sibling axis has one. Skipped when zoom is enabled,
    which keeps zoom's axes suppressed as they were before.
-   Drop the two chart-wide hasClickListeners() gates on the axis click and
    dblclick handlers, so the per-axis check is reached when no axis has a
    listener at all.

Test harness (findTarget.ts) previously routed a click to an axis proxy only when zoom or an axis click listener existed, so it modelled a DOM that no longer exists and could not observe this behaviour:

-   Route to a proxy whenever it is visible and pointer events are enabled,
    matching `.ag-charts-proxy-elem { pointer-events: auto }`.
-   Treat proxy bounds as the half-open interval a DOM box occupies, so a proxy
    no longer claims the edge pixel of the series area it abuts. boxContains is
    inclusive at both edges, which mis-routed clicks on cone-funnel nodes that
    sit exactly on that boundary.
-   Move the suppressed-overflow-label click from x=800 to x=799: the axis spans
    x 25..800 of an 800px canvas, so 800 was off the element and unreachable by
    a real click. Its `index` expectation is unchanged; `value` is the
    interpolated 998.71 rather than a clamped 1000.