### PR TITLE
AG-3390 Mark the Enzuzo eval as an accepted violation in the post-deploy CSP report

### DIFF
--- a/external/ag-shared/scripts/slack/notify-csp-violations.mjs
+++ b/external/ag-shared/scripts/slack/notify-csp-violations.mjs
@@ -13,9 +13,13 @@
  * would otherwise read as a policy being fixed. Set RUN_COMPLETE=false for such a run and it will
  * still report anything new, without claiming anything was resolved.
  *
+ * A violation the suite marked `accepted` — one the policy knowingly produces and will not be
+ * changed to fix, with the reason carried on the record — is neither counted nor diffed. It is
+ * listed in the step summary so the decision stays visible, and never posted to Slack.
+ *
  * Expects a report as written by the suite's CSP reporter:
  *   { baseUrl?: string, violations: [{ key, directive, blockedUri, disposition, suggestedHashes,
- *     sourceFiles, pages, tests }] }
+ *     sourceFiles, pages, tests, accepted? }] }
  *
  * Env: CSP_REPORT_FILE (required), PREVIOUS_CSP_REPORT_FILE, RUN_COMPLETE, SLACK_CHANNEL,
  * SLACK_BOT_OAUTH_TOKEN, PROJECT_TITLE, SITE_URL, RUN_URL, COMMIT_SHA, DRY_RUN,
@@ -54,7 +58,12 @@ const readReport = (file) => {
     }
 };
 
-const enforcedOf = (report) => (report?.violations ?? []).filter((violation) => violation.disposition === 'enforce');
+const isAccepted = (violation) => typeof violation.accepted === 'string';
+// Enforced and not accepted: what the owning team is being asked to act on.
+const enforcedOf = (report) =>
+    (report?.violations ?? []).filter((violation) => violation.disposition === 'enforce' && !isAccepted(violation));
+const acceptedOf = (report) =>
+    (report?.violations ?? []).filter((violation) => violation.disposition === 'enforce' && isAccepted(violation));
 
 const truncate = (text, limit = MAX_BLOCK_TEXT) => (text.length > limit ? `${text.slice(0, limit - 3)}...` : text);
 
@@ -88,7 +97,8 @@ if (!report) {
 
 const siteUrl = process.env.SITE_URL || report.baseUrl || '';
 const enforced = enforcedOf(report);
-const reportOnlyCount = (report.violations ?? []).length - enforced.length;
+const accepted = acceptedOf(report);
+const reportOnlyCount = (report.violations ?? []).length - enforced.length - accepted.length;
 
 const candidateBaseline = readReport(previousReportFile);
 // A manual run can target any URL, and its report is uploaded like any other, so the most recent
@@ -108,8 +118,11 @@ const resolved = isRunComplete ? enforcedOf(previousReport).filter((violation) =
 for (const violation of enforced) {
     console.log(`::warning title=CSP violation::${describe(violation)}`);
 }
+for (const violation of accepted) {
+    console.log(`::notice title=Accepted CSP violation::${describe(violation)} - ${violation.accepted}`);
+}
 console.log(
-    `${enforced.length} enforced violation(s), ${reportOnlyCount} report-only, ` +
+    `${enforced.length} enforced violation(s), ${accepted.length} accepted, ${reportOnlyCount} report-only, ` +
         `${added.length} new, ${resolved.length} resolved` +
         (previousReport ? '' : ' (no usable baseline to compare against)') +
         (isRunComplete ? '' : ' (incomplete run: not reporting anything as resolved)')
@@ -121,9 +134,19 @@ if (stepSummaryFile) {
               `### CSP violations on ${projectTitle} (${siteUrl})`,
               '',
               ...enforced.map((violation) => `- ${added.includes(violation) ? '**new** ' : ''}${describe(violation)}`),
-              ...(reportOnlyCount ? ['', `${reportOnlyCount} report-only violation(s) not listed.`] : []),
           ]
         : [`### No enforced CSP violations on ${projectTitle} (${siteUrl})`];
+    if (accepted.length) {
+        summary.push(
+            '',
+            `#### Accepted (${accepted.length})`,
+            '',
+            ...accepted.map((violation) => `- ${describe(violation)}<br>${violation.accepted}`)
+        );
+    }
+    if (reportOnlyCount) {
+        summary.push('', `${reportOnlyCount} report-only violation(s) not listed.`);
+    }
     fs.appendFileSync(stepSummaryFile, `${summary.join('\n')}\n`, 'utf8');
 }
 
@@ -165,6 +188,9 @@ if (resolved.length) {
             )
         )
     );
+}
+if (accepted.length) {
+    blocks.push(context(`${accepted.length} accepted violation(s) not listed; see the run summary.`));
 }
 blocks.push(
     context(

--- a/packages/ag-charts-website/scripts/csp/cspViolationReporter.ts
+++ b/packages/ag-charts-website/scripts/csp/cspViolationReporter.ts
@@ -8,6 +8,7 @@ import {
     CSP_VIOLATION_ANNOTATION,
     aggregateCspViolations,
 } from '../../src/utils/csp/cspViolationReport';
+import { ACCEPTED_CSP_VIOLATIONS } from '../../src/utils/htaccess/cspRules';
 
 interface Options {
     outputFile: string;
@@ -59,16 +60,17 @@ export default class CspViolationReporter implements Reporter {
     onEnd(): void {
         const report: CspViolationReport = {
             baseUrl: this.baseUrl,
-            violations: aggregateCspViolations(this.records, this.hints),
+            violations: aggregateCspViolations(this.records, this.hints, ACCEPTED_CSP_VIOLATIONS),
         };
 
         fs.mkdirSync(path.dirname(this.outputFile), { recursive: true });
         fs.writeFileSync(this.outputFile, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
 
-        const enforced = report.violations.filter((violation) => violation.disposition === 'enforce').length;
+        const enforced = report.violations.filter((violation) => violation.disposition === 'enforce');
+        const accepted = enforced.filter((violation) => violation.accepted !== undefined).length;
         process.stdout.write(
-            `CSP report written to ${this.outputFile}: ${enforced} enforced, ` +
-                `${report.violations.length - enforced} report-only.\n`
+            `CSP report written to ${this.outputFile}: ${enforced.length - accepted} enforced, ` +
+                `${accepted} accepted, ${report.violations.length - enforced.length} report-only.\n`
         );
     }
 }

--- a/packages/ag-charts-website/src/utils/csp/cspViolationReport.test.ts
+++ b/packages/ag-charts-website/src/utils/csp/cspViolationReport.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { CspHashHint, CspViolationRecord } from './cspViolationReport';
+import type { AcceptedCspViolation, CspHashHint, CspViolationRecord } from './cspViolationReport';
 import { aggregateCspViolations, cspDirectiveFamily, parseCspHashHint } from './cspViolationReport';
 
 // Abbreviated from real Chromium output; the full policy string is inlined by the browser and
@@ -185,6 +185,83 @@ describe('aggregateCspViolations', () => {
             ['enforce|script-src-elem|inline|sha256-first=', ['/']],
             ['enforce|script-src-elem|inline|sha256-second=', ['/react/ai/']],
         ]);
+    });
+
+    describe('accepted violations', () => {
+        const evalRecord: CspViolationRecord = {
+            directive: 'script-src',
+            blockedUri: 'eval',
+            disposition: 'enforce',
+            sourceFile: 'https://vendor.invalid/scripts/banner/abc',
+            pageUrl: PAGE,
+        };
+        const rule: AcceptedCspViolation = {
+            directive: 'script-src',
+            blockedUri: 'eval',
+            sourceFilePrefix: 'https://vendor.invalid/scripts/banner/',
+            reason: 'redundant fallback',
+        };
+
+        it('marks a matching violation with the reason and leaves it in the report', () => {
+            const violations = aggregateCspViolations(
+                [{ record: evalRecord, testTitle: 'homepage loads' }],
+                [],
+                [rule]
+            );
+
+            expect(violations).toHaveLength(1);
+            expect(violations[0].accepted).toBe('redundant fallback');
+            expect(violations[0].key).toBe('enforce|script-src|eval');
+        });
+
+        it('leaves the field off a violation no rule matches', () => {
+            const violations = aggregateCspViolations([{ record: evalRecord, testTitle: 'homepage loads' }], [], []);
+
+            expect(violations[0]).not.toHaveProperty('accepted');
+        });
+
+        it('does not accept the same eval from a script the rule does not name', () => {
+            const violations = aggregateCspViolations(
+                [
+                    { record: evalRecord, testTitle: 'homepage loads' },
+                    {
+                        record: { ...evalRecord, sourceFile: 'https://other.invalid/app.js', pageUrl: DOCS_PAGE },
+                        testTitle: 'docs data overview loads',
+                    },
+                ],
+                [],
+                [rule]
+            );
+
+            // One group (the key carries no source), and the stranger keeps it visible.
+            expect(violations).toHaveLength(1);
+            expect(violations[0]).not.toHaveProperty('accepted');
+        });
+
+        it('does not accept a different thing the named script is blocked from doing', () => {
+            const violations = aggregateCspViolations(
+                [
+                    {
+                        record: { ...evalRecord, directive: 'connect-src', blockedUri: 'https://vendor.invalid/api' },
+                        testTitle: 'homepage loads',
+                    },
+                ],
+                [],
+                [rule]
+            );
+
+            expect(violations[0]).not.toHaveProperty('accepted');
+        });
+
+        it('never accepts a violation with no source file to attribute it to', () => {
+            const violations = aggregateCspViolations(
+                [{ record: { ...evalRecord, sourceFile: undefined }, testTitle: 'homepage loads' }],
+                [],
+                [rule]
+            );
+
+            expect(violations[0]).not.toHaveProperty('accepted');
+        });
     });
 
     it('gathers one blocked script into a single entry across the pages that serve it', () => {

--- a/packages/ag-charts-website/src/utils/csp/cspViolationReport.ts
+++ b/packages/ag-charts-website/src/utils/csp/cspViolationReport.ts
@@ -44,6 +44,27 @@ export interface AggregatedCspViolation {
     sourceFiles: string[];
     pages: string[];
     tests: string[];
+    /**
+     * Set when the violation matches an `AcceptedCspViolation`: the reason the policy is left
+     * as it is. The violation stays in the report so a change in what the script does is still
+     * visible; CI just stops raising it as something to fix.
+     */
+    accepted?: string;
+}
+
+/**
+ * A violation the policy knowingly produces and will not be changed to fix. Kept as a rule
+ * rather than a filter so the decision travels with the report, and matched narrowly: a
+ * blocked eval from a given third-party script is accepted; anything else that script is
+ * blocked from doing is not, and nor is the same eval from a script this does not name.
+ */
+export interface AcceptedCspViolation {
+    directive: string;
+    blockedUri: string;
+    /** Every source file of the aggregated violation must start with this. */
+    sourceFilePrefix: string;
+    /** Why the policy stays as it is. Surfaces in the report as `accepted`. */
+    reason: string;
 }
 
 export interface CspViolationReport {
@@ -104,9 +125,31 @@ function hashesFor(record: CspViolationRecord, hints: CspHashHint[]): string[] {
     );
 }
 
+/**
+ * A rule accepts an aggregated violation only when every source file matches. A group is keyed
+ * without its source, so an unrelated script hitting the same directive and URI lands in the
+ * same group; that must resurface the group rather than be waved through with the known one.
+ * A violation with no source file at all cannot be attributed and so is never accepted.
+ */
+function acceptanceReason(
+    violation: Pick<AggregatedCspViolation, 'directive' | 'blockedUri' | 'sourceFiles'>,
+    accepted: AcceptedCspViolation[]
+): string | undefined {
+    if (violation.sourceFiles.length === 0) {
+        return undefined;
+    }
+    return accepted.find(
+        (rule) =>
+            rule.directive === violation.directive &&
+            rule.blockedUri === violation.blockedUri &&
+            violation.sourceFiles.every((file) => file.startsWith(rule.sourceFilePrefix))
+    )?.reason;
+}
+
 export function aggregateCspViolations(
     records: { record: CspViolationRecord; testTitle: string }[],
-    hints: CspHashHint[]
+    hints: CspHashHint[],
+    accepted: AcceptedCspViolation[] = []
 ): AggregatedCspViolation[] {
     const groups = new Map<string, { violation: AggregatedCspViolation; pagePaths: Set<string> }>();
 
@@ -139,12 +182,16 @@ export function aggregateCspViolations(
         }
     }
 
-    const violations = [...groups.values()].map(({ violation, pagePaths }) => ({
-        ...violation,
-        sourceFiles: sorted(violation.sourceFiles),
-        pages: sorted(pagePaths),
-        tests: sorted(violation.tests),
-    }));
+    const violations = [...groups.values()].map(({ violation, pagePaths }) => {
+        const aggregated: AggregatedCspViolation = {
+            ...violation,
+            sourceFiles: sorted(violation.sourceFiles),
+            pages: sorted(pagePaths),
+            tests: sorted(violation.tests),
+        };
+        const reason = acceptanceReason(aggregated, accepted);
+        return reason === undefined ? aggregated : { ...aggregated, accepted: reason };
+    });
 
     return violations.sort(
         (a, b) =>

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.test.ts
@@ -1,13 +1,19 @@
 import astroPackageJson from 'astro/package.json';
 import { createHash } from 'node:crypto';
 
+import { aggregateCspViolations } from '../csp/cspViolationReport';
 import {
     DARK_MODE_INIT_SCRIPT,
     KBD_PLATFORM_INIT_SCRIPT,
     PLAUSIBLE_INIT_SCRIPT,
     PLAUSIBLE_PAGE_LOAD_SCRIPT,
 } from '../csp/inlineScripts';
-import { ASTRO_HYDRATION_HASHES_VERIFIED_FOR, getCspDirectives, getScopedCspHtaccessBlock } from './cspRules';
+import {
+    ACCEPTED_CSP_VIOLATIONS,
+    ASTRO_HYDRATION_HASHES_VERIFIED_FOR,
+    getCspDirectives,
+    getScopedCspHtaccessBlock,
+} from './cspRules';
 
 const sha256Source = (source: string) => `'sha256-${createHash('sha256').update(source, 'utf8').digest('base64')}'`;
 const hasHash = (sources: string[]) => sources.some((s) => s.startsWith("'sha256-"));
@@ -174,6 +180,28 @@ describe('cspRules', () => {
             // The banner's new Function paths degrade rather than justify re-opening eval
             // site-wide; see the note above ENZUZO_APP_HOST in cspRules.ts.
             expect(getCspDirectives({ env: 'production', scope: 'site' })['script-src']).not.toContain("'unsafe-eval'");
+        });
+
+        it('accepts the blocked eval from its cookiebar bundle, and only that', () => {
+            // The shape the post-deploy suite actually observes on staging, so the acceptance
+            // stops matching if Enzuzo moves the bundle or the browser reports it differently.
+            const observed = {
+                directive: 'script-src',
+                blockedUri: 'eval',
+                disposition: 'enforce' as const,
+                sourceFile: 'https://app.enzuzo.com/scripts/cookiebar/061e8460-91b3-11f1-98ff-978c2fcf2681',
+                pageUrl: 'https://charts-staging.ag-grid.com/',
+            };
+            const aggregate = (record: typeof observed) =>
+                aggregateCspViolations([{ record, testTitle: 'homepage loads' }], [], ACCEPTED_CSP_VIOLATIONS)[0];
+
+            expect(aggregate(observed).accepted).toEqual(expect.stringContaining('Enzuzo'));
+            // The consent-bridge hash going stale must still surface...
+            expect(aggregate({ ...observed, blockedUri: 'inline' })).not.toHaveProperty('accepted');
+            // ...as must an eval from anything other than the banner bundle.
+            expect(
+                aggregate({ ...observed, sourceFile: 'https://app.enzuzo.com/scripts/cookies/061e8460' })
+            ).not.toHaveProperty('accepted');
         });
 
         it('applies on every page, not just the ones that render a cookies table', () => {

--- a/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/cspRules.ts
@@ -17,6 +17,7 @@
  */
 import { createHash } from 'node:crypto';
 
+import type { AcceptedCspViolation } from '../csp/cspViolationReport';
 import {
     DARK_MODE_INIT_SCRIPT,
     KBD_PLATFORM_INIT_SCRIPT,
@@ -120,12 +121,35 @@ const SITE_SCRIPT_HASHES = [
 // only place the site declares these origins. Its `new Function` paths throw without
 // 'unsafe-eval', which we will not grant site-wide, so keep the Enzuzo console configuration
 // free of template placeholders and string-bodied event handlers.
+// Independently of those, the bundle calls eval() unconditionally on load, in a guarded
+// fallback that redefines functions it has already defined, so the call achieves nothing when
+// it succeeds and costs nothing when it is blocked. It is blocked on every page, and that is
+// accepted below so the post-deploy CSP report does not carry it as something to fix. The
+// acceptance is deliberately narrow — only eval, only from the cookiebar bundle — so a stale
+// hash for the consent bridge, a blocked connect, or an eval from any other script still
+// surfaces.
 // React and React DOM ship no ES module build on npm, so the example runner's import map
 // resolves them through esm.sh.
 const ESM_SH_HOST = 'https://esm.sh';
 
 const ENZUZO_APP_HOST = 'https://app.enzuzo.com';
 const ENZUZO_GVL_HOST = 'https://gvl.enzuzo.com';
+
+/**
+ * Violations the site policy knowingly produces and will not be changed to fix. Read by the
+ * page-verification suite's CSP reporter (scripts/csp/cspViolationReporter.ts) so the
+ * post-deploy report marks them accepted rather than raising them. Each entry's reasoning
+ * belongs in the comment above the host it concerns, not here.
+ */
+export const ACCEPTED_CSP_VIOLATIONS: AcceptedCspViolation[] = [
+    {
+        directive: 'script-src',
+        blockedUri: 'eval',
+        // The bundle path carries the account id; match the path, not the whole URL.
+        sourceFilePrefix: `${ENZUZO_APP_HOST}/scripts/cookiebar/`,
+        reason: "Enzuzo's banner bundle calls eval() in a redundant fallback on load; 'unsafe-eval' is not granted site-wide for a consent banner (see ENZUZO_APP_HOST in cspRules.ts).",
+    },
+];
 
 // LinkedIn Insight Tag, loaded by a tag in the shared GTM container, so the CSP is the only
 // place the site declares these origins. The rest of LinkedIn's published required-domains


### PR DESCRIPTION
Port of ag-grid/ag-grid#15047 to the charts website.

## Summary

The post-deploy page-verification run reports one enforced CSP violation on every page of staging: the Enzuzo cookie-banner bundle calls `eval()` in a redundant fallback on load, and the site policy deliberately omits `'unsafe-eval'`. The policy is right and is not changing, so the report should say so rather than carry the violation as a standing item to fix.

This adds an accepted-violations list to the CSP rules and teaches the reporting pipeline to treat entries on it as known and explained rather than actionable.

- `cspViolationReport.ts`: new `AcceptedCspViolation` rule type and an optional `accepted` reason on aggregated violations. A rule matches on directive, blocked URI and a source-file prefix, and only when every source file in the group matches. Groups with no source file are never accepted.
- `cspRules.ts`: exports `ACCEPTED_CSP_VIOLATIONS` beside the Enzuzo host constants, with one entry for `script-src` blocking `eval` from the cookiebar bundle. The Enzuzo note is extended to explain the fallback and why it is accepted. The list lives here so the decision sits next to the policy that causes it.
- Playwright CSP reporter: passes the list into aggregation, so the JSON artifact carries the flag and reason. The violation stays in the artifact so any change in what the script does remains visible.
- Shared Slack notifier (`external/ag-shared`): accepted violations are left out of the enforced count, the run-to-run diff and the Slack post. They appear as GitHub notice annotations and in an "Accepted" section of the step summary.

The `Content-Security-Policy` header Apache serves is unchanged. The browser still blocks the eval; only the reporting changes.

## Scope of acceptance

Deliberately narrow so real regressions still surface: a stale hash for the Enzuzo consent-bridge script, a blocked connect, or an `eval` from any other script are not accepted.

## After merge

The post-deploy workflow only runs on `latest`, so this takes effect once `b14.2.0` lands there. The first run after that compares against a baseline artifact that predates the flag, so it will post one "CSP violations cleared" message to the CSP channel listing the eval as resolved. Every run after that is quiet.

## Verification

- `cspViolationReport.test.ts` and `cspRules.test.ts` pass (49 tests), including a test against the exact violation shape observed on charts staging.
- Reporter import chain type-checks and loads under `tsx`; it still depends only on Node built-ins, which the standalone Playwright install in the workflow requires.
- Dry run of the Slack script against the latest real charts-staging artifact: 0 enforced, 1 accepted, no post once the baseline is also flagged.
- Prettier and ESLint clean on changed files.