### PR TITLE
AG-17830 Rename validations.onDiagnosticRaised to issueRaised, standardise on severity

### DIFF
--- a/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-base.ts
+++ b/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts-base.ts
@@ -95,10 +95,10 @@ export abstract class AgChartsBase<Options extends {}> implements AfterViewInit,
         if (propsOptions.contextMenu) {
             patched.contextMenu = this.patchContextMenu(propsOptions.contextMenu);
         }
-        if (typeof propsOptions.validations?.onDiagnosticRaised === 'function') {
+        if (typeof propsOptions.validations?.issueRaised === 'function') {
             patched.validations = {
                 ...propsOptions.validations,
-                onDiagnosticRaised: this.wrapZoneAction(propsOptions.validations.onDiagnosticRaised),
+                issueRaised: this.wrapZoneAction(propsOptions.validations.issueRaised),
             };
         }
         patched.container ??= this._nativeElement;

--- a/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts.component.spec.ts
+++ b/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts.component.spec.ts
@@ -232,12 +232,12 @@ class ValidationsHostComponent {
         ],
         series: [{ type: 'bar', xKey: 'type', yKey: 'earnings' }],
         validations: {
-            onDiagnosticRaised: recordedAction(this.issueRaised),
+            issueRaised: recordedAction(this.issueRaised),
         },
     };
 }
 
-describe('validations.onDiagnosticRaised zone patching', () => {
+describe('validations.issueRaised zone patching', () => {
     let host: ValidationsHostComponent;
     let fixture: ComponentFixture<ValidationsHostComponent>;
     let ngZone: NgZone;
@@ -262,9 +262,9 @@ describe('validations.onDiagnosticRaised zone patching', () => {
 
     it('runs the callback inside the Angular zone and leaves the consumer options untouched', () => {
         const created = createChartSpy.calls.argsFor(0)[0] as AgChartOptions;
-        const patched = (created as any).validations.onDiagnosticRaised;
+        const patched = (created as any).validations.issueRaised;
 
-        expect(patched).not.toBe((host.options as any).validations.onDiagnosticRaised);
+        expect(patched).not.toBe((host.options as any).validations.issueRaised);
 
         ngZone.runOutsideAngular(() => patched({ level: 'error', message: 'boom' }));
 

--- a/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts.component.spec.ts
+++ b/packages/ag-charts-angular/projects/ag-charts-angular/src/lib/ag-charts.component.spec.ts
@@ -266,7 +266,7 @@ describe('validations.issueRaised zone patching', () => {
 
         expect(patched).not.toBe((host.options as any).validations.issueRaised);
 
-        ngZone.runOutsideAngular(() => patched({ level: 'error', message: 'boom' }));
+        ngZone.runOutsideAngular(() => patched({ severity: 'error', message: 'boom' }));
 
         expect(host.issueRaised.calls).toBe(1);
         expect(host.issueRaised.inZone).toEqual([true]);

--- a/packages/ag-charts-angular/tests/zone-callback-inventory.json
+++ b/packages/ag-charts-angular/tests/zone-callback-inventory.json
@@ -143,7 +143,7 @@
         "classification": "zone-wrap",
         "reason": "Chart listener; re-entered into the zone by patchChartOptions via patchListeners(options.listeners)."
     },
-    "AgChartValidationsOptions.onDiagnosticRaised": {
+    "AgChartValidationsOptions.issueRaised": {
         "classification": "zone-wrap",
         "reason": "Validation issues are dispatched while options are applied, which the wrapper does outside the zone; re-entered into the zone by patchChartOptions."
     },

--- a/packages/ag-charts-community/src/api/agCharts.test.ts
+++ b/packages/ag-charts-community/src/api/agCharts.test.ts
@@ -464,7 +464,7 @@ describe('AgCharts', () => {
             chart = AgCharts.create(undefined as any);
             expectErrorCalls().toHaveLength(1);
             const { validationCollector } = deproxy(chart);
-            validationCollector.setOverlayLevel('error');
+            validationCollector.setOverlaySeverity('error');
             expect(validationCollector.hasVisibleIssues()).toBe(true);
             expect(validationCollector.getVisibleIssues().error).toEqual([
                 { severity: 'error', message: expect.stringMatching(/^AgCharts\.create\(\) requires a non-empty/) },

--- a/packages/ag-charts-community/src/api/agCharts.ts
+++ b/packages/ag-charts-community/src/api/agCharts.ts
@@ -63,7 +63,7 @@ const OPTIONS_ARGUMENT_ISSUE = Symbol('agChartsOptionsArgumentIssue');
  * so the fields named in the message are guidance for the caller, not a stricter requirement.
  *
  * Reported, never thrown: the chart reports it as an `error`-severity validation issue, so it reaches
- * the console, the `validations.overlayLevel` overlay and `validations.issueRaised` like any other
+ * the console, the `validations.overlaySeverity` overlay and `validations.issueRaised` like any other
  * validation error, and a wrapper does not have to translate an exception into its own error channel.
  */
 function optionsArgumentIssue(options: unknown, methodName: string): string | undefined {

--- a/packages/ag-charts-community/src/api/agCharts.ts
+++ b/packages/ag-charts-community/src/api/agCharts.ts
@@ -63,7 +63,7 @@ const OPTIONS_ARGUMENT_ISSUE = Symbol('agChartsOptionsArgumentIssue');
  * so the fields named in the message are guidance for the caller, not a stricter requirement.
  *
  * Reported, never thrown: the chart reports it as an `error`-severity validation issue, so it reaches
- * the console, the `validations.overlayLevel` overlay and `validations.onDiagnosticRaised` like any other
+ * the console, the `validations.overlayLevel` overlay and `validations.issueRaised` like any other
  * validation error, and a wrapper does not have to translate an exception into its own error channel.
  */
 function optionsArgumentIssue(options: unknown, methodName: string): string | undefined {

--- a/packages/ag-charts-community/src/chart/chart.test.ts
+++ b/packages/ag-charts-community/src/chart/chart.test.ts
@@ -2268,7 +2268,7 @@ describe('validations.issueRaised', () => {
         chart.update(ChartUpdateType.FULL);
         await waitForChartStability(chart);
 
-        expect(issueRaised).toHaveBeenCalledWith({ level: 'error', message: thrownError.message });
+        expect(issueRaised).toHaveBeenCalledWith({ severity: 'error', message: thrownError.message });
     });
 });
 
@@ -2297,7 +2297,7 @@ describe('AG-17830 QA — validations.issueRaised', () => {
         ).toThrow(/validations.throwOn: warning/);
 
         expect(issueRaised).toHaveBeenCalledWith({
-            level: 'warning',
+            severity: 'warning',
             message: expect.stringContaining('series[0].strokeWidth'),
         });
         expectWarningsCalls().toHaveLength(1);
@@ -2320,7 +2320,7 @@ describe('AG-17830 QA — validations.issueRaised', () => {
 
         const errorMock = console.error as Mock;
         expect(issueRaised).toHaveBeenCalledWith({
-            level: 'error',
+            severity: 'error',
             message: expect.stringContaining('required modules are not registered'),
         });
         expect(errorMock).toHaveBeenCalledTimes(1);
@@ -2348,7 +2348,7 @@ describe('AG-17830 QA — validations.issueRaised', () => {
         ).rejects.toThrow(/validations.throwOn: warning/);
 
         expect(issueRaised).toHaveBeenCalledWith({
-            level: 'warning',
+            severity: 'warning',
             message: expect.stringContaining('series[0].strokeWidth'),
         });
         expectWarningsCalls().toHaveLength(1);
@@ -2399,7 +2399,7 @@ describe('AG-17830 QA — validations.issueRaised', () => {
 
         expect(outerListener).toHaveBeenCalledTimes(1);
         expect(innerListener).toHaveBeenCalledWith({
-            level: 'warning',
+            severity: 'warning',
             message: expect.stringContaining('series[0].strokeWidth'),
         });
         expectWarningsCalls().toHaveLength(2);
@@ -2492,7 +2492,7 @@ describe('AG-17830 QA — validations.issueRaised', () => {
         );
         boom = false;
 
-        expect(issueRaised).toHaveBeenCalledWith({ level: 'error', message: 'datum exploded' });
+        expect(issueRaised).toHaveBeenCalledWith({ severity: 'error', message: 'datum exploded' });
         (console.error as Mock).mockClear();
     });
 
@@ -2523,7 +2523,7 @@ describe('AG-17830 QA — validations.issueRaised', () => {
         await waitForChartStability(chart);
 
         expect(issueRaised).toHaveBeenCalledWith({
-            level: 'error',
+            severity: 'error',
             message: expect.stringContaining('itemStyler boom'),
         });
         expect(chart.validationCollector.hasVisibleIssues()).toBe(true);

--- a/packages/ag-charts-community/src/chart/chart.test.ts
+++ b/packages/ag-charts-community/src/chart/chart.test.ts
@@ -2231,7 +2231,7 @@ describe('validations.throwOn — runtime errors', () => {
     });
 });
 
-describe('validations.onDiagnosticRaised', () => {
+describe('validations.issueRaised', () => {
     setupMockConsole();
     setupMockCanvas();
 
@@ -2241,7 +2241,7 @@ describe('validations.onDiagnosticRaised', () => {
     });
 
     it('fires for a runtime error caught in tryPerformUpdate(), regardless of consoleLogLevel/overlayLevel', async () => {
-        const onDiagnosticRaised = vi.fn();
+        const issueRaised = vi.fn();
         const thrownError = new Error('processData boom');
 
         const proxy = AgCharts.create({
@@ -2254,7 +2254,7 @@ describe('validations.onDiagnosticRaised', () => {
             validations: {
                 consoleLogLevel: 'none',
                 overlayLevel: 'none',
-                onDiagnosticRaised,
+                issueRaised,
             },
         }) as AgChartProxy;
         chart = deproxy(proxy);
@@ -2268,11 +2268,11 @@ describe('validations.onDiagnosticRaised', () => {
         chart.update(ChartUpdateType.FULL);
         await waitForChartStability(chart);
 
-        expect(onDiagnosticRaised).toHaveBeenCalledWith({ level: 'error', message: thrownError.message });
+        expect(issueRaised).toHaveBeenCalledWith({ level: 'error', message: thrownError.message });
     });
 });
 
-describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
+describe('AG-17830 QA — validations.issueRaised', () => {
     setupMockConsole();
     setupMockCanvas();
 
@@ -2285,18 +2285,18 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
     // AC 3: the listener is never gated by a severity threshold, and `throwOn` is one. The throw
     // unwinds out of `new ChartOptions()`, so the chart never adopts the issues that caused it.
     it('fires on create() for an issue that also trips throwOn', () => {
-        const onDiagnosticRaised = vi.fn();
+        const issueRaised = vi.fn();
 
         expect(() =>
             AgCharts.create({
                 container: document.body,
                 data: [{ x: 'A', y: 10 }],
                 series: [{ type: 'bar', xKey: 'x', yKey: 'y', strokeWidth: 'thick' as any }],
-                validations: { throwOn: 'warning', onDiagnosticRaised },
+                validations: { throwOn: 'warning', issueRaised },
             })
         ).toThrow(/validations.throwOn: warning/);
 
-        expect(onDiagnosticRaised).toHaveBeenCalledWith({
+        expect(issueRaised).toHaveBeenCalledWith({
             level: 'warning',
             message: expect.stringContaining('series[0].strokeWidth'),
         });
@@ -2306,7 +2306,7 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
     // The dropped-module issue is reported to the console by `processModuleOptions`, so it never
     // enters `validationIssues` — the throw path has to dispatch the issue that tripped it.
     it('fires for a dropped-module error that trips throwOn', () => {
-        const onDiagnosticRaised = vi.fn();
+        const issueRaised = vi.fn();
 
         expect(() =>
             AgCharts.create({
@@ -2314,12 +2314,12 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
                 data: [{ x: 'A', y: 10 }],
                 series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
                 zoom: { enabled: true },
-                validations: { throwOn: 'error', onDiagnosticRaised },
+                validations: { throwOn: 'error', issueRaised },
             })
         ).toThrow(/validations.throwOn: error/);
 
         const errorMock = console.error as Mock;
-        expect(onDiagnosticRaised).toHaveBeenCalledWith({
+        expect(issueRaised).toHaveBeenCalledWith({
             level: 'error',
             message: expect.stringContaining('required modules are not registered'),
         });
@@ -2328,17 +2328,17 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
     });
 
     it('fires on update() for an issue that also trips throwOn', async () => {
-        const onDiagnosticRaised = vi.fn();
+        const issueRaised = vi.fn();
         const options: AgCartesianChartOptions = {
             container: document.body,
             data: [{ x: 'A', y: 10 }],
             series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
-            validations: { throwOn: 'warning', onDiagnosticRaised },
+            validations: { throwOn: 'warning', issueRaised },
         };
         const proxy = AgCharts.create(options) as AgChartProxy;
         chart = deproxy(proxy);
         await waitForChartStability(chart);
-        onDiagnosticRaised.mockClear();
+        issueRaised.mockClear();
 
         await expect(
             proxy.update({
@@ -2347,7 +2347,7 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
             })
         ).rejects.toThrow(/validations.throwOn: warning/);
 
-        expect(onDiagnosticRaised).toHaveBeenCalledWith({
+        expect(issueRaised).toHaveBeenCalledWith({
             level: 'warning',
             message: expect.stringContaining('series[0].strokeWidth'),
         });
@@ -2355,7 +2355,7 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
     });
 
     it('a throwing consumer callback does not displace the fail-fast error', () => {
-        const onDiagnosticRaised = vi.fn(() => {
+        const issueRaised = vi.fn(() => {
             throw new Error('consumer boom');
         });
 
@@ -2364,17 +2364,14 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
                 container: document.body,
                 data: [{ x: 'A', y: 10 }],
                 series: [{ type: 'bar', xKey: 'x', yKey: 'y', strokeWidth: 'thick' as any }],
-                validations: { throwOn: 'warning', onDiagnosticRaised },
+                validations: { throwOn: 'warning', issueRaised },
             })
         ).toThrow(/validations.throwOn: warning/);
 
-        expect(onDiagnosticRaised).toHaveBeenCalled();
+        expect(issueRaised).toHaveBeenCalled();
         expectWarningsCalls().toHaveLength(1);
         const errorMock = console.error as Mock;
-        expect(errorMock).toHaveBeenCalledWith(
-            'AG Charts - validations.onDiagnosticRaised threw an error',
-            expect.any(Error)
-        );
+        expect(errorMock).toHaveBeenCalledWith('AG Charts - validations.issueRaised threw an error', expect.any(Error));
         errorMock.mockClear();
     });
 
@@ -2387,7 +2384,7 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
                 container: document.body,
                 data: [{ x: 'A', y: 10 }],
                 series: [{ type: 'bar', xKey: 'x', yKey: 'y', strokeWidth: 'thick' as any }],
-                validations: { throwOn: 'warning', onDiagnosticRaised: innerListener },
+                validations: { throwOn: 'warning', issueRaised: innerListener },
             });
         });
 
@@ -2396,7 +2393,7 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
                 container: document.body,
                 data: [{ x: 'A', y: 10 }],
                 series: [{ type: 'bar', xKey: 'x', yKey: 'y', strokeWidth: 'thick' as any }],
-                validations: { throwOn: 'warning', onDiagnosticRaised: outerListener },
+                validations: { throwOn: 'warning', issueRaised: outerListener },
             })
         ).toThrow(/validations.throwOn: warning/);
 
@@ -2408,10 +2405,7 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
         expectWarningsCalls().toHaveLength(2);
         // The inner chart's own fail-fast error unwinds through the outer listener.
         const errorMock = console.error as Mock;
-        expect(errorMock).toHaveBeenCalledWith(
-            'AG Charts - validations.onDiagnosticRaised threw an error',
-            expect.any(Error)
-        );
+        expect(errorMock).toHaveBeenCalledWith('AG Charts - validations.issueRaised threw an error', expect.any(Error));
         errorMock.mockClear();
     });
 
@@ -2421,15 +2415,15 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
             container: document.body,
             data: [{ x: 'A', y: 10 }],
             series: [{ type: 'bar' as const, xKey: 'x', yKey: 'y', strokeWidth: 'thick' as any }],
-            validations: { throwOn: 'warning' as const, onDiagnosticRaised },
+            validations: { throwOn: 'warning' as const, issueRaised },
         });
-        const onDiagnosticRaised = vi.fn(() => {
+        const issueRaised = vi.fn(() => {
             AgCharts.create(failingOptions());
         });
 
         expect(() => AgCharts.create(failingOptions())).toThrow(/validations.throwOn: warning/);
 
-        expect(onDiagnosticRaised).toHaveBeenCalledTimes(1);
+        expect(issueRaised).toHaveBeenCalledTimes(1);
         expectWarningsCalls().toHaveLength(2);
         (console.error as Mock).mockClear();
     });
@@ -2445,7 +2439,7 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
                 series: [{ type: 'bar', xKey: 'x', yKey: 'y', strokeWidth: 'thick' as any }],
                 validations: {
                     throwOn: 'warning',
-                    onDiagnosticRaised: (event) => {
+                    issueRaised: (event) => {
                         calls.push(event);
                         create();
                     },
@@ -2466,7 +2460,7 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
     // The merge of AG-17831 added a second fail-fast exit — an error escaping option processing — that
     // bypasses `Chart.tryPerformUpdate()`'s catch, so nothing else can tell the listener about it.
     it('reports an error that escapes option processing under an armed throwOn', async () => {
-        const onDiagnosticRaised = vi.fn();
+        const issueRaised = vi.fn();
         let boom = false;
         const rows = [
             { x: 'A', y: 10 },
@@ -2484,12 +2478,12 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
             height: 300,
             data: rows.slice(),
             series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
-            validations: { throwOn: 'error', onDiagnosticRaised },
+            validations: { throwOn: 'error', issueRaised },
         });
 
         const proxy = AgCharts.create(options() as any) as AgChartProxy;
         await proxy.waitForUpdate();
-        onDiagnosticRaised.mockClear();
+        issueRaised.mockClear();
         (console.error as Mock).mockClear();
 
         boom = true;
@@ -2498,14 +2492,14 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
         );
         boom = false;
 
-        expect(onDiagnosticRaised).toHaveBeenCalledWith({ level: 'error', message: 'datum exploded' });
+        expect(issueRaised).toHaveBeenCalledWith({ level: 'error', message: 'datum exploded' });
         (console.error as Mock).mockClear();
     });
 
     // The callbacks run in the render pass that a first-render update-type shortcut restarted, which
     // no longer counts as re-evaluating them — so the buffered error was never committed.
     it('reports a callback that throws on the first render to both the overlay and the listener', async () => {
-        const onDiagnosticRaised = vi.fn();
+        const issueRaised = vi.fn();
 
         const proxy = AgCharts.create({
             container: document.body,
@@ -2523,12 +2517,12 @@ describe('AG-17830 QA — validations.onDiagnosticRaised', () => {
                     },
                 },
             ],
-            validations: { overlayLevel: 'error', onDiagnosticRaised },
+            validations: { overlayLevel: 'error', issueRaised },
         }) as AgChartProxy;
         chart = deproxy(proxy);
         await waitForChartStability(chart);
 
-        expect(onDiagnosticRaised).toHaveBeenCalledWith({
+        expect(issueRaised).toHaveBeenCalledWith({
             level: 'error',
             message: expect.stringContaining('itemStyler boom'),
         });

--- a/packages/ag-charts-community/src/chart/chart.test.ts
+++ b/packages/ag-charts-community/src/chart/chart.test.ts
@@ -2145,7 +2145,7 @@ describe('validations.throwOn — runtime errors', () => {
     });
 
     it('writes the console record and records the overlay issue before rejecting — fail-fast suppresses nothing', async () => {
-        const proxy = AgCharts.create(throwOnOptions({ throwOn: 'error', overlayLevel: 'error' })) as AgChartProxy;
+        const proxy = AgCharts.create(throwOnOptions({ throwOn: 'error', overlaySeverity: 'error' })) as AgChartProxy;
         chart = deproxy(proxy);
         armProcessDataThrow(chart);
 
@@ -2240,7 +2240,7 @@ describe('validations.issueRaised', () => {
         chart?.destroy();
     });
 
-    it('fires for a runtime error caught in tryPerformUpdate(), regardless of consoleLogLevel/overlayLevel', async () => {
+    it('fires for a runtime error caught in tryPerformUpdate(), regardless of consoleLogSeverity/overlaySeverity', async () => {
         const issueRaised = vi.fn();
         const thrownError = new Error('processData boom');
 
@@ -2252,8 +2252,8 @@ describe('validations.issueRaised', () => {
             ],
             series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
             validations: {
-                consoleLogLevel: 'none',
-                overlayLevel: 'none',
+                consoleLogSeverity: 'none',
+                overlaySeverity: 'none',
                 issueRaised,
             },
         }) as AgChartProxy;
@@ -2517,7 +2517,7 @@ describe('AG-17830 QA — validations.issueRaised', () => {
                     },
                 },
             ],
-            validations: { overlayLevel: 'error', issueRaised },
+            validations: { overlaySeverity: 'error', issueRaised },
         }) as AgChartProxy;
         chart = deproxy(proxy);
         await waitForChartStability(chart);

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -36,7 +36,7 @@ import type {
     AgBaseAxisOptions,
     AgChartInstance,
     AgChartOptions,
-    AgChartValidationLevel,
+    AgChartValidationSeverity,
     AgColorType,
     AgCoordinates,
     AgDataTransaction,
@@ -588,7 +588,7 @@ export abstract class Chart implements ModuleInstance, ChartService {
                 if (opts != null) this.overlays.set(opts);
             }),
             ctx.chartState.observe((get) => {
-                this.validationCollector.setOverlayLevel(get('options', 'validations')?.overlayLevel ?? 'none');
+                this.validationCollector.setOverlaySeverity(get('options', 'validations')?.overlaySeverity ?? 'none');
             }),
             // A tooltip is painted in the browser's top layer (a `popover`), so no z-index can place it
             // beneath the validation overlay. Hold tooltips back while the overlay is shown so it stays legible.
@@ -600,10 +600,10 @@ export abstract class Chart implements ModuleInstance, ChartService {
                 }
             }),
             ctx.chartState.observe((get) => {
-                ctx.logger.setLevel(get('options', 'validations')?.consoleLogLevel ?? 'deprecation');
+                ctx.logger.setLevel(get('options', 'validations')?.consoleLogSeverity ?? 'deprecation');
             }),
             ctx.chartState.observe((get) => {
-                this.throwOnLevel = get('options', 'validations')?.throwOn ?? 'none';
+                this.throwOnSeverity = get('options', 'validations')?.throwOn ?? 'none';
                 this.setIssueListener(get('options', 'validations')?.issueRaised);
             }),
             ctx.layoutManager.registerElement(LayoutElement.Caption, (e) => {
@@ -919,7 +919,7 @@ export abstract class Chart implements ModuleInstance, ChartService {
     private readonly updateMutex = new Mutex();
     private clearCallbackCacheOnUpdate: boolean = false;
     private updateRequestors: Record<string, ChartUpdateType> = {};
-    private throwOnLevel: AgChartValidationLevel = 'none';
+    private throwOnSeverity: AgChartValidationSeverity = 'none';
     private pendingFailFastError?: Error;
 
     private readonly performUpdateTrigger = debouncedCallback(({ count }) => {
@@ -1024,7 +1024,7 @@ export abstract class Chart implements ModuleInstance, ChartService {
             });
             this.runningUpdateType = ChartUpdateType.NONE;
             this._performUpdateNotify.notify();
-            if (severityAtOrAbove(this.throwOnLevel, 'error')) {
+            if (severityAtOrAbove(this.throwOnSeverity, 'error')) {
                 this.pendingFailFastError = new Error(
                     `AG Charts - validations.throwOn: error - ${String(error?.message ?? error)}`
                 );

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -604,7 +604,7 @@ export abstract class Chart implements ModuleInstance, ChartService {
             }),
             ctx.chartState.observe((get) => {
                 this.throwOnLevel = get('options', 'validations')?.throwOn ?? 'none';
-                this.setIssueListener(get('options', 'validations')?.onDiagnosticRaised);
+                this.setIssueListener(get('options', 'validations')?.issueRaised);
             }),
             ctx.layoutManager.registerElement(LayoutElement.Caption, (e) => {
                 e.layoutBox.shrink(ctx.chartState.getValue('options', 'padding'));
@@ -1788,9 +1788,9 @@ export abstract class Chart implements ModuleInstance, ChartService {
      * previous tenant's listener in place would hand it this chart's issues. This can also run before
      * the option's validator has, hence the coercion rather than trusting the value.
      */
-    private setIssueListener(onDiagnosticRaised: unknown) {
+    private setIssueListener(issueRaised: unknown) {
         this.validationCollector.setIssueListener(
-            typeof onDiagnosticRaised === 'function' ? (onDiagnosticRaised as ValidationIssueListener) : undefined,
+            typeof issueRaised === 'function' ? (issueRaised as ValidationIssueListener) : undefined,
             this.ctx.logger
         );
     }
@@ -1798,7 +1798,7 @@ export abstract class Chart implements ModuleInstance, ChartService {
     applyOptions(newChartOptions: ChartOptions) {
         // Registered from the same options object in the same statement pair, so this pass's issues
         // reach the listener this pass declared without depending on when chartState observers flush.
-        this.setIssueListener(newChartOptions.processedOptions.validations?.onDiagnosticRaised);
+        this.setIssueListener(newChartOptions.processedOptions.validations?.issueRaised);
         this.validationCollector.setIssues(newChartOptions.validationIssues);
 
         if (newChartOptions.seriesWithUserVisibility) {

--- a/packages/ag-charts-community/src/chart/chartOptionsDefs.ts
+++ b/packages/ag-charts-community/src/chart/chartOptionsDefs.ts
@@ -60,7 +60,7 @@ export const commonChartOptions = {
         overlayLevel: validationLevel,
         consoleLogLevel: validationLevel,
         throwOn: validationLevel,
-        onDiagnosticRaised: callback,
+        issueRaised: callback,
     },
     container: htmlElement,
     context: () => true,

--- a/packages/ag-charts-community/src/chart/chartOptionsDefs.ts
+++ b/packages/ag-charts-community/src/chart/chartOptionsDefs.ts
@@ -29,7 +29,7 @@ import type {
     AgActiveItemState,
     AgActiveState,
     AgCartesianChartOptions,
-    AgChartValidationLevel,
+    AgChartValidationSeverity,
     AgInitialStateLegendOptions,
     AgPolarChartOptions,
     AgSeriesAreaBackgroundRegion,
@@ -49,7 +49,7 @@ export const initialStatePickedOptionsDef: OptionsDefs<AgActiveState> = {
 };
 
 // Exhaustive against the public option type, so neither side can gain a level without the other.
-const validationLevel = strictUnion<AgChartValidationLevel>()('error', 'warning', 'deprecation', 'none');
+const validationSeverity = strictUnion<AgChartValidationSeverity>()('error', 'warning', 'deprecation', 'none');
 
 // These options are being validated by other modules
 export const commonChartOptions = {
@@ -57,9 +57,9 @@ export const commonChartOptions = {
     withinStudio: undocumented(boolean),
     loading: boolean,
     validations: {
-        overlayLevel: validationLevel,
-        consoleLogLevel: validationLevel,
-        throwOn: validationLevel,
+        overlaySeverity: validationSeverity,
+        consoleLogSeverity: validationSeverity,
+        throwOn: validationSeverity,
         issueRaised: callback,
     },
     container: htmlElement,

--- a/packages/ag-charts-community/src/chart/overlay/validationOverlay.test.ts
+++ b/packages/ag-charts-community/src/chart/overlay/validationOverlay.test.ts
@@ -36,11 +36,11 @@ describe('ValidationOverlay', () => {
         }
     });
 
-    describe('#overlayLevel threshold', () => {
+    describe('#overlaySeverity threshold', () => {
         test('warning level renders the overlay with a warnings section and summary, console warning still fires', async () => {
             chart = await createChart({
                 ...invalidStrokeWidthOptions,
-                validations: { overlayLevel: 'warning' },
+                validations: { overlaySeverity: 'warning' },
             } as AgChartOptions);
 
             const overlayEl = chart.ctx.agDocument.body.querySelector('.ag-charts-validation-overlay');
@@ -82,7 +82,7 @@ describe('ValidationOverlay', () => {
         test('error level excludes a warning-severity issue, so no overlay is rendered', async () => {
             chart = await createChart({
                 ...invalidStrokeWidthOptions,
-                validations: { overlayLevel: 'error' },
+                validations: { overlaySeverity: 'error' },
             } as AgChartOptions);
 
             expect(chart.ctx.agDocument.body.querySelector('.ag-charts-validation-overlay')).toBeNull();
@@ -102,7 +102,7 @@ describe('ValidationOverlay', () => {
             chart = await createChart({
                 ...invalidStrokeWidthOptions,
                 data: [],
-                validations: { overlayLevel: 'warning' },
+                validations: { overlaySeverity: 'warning' },
             } as AgChartOptions);
 
             expect(chart.ctx.agDocument.body.querySelector('.ag-charts-validation-overlay')).not.toBeNull();
@@ -124,7 +124,7 @@ describe('ValidationOverlay', () => {
         test('replacing one issue with another re-renders the overlay content while it stays shown', async () => {
             const options = prepareTestOptions({
                 ...invalidStrokeWidthOptions,
-                validations: { overlayLevel: 'warning' },
+                validations: { overlaySeverity: 'warning' },
             } as AgChartOptions);
             const proxy = AgCharts.create(options);
             chart = deproxy(proxy);
@@ -173,7 +173,7 @@ describe('ValidationOverlay', () => {
             const suppressSpy = vi.spyOn(chart.ctx.tooltipManager, 'suppressTooltip');
             const unsuppressSpy = vi.spyOn(chart.ctx.tooltipManager, 'unsuppressTooltip');
 
-            chart.validationCollector.setOverlayLevel('warning');
+            chart.validationCollector.setOverlaySeverity('warning');
             expect(chart.validationCollector.hasVisibleIssues()).toBe(true);
             expect(suppressSpy).toHaveBeenCalledWith('validation-overlay');
             expect(unsuppressSpy).not.toHaveBeenCalled();
@@ -198,7 +198,7 @@ describe('ValidationOverlay', () => {
             try {
                 chart = await createChart({
                     ...invalidStrokeWidthOptions,
-                    validations: { overlayLevel: 'warning' },
+                    validations: { overlaySeverity: 'warning' },
                 } as AgChartOptions);
 
                 expect(chart.validationCollector.hasVisibleIssues()).toBe(true);
@@ -240,7 +240,7 @@ describe('ValidationOverlay', () => {
         test('a throwing itemStyler surfaces one error entry on the overlay and the chart still renders', async () => {
             chart = await createChart({
                 ...throwingItemStylerOptions,
-                validations: { overlayLevel: 'error' },
+                validations: { overlaySeverity: 'error' },
             } as AgChartOptions);
 
             const overlayEl = chart.ctx.agDocument.body.querySelector('.ag-charts-validation-overlay');
@@ -267,7 +267,7 @@ describe('ValidationOverlay', () => {
         test('a still-broken itemStyler stays on the overlay across a cache-hit redraw', async () => {
             chart = await createChart({
                 ...throwingItemStylerOptions,
-                validations: { overlayLevel: 'error' },
+                validations: { overlaySeverity: 'error' },
             } as AgChartOptions);
 
             const errorMessages = () =>
@@ -298,7 +298,7 @@ describe('ValidationOverlay', () => {
         test('dismiss hides the overlay; a subsequent different issue re-shows it', async () => {
             const options = prepareTestOptions({
                 ...invalidStrokeWidthOptions,
-                validations: { overlayLevel: 'warning' },
+                validations: { overlaySeverity: 'warning' },
             } as AgChartOptions);
             const proxy = AgCharts.create(options);
             chart = deproxy(proxy);

--- a/packages/ag-charts-community/src/chart/update/overlaysProcessor.test.ts
+++ b/packages/ag-charts-community/src/chart/update/overlaysProcessor.test.ts
@@ -174,7 +174,7 @@ describe('OverlaysProcessor', () => {
         const { overlays, validationCollector, eventsHub } = build();
         const validationSpy = vi.spyOn(overlays.validation, 'getElement');
 
-        validationCollector.setOverlayLevel('warning');
+        validationCollector.setOverlaySeverity('warning');
         validationCollector.setIssues([{ severity: 'warning', message: 'bad option' }]);
 
         // width/height options shrink the canvas (200x200) below its 800x600 DOM container; the modal
@@ -189,7 +189,7 @@ describe('OverlaysProcessor', () => {
         const { overlays, validationCollector, eventsHub } = build();
         const validationSpy = vi.spyOn(overlays.validation, 'getElement');
 
-        validationCollector.setOverlayLevel('warning');
+        validationCollector.setOverlaySeverity('warning');
         validationCollector.setIssues([{ severity: 'warning', message: 'bad option' }]);
 
         emitLayout(eventsHub, new BBox(0, 0, 800, 600), { width: 800, height: 600 });
@@ -208,7 +208,7 @@ describe('OverlaysProcessor', () => {
         const { overlays, validationCollector, eventsHub } = build();
         const validationSpy = vi.spyOn(overlays.validation, 'getElement');
 
-        validationCollector.setOverlayLevel('error');
+        validationCollector.setOverlaySeverity('error');
         validationCollector.setIssues([{ severity: 'error', message: 'update error' }]);
         emitLayout(eventsHub, new BBox(0, 0, 800, 600), { width: 800, height: 600 });
         expect(overlays.validation.focusBox).toEqual(new BBox(0, 0, 800, 600));

--- a/packages/ag-charts-community/src/chart/validation/validationIssueCollector.test.ts
+++ b/packages/ag-charts-community/src/chart/validation/validationIssueCollector.test.ts
@@ -305,16 +305,16 @@ describe('severityAtOrAbove', () => {
 });
 
 describe('ValidationIssueCollector - issue listener', () => {
-    it('dispatches { level, message } for each severity', () => {
+    it('dispatches { severity, message } for each severity', () => {
         const collector = new ValidationIssueCollector();
         const listener = vi.fn();
         collector.setIssueListener(listener);
 
         collector.setIssues([errorIssue, warningIssue, deprecationIssue]);
 
-        expect(listener).toHaveBeenNthCalledWith(1, { level: 'error', message: errorIssue.message });
-        expect(listener).toHaveBeenNthCalledWith(2, { level: 'warning', message: warningIssue.message });
-        expect(listener).toHaveBeenNthCalledWith(3, { level: 'deprecation', message: deprecationIssue.message });
+        expect(listener).toHaveBeenNthCalledWith(1, { severity: 'error', message: errorIssue.message });
+        expect(listener).toHaveBeenNthCalledWith(2, { severity: 'warning', message: warningIssue.message });
+        expect(listener).toHaveBeenNthCalledWith(3, { severity: 'deprecation', message: deprecationIssue.message });
         expect(listener).toHaveBeenCalledTimes(3);
     });
 
@@ -330,9 +330,9 @@ describe('ValidationIssueCollector - issue listener', () => {
         collector.commitCallbackIssues();
 
         expect(listener).toHaveBeenCalledTimes(3);
-        expect(listener).toHaveBeenNthCalledWith(1, { level: 'warning', message: warningIssue.message });
-        expect(listener).toHaveBeenNthCalledWith(2, { level: 'error', message: errorIssue.message });
-        expect(listener).toHaveBeenNthCalledWith(3, { level: 'deprecation', message: deprecationIssue.message });
+        expect(listener).toHaveBeenNthCalledWith(1, { severity: 'warning', message: warningIssue.message });
+        expect(listener).toHaveBeenNthCalledWith(2, { severity: 'error', message: errorIssue.message });
+        expect(listener).toHaveBeenNthCalledWith(3, { severity: 'deprecation', message: deprecationIssue.message });
     });
 
     it('does not re-dispatch a runtime error the catch site re-reports each failed pass', () => {
@@ -353,8 +353,8 @@ describe('ValidationIssueCollector - issue listener', () => {
 
         collector.setIssues([errorIssue, warningIssue]);
         expect(listener).toHaveBeenCalledTimes(2);
-        expect(listener).toHaveBeenNthCalledWith(1, { level: 'error', message: errorIssue.message });
-        expect(listener).toHaveBeenNthCalledWith(2, { level: 'warning', message: warningIssue.message });
+        expect(listener).toHaveBeenNthCalledWith(1, { severity: 'error', message: errorIssue.message });
+        expect(listener).toHaveBeenNthCalledWith(2, { severity: 'warning', message: warningIssue.message });
 
         listener.mockClear();
         collector.setIssues([errorIssue, warningIssue]);
@@ -362,7 +362,7 @@ describe('ValidationIssueCollector - issue listener', () => {
 
         collector.setIssues([errorIssue, warningIssue, deprecationIssue]);
         expect(listener).toHaveBeenCalledTimes(1);
-        expect(listener).toHaveBeenCalledWith({ level: 'deprecation', message: deprecationIssue.message });
+        expect(listener).toHaveBeenCalledWith({ severity: 'deprecation', message: deprecationIssue.message });
     });
 
     it('dispatches regardless of overlay level and dismissal', () => {
@@ -378,7 +378,7 @@ describe('ValidationIssueCollector - issue listener', () => {
         listener.mockClear();
         collector.setDataIssues([warningIssue]);
         expect(listener).toHaveBeenCalledTimes(1);
-        expect(listener).toHaveBeenCalledWith({ level: 'warning', message: warningIssue.message });
+        expect(listener).toHaveBeenCalledWith({ severity: 'warning', message: warningIssue.message });
     });
 
     it('a throwing listener does not propagate out of the recording call', () => {
@@ -442,8 +442,8 @@ describe('ValidationIssueCollector - issue listener', () => {
         collector.setIssues([errorIssue, warningIssue]);
 
         expect(second).toHaveBeenCalledTimes(2);
-        expect(second).toHaveBeenNthCalledWith(1, { level: 'error', message: errorIssue.message });
-        expect(second).toHaveBeenNthCalledWith(2, { level: 'warning', message: warningIssue.message });
+        expect(second).toHaveBeenNthCalledWith(1, { severity: 'error', message: errorIssue.message });
+        expect(second).toHaveBeenNthCalledWith(2, { severity: 'warning', message: warningIssue.message });
         expect(first).toHaveBeenCalledTimes(2);
     });
 

--- a/packages/ag-charts-community/src/chart/validation/validationIssueCollector.test.ts
+++ b/packages/ag-charts-community/src/chart/validation/validationIssueCollector.test.ts
@@ -405,7 +405,7 @@ describe('ValidationIssueCollector - issue listener', () => {
         collector.setIssues([errorIssue]);
 
         expect(loggerError).toHaveBeenCalledTimes(1);
-        expect(loggerError).toHaveBeenCalledWith('validations.onDiagnosticRaised threw an error', expect.any(Error));
+        expect(loggerError).toHaveBeenCalledWith('validations.issueRaised threw an error', expect.any(Error));
     });
 
     it('a re-entrant listener does not recurse, and its issues are delivered after it returns', () => {

--- a/packages/ag-charts-community/src/chart/validation/validationIssueCollector.test.ts
+++ b/packages/ag-charts-community/src/chart/validation/validationIssueCollector.test.ts
@@ -9,27 +9,27 @@ const warningIssue = { severity: 'warning', message: 'bad option' } as const;
 const deprecationIssue = { severity: 'deprecation', message: 'deprecated thing' } as const;
 
 describe('ValidationIssueCollector', () => {
-    it('shows nothing when overlayLevel is none, regardless of issues', () => {
+    it('shows nothing when overlaySeverity is none, regardless of issues', () => {
         const collector = new ValidationIssueCollector();
         collector.setIssues([errorIssue, warningIssue]);
         expect(collector.hasVisibleIssues()).toBe(false);
     });
 
-    it('applies inclusive threshold semantics (level shows its severity and every louder one)', () => {
+    it('applies inclusive threshold semantics (a threshold admits its severity and every louder one)', () => {
         const collector = new ValidationIssueCollector();
         collector.setIssues([errorIssue, warningIssue, deprecationIssue]);
 
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
         expect(collector.getVisibleIssues()).toEqual({ error: [errorIssue], warning: [], deprecation: [] });
 
-        collector.setOverlayLevel('warning');
+        collector.setOverlaySeverity('warning');
         expect(collector.getVisibleIssues()).toEqual({
             error: [errorIssue],
             warning: [warningIssue],
             deprecation: [],
         });
 
-        collector.setOverlayLevel('deprecation');
+        collector.setOverlaySeverity('deprecation');
         expect(collector.getVisibleIssues()).toEqual({
             error: [errorIssue],
             warning: [warningIssue],
@@ -39,14 +39,14 @@ describe('ValidationIssueCollector', () => {
 
     it('does not show a warning-only collection at the error threshold', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
         collector.setIssues([warningIssue]);
         expect(collector.hasVisibleIssues()).toBe(false);
     });
 
     it('captures a caught runtime error as an error-severity issue', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
         collector.recordRuntimeError({ severity: 'error', message: 'update error', code: 'stack trace' });
         expect(collector.hasVisibleIssues()).toBe(true);
         expect(collector.getVisibleIssues().error).toHaveLength(1);
@@ -54,7 +54,7 @@ describe('ValidationIssueCollector', () => {
 
     it('de-duplicates an identical caught runtime error re-reported on every update pass', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
         const runtimeError = { severity: 'error', message: 'update error', code: 'stack trace' } as const;
 
         // Each resize/layout pass re-runs the update, which re-throws and re-reports the same error.
@@ -67,7 +67,7 @@ describe('ValidationIssueCollector', () => {
 
     it('de-duplicates a re-reported runtime error even when only its code (stack trace) differs', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
 
         collector.recordRuntimeError({ severity: 'error', message: 'update error', code: 'stack A' });
         collector.recordRuntimeError({ severity: 'error', message: 'update error', code: 'stack B' });
@@ -77,7 +77,7 @@ describe('ValidationIssueCollector', () => {
 
     it('keeps distinct caught runtime errors (different message)', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
 
         collector.recordRuntimeError({ severity: 'error', message: 'boom one' });
         collector.recordRuntimeError({ severity: 'error', message: 'boom two' });
@@ -87,7 +87,7 @@ describe('ValidationIssueCollector', () => {
 
     it('keeps a dismissed runtime-error overlay dismissed when the same error re-reports next pass', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
         const runtimeError = { severity: 'error', message: 'update error', code: 'stack trace' } as const;
 
         collector.recordRuntimeError(runtimeError);
@@ -103,7 +103,7 @@ describe('ValidationIssueCollector', () => {
 
     it('does not conflate a caught runtime error with an option issue that shares its severity and message', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
         const shared = { severity: 'error', message: 'boom' } as const;
 
         collector.setIssues([shared]); // an option-validation error
@@ -115,7 +115,7 @@ describe('ValidationIssueCollector', () => {
 
     it('clears a caught runtime error when a fresh option-application cycle sets new issues', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
         collector.recordRuntimeError({ severity: 'error', message: 'update error' });
         expect(collector.getVisibleIssues().error).toHaveLength(1);
 
@@ -126,7 +126,7 @@ describe('ValidationIssueCollector', () => {
 
     it('dismiss hides the overlay; an identical re-apply stays dismissed but a changed one re-shows', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('warning');
+        collector.setOverlaySeverity('warning');
         collector.setIssues([warningIssue]);
         expect(collector.hasVisibleIssues()).toBe(true);
 
@@ -142,7 +142,7 @@ describe('ValidationIssueCollector', () => {
 
     it('re-shows a dismissed issue when only its code changes', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('warning');
+        collector.setOverlaySeverity('warning');
         collector.setIssues([{ severity: 'warning', message: 'bad option', code: 'series[0].a' }]);
         expect(collector.hasVisibleIssues()).toBe(true);
 
@@ -156,7 +156,7 @@ describe('ValidationIssueCollector', () => {
 
     it('surfaces data-feed issues and clears them statelessly when the next cycle is clean', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('warning');
+        collector.setOverlaySeverity('warning');
         const dataIssue = { severity: 'warning', message: "the key 'xyz' was not found in any data element." } as const;
 
         collector.setDataIssues([dataIssue]);
@@ -169,7 +169,7 @@ describe('ValidationIssueCollector', () => {
 
     it('combines option-feed and data-feed issues in the overlay', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('warning');
+        collector.setOverlaySeverity('warning');
         collector.setIssues([warningIssue]);
         const dataIssue = { severity: 'warning', message: 'invalid value of type [object] ignored: [x]' } as const;
         collector.setDataIssues([dataIssue]);
@@ -179,7 +179,7 @@ describe('ValidationIssueCollector', () => {
 
     it('re-shows a dismissed overlay only when the data feed changes', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('warning');
+        collector.setOverlaySeverity('warning');
         const dataIssue = { severity: 'warning', message: 'bad key' } as const;
         collector.setDataIssues([dataIssue]);
         collector.dismiss();
@@ -194,7 +194,7 @@ describe('ValidationIssueCollector', () => {
 
     it('surfaces buffered callback errors as error issues, de-duplicated within a render cycle', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
         const callbackError = {
             severity: 'error',
             message: 'Uncaught exception in user callback `series[0].itemStyler`: boom',
@@ -211,7 +211,7 @@ describe('ValidationIssueCollector', () => {
 
     it('clears callback errors statelessly when the next render cycle no longer throws', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
         const callbackError = { severity: 'error', message: 'Uncaught exception in user callback: boom' } as const;
 
         collector.beginCallbackIssues();
@@ -227,7 +227,7 @@ describe('ValidationIssueCollector', () => {
 
     it('keeps a dismissed callback-error overlay dismissed when the same error re-commits next cycle', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
         const callbackError = { severity: 'error', message: 'Uncaught exception in user callback: boom' } as const;
 
         collector.beginCallbackIssues();
@@ -245,7 +245,7 @@ describe('ValidationIssueCollector', () => {
 
     it('does not re-commit a committed callback error on a pass that buffered nothing new', () => {
         const collector = new ValidationIssueCollector();
-        collector.setOverlayLevel('error');
+        collector.setOverlaySeverity('error');
         const callbackError = { severity: 'error', message: 'Uncaught exception in user callback: boom' } as const;
 
         collector.beginCallbackIssues();
@@ -268,7 +268,7 @@ describe('ValidationIssueCollector', () => {
         const listener = vi.fn();
         collector.addListener(listener);
 
-        collector.setOverlayLevel('warning');
+        collector.setOverlaySeverity('warning');
         collector.setIssues([warningIssue]);
         collector.recordRuntimeError(errorIssue);
         collector.dismiss();
@@ -279,28 +279,28 @@ describe('ValidationIssueCollector', () => {
 
 describe('severityAtOrAbove', () => {
     it.each<{
-        level: 'error' | 'warning' | 'deprecation' | 'none';
+        threshold: 'error' | 'warning' | 'deprecation' | 'none';
         severity: 'error' | 'warning' | 'deprecation';
         expected: boolean;
     }>([
-        // error level admits only error
-        { level: 'error', severity: 'error', expected: true },
-        { level: 'error', severity: 'warning', expected: false },
-        { level: 'error', severity: 'deprecation', expected: false },
-        // warning level admits error and warning
-        { level: 'warning', severity: 'error', expected: true },
-        { level: 'warning', severity: 'warning', expected: true },
-        { level: 'warning', severity: 'deprecation', expected: false },
-        // deprecation level admits all three severities
-        { level: 'deprecation', severity: 'error', expected: true },
-        { level: 'deprecation', severity: 'warning', expected: true },
-        { level: 'deprecation', severity: 'deprecation', expected: true },
-        // none level admits nothing
-        { level: 'none', severity: 'error', expected: false },
-        { level: 'none', severity: 'warning', expected: false },
-        { level: 'none', severity: 'deprecation', expected: false },
-    ])('level=$level, severity=$severity => $expected', ({ level, severity, expected }) => {
-        expect(severityAtOrAbove(level, severity)).toBe(expected);
+        // the error threshold admits only error
+        { threshold: 'error', severity: 'error', expected: true },
+        { threshold: 'error', severity: 'warning', expected: false },
+        { threshold: 'error', severity: 'deprecation', expected: false },
+        // the warning threshold admits error and warning
+        { threshold: 'warning', severity: 'error', expected: true },
+        { threshold: 'warning', severity: 'warning', expected: true },
+        { threshold: 'warning', severity: 'deprecation', expected: false },
+        // the deprecation threshold admits all three severities
+        { threshold: 'deprecation', severity: 'error', expected: true },
+        { threshold: 'deprecation', severity: 'warning', expected: true },
+        { threshold: 'deprecation', severity: 'deprecation', expected: true },
+        // the none threshold admits nothing
+        { threshold: 'none', severity: 'error', expected: false },
+        { threshold: 'none', severity: 'warning', expected: false },
+        { threshold: 'none', severity: 'deprecation', expected: false },
+    ])('threshold=$threshold, severity=$severity => $expected', ({ threshold, severity, expected }) => {
+        expect(severityAtOrAbove(threshold, severity)).toBe(expected);
     });
 });
 
@@ -365,11 +365,11 @@ describe('ValidationIssueCollector - issue listener', () => {
         expect(listener).toHaveBeenCalledWith({ severity: 'deprecation', message: deprecationIssue.message });
     });
 
-    it('dispatches regardless of overlay level and dismissal', () => {
+    it('dispatches regardless of overlay severity and dismissal', () => {
         const collector = new ValidationIssueCollector();
         const listener = vi.fn();
         collector.setIssueListener(listener);
-        collector.setOverlayLevel('none');
+        collector.setOverlaySeverity('none');
 
         collector.setIssues([errorIssue]);
         expect(listener).toHaveBeenCalledTimes(1);

--- a/packages/ag-charts-community/src/chart/validation/validationIssueCollector.ts
+++ b/packages/ag-charts-community/src/chart/validation/validationIssueCollector.ts
@@ -102,7 +102,7 @@ export class ValidationIssueCollector {
                 try {
                     listener({ level: pending.severity, message: pending.message });
                 } catch (error) {
-                    this.issueListenerLogger?.error('validations.onDiagnosticRaised threw an error', error);
+                    this.issueListenerLogger?.error('validations.issueRaised threw an error', error);
                 }
             }
         } finally {

--- a/packages/ag-charts-community/src/chart/validation/validationIssueCollector.ts
+++ b/packages/ag-charts-community/src/chart/validation/validationIssueCollector.ts
@@ -37,7 +37,7 @@ export function severityAtOrAbove(level: ValidationOverlayLevel, severity: Valid
     return LEVEL_INCLUDES[level].includes(severity);
 }
 
-export type ValidationIssueListener = (event: { level: ValidationSeverity; message: string }) => void;
+export type ValidationIssueListener = (event: { severity: ValidationSeverity; message: string }) => void;
 
 function keyOf(issue: ValidationIssue): string {
     return `${issue.severity}:${issue.message}:${issue.code ?? ''}`;
@@ -100,7 +100,7 @@ export class ValidationIssueCollector {
             while (this.pendingDispatch.length > 0) {
                 const pending = this.pendingDispatch.shift()!;
                 try {
-                    listener({ level: pending.severity, message: pending.message });
+                    listener({ severity: pending.severity, message: pending.message });
                 } catch (error) {
                     this.issueListenerLogger?.error('validations.issueRaised threw an error', error);
                 }

--- a/packages/ag-charts-community/src/chart/validation/validationIssueCollector.ts
+++ b/packages/ag-charts-community/src/chart/validation/validationIssueCollector.ts
@@ -3,7 +3,7 @@ import type { Logger } from 'ag-charts-core';
 import { Listeners } from '../../util/listeners';
 
 export type ValidationSeverity = 'error' | 'warning' | 'deprecation';
-export type ValidationOverlayLevel = ValidationSeverity | 'none';
+export type ValidationSeverityThreshold = ValidationSeverity | 'none';
 
 export interface ValidationIssue {
     severity: ValidationSeverity;
@@ -24,8 +24,8 @@ export interface ValidationSink {
 
 export const SEVERITY_ORDER: ValidationSeverity[] = ['error', 'warning', 'deprecation'];
 
-// Inclusive threshold: a level shows its own severity and every louder one ('error' is loudest).
-const LEVEL_INCLUDES: Record<ValidationOverlayLevel, ValidationSeverity[]> = {
+// Inclusive threshold: a threshold admits its own severity and every louder one ('error' is loudest).
+const SEVERITY_INCLUDES: Record<ValidationSeverityThreshold, ValidationSeverity[]> = {
     error: ['error'],
     warning: ['error', 'warning'],
     deprecation: ['error', 'warning', 'deprecation'],
@@ -33,8 +33,8 @@ const LEVEL_INCLUDES: Record<ValidationOverlayLevel, ValidationSeverity[]> = {
 };
 
 /** Inclusive-threshold test shared by the overlay and `validations.throwOn`. */
-export function severityAtOrAbove(level: ValidationOverlayLevel, severity: ValidationSeverity): boolean {
-    return LEVEL_INCLUDES[level].includes(severity);
+export function severityAtOrAbove(threshold: ValidationSeverityThreshold, severity: ValidationSeverity): boolean {
+    return SEVERITY_INCLUDES[threshold].includes(severity);
 }
 
 export type ValidationIssueListener = (event: { severity: ValidationSeverity; message: string }) => void;
@@ -57,7 +57,7 @@ export class ValidationIssueCollector {
     private callbackIssues: ValidationIssue[] = [];
     private pendingCallbackIssues: ValidationIssue[] = [];
     private runtimeIssues: ValidationIssue[] = [];
-    private overlayLevel: ValidationOverlayLevel = 'none';
+    private overlaySeverity: ValidationSeverityThreshold = 'none';
     private dismissed = false;
     private signature = '';
     private readonly listeners = new Listeners<'change', () => void>();
@@ -110,9 +110,9 @@ export class ValidationIssueCollector {
         }
     }
 
-    setOverlayLevel(level: ValidationOverlayLevel) {
-        if (this.overlayLevel === level) return;
-        this.overlayLevel = level;
+    setOverlaySeverity(severity: ValidationSeverityThreshold) {
+        if (this.overlaySeverity === severity) return;
+        this.overlaySeverity = severity;
         this.listeners.dispatch('change');
     }
 
@@ -209,14 +209,14 @@ export class ValidationIssueCollector {
     }
 
     hasVisibleIssues(): boolean {
-        if (this.overlayLevel === 'none' || this.dismissed) return false;
-        return this.allIssues().some((issue) => severityAtOrAbove(this.overlayLevel, issue.severity));
+        if (this.overlaySeverity === 'none' || this.dismissed) return false;
+        return this.allIssues().some((issue) => severityAtOrAbove(this.overlaySeverity, issue.severity));
     }
 
     getVisibleIssues(): GroupedValidationIssues {
         const grouped: GroupedValidationIssues = { error: [], warning: [], deprecation: [] };
         for (const issue of this.allIssues()) {
-            if (severityAtOrAbove(this.overlayLevel, issue.severity)) {
+            if (severityAtOrAbove(this.overlaySeverity, issue.severity)) {
                 grouped[issue.severity].push(issue);
             }
         }

--- a/packages/ag-charts-community/src/module/optionsModule.test.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.test.ts
@@ -4383,10 +4383,10 @@ describe('ChartOptions', () => {
             ...extra,
         }) as AgChartOptions;
 
-    describe('validations.consoleLogLevel', () => {
+    describe('validations.consoleLogSeverity', () => {
         it('silences first-render validation warnings when set to `none`, without silencing validation itself', () => {
             const chartOptions = new ChartOptions(
-                invalidOptions({ validations: { consoleLogLevel: 'none' } }),
+                invalidOptions({ validations: { consoleLogSeverity: 'none' } }),
                 {} as AgChartOptions,
                 {},
                 {},
@@ -4397,7 +4397,7 @@ describe('ChartOptions', () => {
             expect(chartOptions.validationIssues.length).toBeGreaterThan(0);
         });
 
-        it('warns for the same invalid options without a consoleLogLevel override', () => {
+        it('warns for the same invalid options without a consoleLogSeverity override', () => {
             const chartOptions = new ChartOptions(invalidOptions(), {} as AgChartOptions, {}, {}, {});
 
             expect(console.warn).toHaveBeenCalled();
@@ -4406,7 +4406,7 @@ describe('ChartOptions', () => {
 
         it('silences validation warnings when set to `error`', () => {
             const chartOptions = new ChartOptions(
-                invalidOptions({ validations: { consoleLogLevel: 'error' } }),
+                invalidOptions({ validations: { consoleLogSeverity: 'error' } }),
                 {} as AgChartOptions,
                 {},
                 {},
@@ -4417,28 +4417,28 @@ describe('ChartOptions', () => {
             expect(chartOptions.validationIssues.length).toBeGreaterThan(0);
         });
 
-        it('reports an invalid consoleLogLevel value rather than silencing logging with it', () => {
+        it('reports an invalid consoleLogSeverity value rather than silencing logging with it', () => {
             const chartOptions = new ChartOptions(
-                invalidOptions({ validations: { consoleLogLevel: 'verbose' } }),
+                invalidOptions({ validations: { consoleLogSeverity: 'verbose' } }),
                 {} as AgChartOptions,
                 {},
                 {},
                 {}
             );
 
-            expect(chartOptions.validationIssues.some((issue) => issue.code === 'validations.consoleLogLevel')).toBe(
+            expect(chartOptions.validationIssues.some((issue) => issue.code === 'validations.consoleLogSeverity')).toBe(
                 true
             );
             const messages = (console.warn as Mock).mock.calls.map(([m]) => String(m));
-            expect(messages.some((m) => m.includes('validations.consoleLogLevel'))).toBe(true);
+            expect(messages.some((m) => m.includes('validations.consoleLogSeverity'))).toBe(true);
             expect(messages.some((m) => m.includes('notanumber'))).toBe(true);
         });
 
-        it('reports an explicit null consoleLogLevel rather than deferring to a silencing override', () => {
+        it('reports an explicit null consoleLogSeverity rather than deferring to a silencing override', () => {
             const chartOptions = new ChartOptions(
-                invalidOptions({ validations: { consoleLogLevel: null } }),
+                invalidOptions({ validations: { consoleLogSeverity: null } }),
                 {} as AgChartOptions,
-                { validations: { consoleLogLevel: 'none' } } as Partial<AgChartOptions>,
+                { validations: { consoleLogSeverity: 'none' } } as Partial<AgChartOptions>,
                 {},
                 {}
             );
@@ -4450,7 +4450,7 @@ describe('ChartOptions', () => {
 
         it('returns to default logging once a delta update removes a `none` override', () => {
             const base = new ChartOptions(
-                invalidOptions({ validations: { consoleLogLevel: 'none' } }),
+                invalidOptions({ validations: { consoleLogSeverity: 'none' } }),
                 {} as AgChartOptions,
                 {},
                 {},
@@ -4711,9 +4711,9 @@ describe('ChartOptions', () => {
             );
         });
 
-        it('records the issue independently of `consoleLogLevel` silencing the console', () => {
+        it('records the issue independently of `consoleLogSeverity` silencing the console', () => {
             const chartOptions = new ChartOptions(
-                badStrokeWidthOptions({ consoleLogLevel: 'none' }),
+                badStrokeWidthOptions({ consoleLogSeverity: 'none' }),
                 {} as AgChartOptions,
                 {},
                 {},

--- a/packages/ag-charts-community/src/module/optionsModule.test.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.test.ts
@@ -4687,14 +4687,14 @@ describe('ChartOptions', () => {
         });
     });
 
-    describe('validations.onDiagnosticRaised', () => {
+    describe('validations.issueRaised', () => {
         const badStrokeWidthOptions = (validations?: object) =>
             ({
                 series: [{ type: 'line', xKey: 'x', yKey: 'y', strokeWidth: 'notanumber' }],
                 validations,
             }) as unknown as AgChartOptions;
 
-        // `onDiagnosticRaised` is wired up on the `Chart`, absent at this level, so assert on
+        // `issueRaised` is wired up on the `Chart`, absent at this level, so assert on
         // `validationIssues`, the array the listener is fed from.
         it('records an issue whose message matches the console warning content', () => {
             const chartOptions = new ChartOptions(badStrokeWidthOptions(), {} as AgChartOptions, {}, {}, {});
@@ -4729,13 +4729,13 @@ describe('ChartOptions', () => {
             });
         });
 
-        it('rejects a non-function `onDiagnosticRaised` without throwing', () => {
+        it('rejects a non-function `issueRaised` without throwing', () => {
             let chartOptions: ChartOptions | undefined;
             expect(() => {
                 chartOptions = new ChartOptions(
                     {
                         series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
-                        validations: { onDiagnosticRaised: 'not-a-function' as any },
+                        validations: { issueRaised: 'not-a-function' as any },
                     } as AgChartOptions,
                     {} as AgChartOptions,
                     {},
@@ -4747,8 +4747,8 @@ describe('ChartOptions', () => {
             expect(chartOptions!.validationIssues).toContainEqual({
                 severity: 'warning',
                 message:
-                    'Option `validations.onDiagnosticRaised` cannot be set to `"not-a-function"`; expecting a function, ignoring.',
-                code: 'validations.onDiagnosticRaised',
+                    'Option `validations.issueRaised` cannot be set to `"not-a-function"`; expecting a function, ignoring.',
+                code: 'validations.issueRaised',
             });
         });
     });

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -910,7 +910,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         try {
             for (const issue of issues) {
                 try {
-                    listener({ level: issue.severity, message: issue.message });
+                    listener({ severity: issue.severity, message: issue.message });
                 } catch (error) {
                     // A throwing consumer must not displace the fail-fast error the caller is about to get.
                     this.logger.error('validations.issueRaised threw an error', error);

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -308,7 +308,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
 
     private throwOn: AgChartValidationLevel = 'none';
 
-    // `validations.onDiagnosticRaised`, resolved here rather than read off the chart because a fail-fast
+    // `validations.issueRaised`, resolved here rather than read off the chart because a fail-fast
     // throw aborts this constructor: the chart never adopts these issues, so this is the only
     // reference to the listener that survives to report them. See `dispatchIssuesBeforeThrow`.
     private issueListener?: ValidationIssueListener;
@@ -397,9 +397,9 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         // Armed before the first validation pass for the same reason as `throwOn`: an issue raised
         // during `slowSetup()` can abort it, and the listener must already be known to be told.
         this.applyIssueListener(
-            isObjectWithProperty(userValidations, 'onDiagnosticRaised')
-                ? userValidations.onDiagnosticRaised
-                : getValidations(this.processedOverrides)?.onDiagnosticRaised
+            isObjectWithProperty(userValidations, 'issueRaised')
+                ? userValidations.issueRaised
+                : getValidations(this.processedOverrides)?.issueRaised
         );
 
         let activeTheme,
@@ -475,7 +475,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         // State consistency only: this runs after every `record*` call, so it arms nothing this pass.
         this.applyThrowOn(getValidations(this.processedOptions)?.throwOn);
         // As above: re-applied from the merged result so a theme- or preset-supplied listener also counts.
-        this.applyIssueListener(getValidations(this.processedOptions)?.onDiagnosticRaised);
+        this.applyIssueListener(getValidations(this.processedOptions)?.issueRaised);
         this.fastDelta = fastDelta ?? undefined;
         this.themeParameters = themeParameters;
         this.annotationThemes = annotationThemes;
@@ -820,7 +820,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         this.applyConsoleLogLevel(getValidations(this.processedOptions)?.consoleLogLevel);
         // Likewise for the throw threshold and the issue listener.
         this.applyThrowOn(getValidations(this.processedOptions)?.throwOn);
-        this.applyIssueListener(getValidations(this.processedOptions)?.onDiagnosticRaised);
+        this.applyIssueListener(getValidations(this.processedOptions)?.issueRaised);
     }
 
     /** Point wrapped user callbacks at the owning chart's validation sink, so a swallowed throw surfaces. */
@@ -860,7 +860,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
     }
 
     /**
-     * Resolves `validations.onDiagnosticRaised`. This runs before the union validator has, hence the
+     * Resolves `validations.issueRaised`. This runs before the union validator has, hence the
      * coercion rather than trusting the value.
      */
     private applyIssueListener(listener: unknown) {
@@ -869,7 +869,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
 
     /**
      * Reports every issue this pass produced — the accumulated ones plus the `trigger` that tripped
-     * the threshold — to `validations.onDiagnosticRaised` immediately before a fail-fast throw. AC 3: the
+     * the threshold — to `validations.issueRaised` immediately before a fail-fast throw. AC 3: the
      * listener is never gated by a severity threshold, and `throwOn` is a threshold — but the throw
      * unwinds out of this constructor, so `Chart.applyOptions()` never runs
      * and the collector that normally dispatches never receives these issues. Delivering here is what
@@ -913,7 +913,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
                     listener({ level: issue.severity, message: issue.message });
                 } catch (error) {
                     // A throwing consumer must not displace the fail-fast error the caller is about to get.
-                    this.logger.error('validations.onDiagnosticRaised threw an error', error);
+                    this.logger.error('validations.issueRaised threw an error', error);
                 }
             }
         } finally {
@@ -954,7 +954,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
     /**
      * Report an argument that could not be options at all (`create(undefined)`, `create(3)`, an empty
      * object) through the same feed as any option-validation error, so it reaches the console log, the
-     * `validations.overlayLevel` overlay, `validations.onDiagnosticRaised` and `validations.throwOn`. Raised
+     * `validations.overlayLevel` overlay, `validations.issueRaised` and `validations.throwOn`. Raised
      * at `error` severity - unlike a per-option problem, nothing of the caller's intent survives it.
      *
      * Pushed as a new array: the unchanged-options fast path aliases `validationIssues` to the base
@@ -977,7 +977,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
     /**
      * Throws for the first issue whose severity meets the armed `validations.throwOn` threshold — never
      * called before the console record and the overlay push above have already happened, and never
-     * before this pass's issues have reached `validations.onDiagnosticRaised`.
+     * before this pass's issues have reached `validations.issueRaised`.
      */
     private throwIfFailFast(issue: ValidationIssue): void {
         if (this.suppressFailFast || this.throwOn === 'none' || !severityAtOrAbove(this.throwOn, issue.severity)) {
@@ -1008,7 +1008,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         // Console record first, and worded exactly as the unarmed update-loop catch words it, so the
         // two paths read identically in the console.
         this.logger.error('update error', error, error instanceof Error ? error.stack : undefined);
-        // Then `validations.onDiagnosticRaised`, for the same reason the `record*` path dispatches before its
+        // Then `validations.issueRaised`, for the same reason the `record*` path dispatches before its
         // throw (AG-17830 AC 3): this escape bypasses the update loop's catch, so the collector that
         // normally reports a caught runtime error never sees this one. The message is the raw error's,
         // matching both the thrown copy and what the collector would have reported unarmed.

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -49,7 +49,7 @@ import {
 import {
     type AgChartOptions,
     type AgChartThemeParams,
-    type AgChartValidationLevel,
+    type AgChartValidationSeverity,
     type AgChartValidationsOptions,
     type AgMiniChartSeriesOptions,
     type AgPresetOptions,
@@ -89,11 +89,11 @@ import {
 } from './optionsStructuralCache';
 import type { SeriesGrouping } from './seriesGrouping';
 
-/** The default `validations.consoleLogLevel` — everything, including deprecation notices. */
-const DEFAULT_CONSOLE_LOG_LEVEL: AgChartValidationLevel = 'deprecation';
+/** The default `validations.consoleLogSeverity` — everything, including deprecation notices. */
+const DEFAULT_CONSOLE_LOG_SEVERITY: AgChartValidationSeverity = 'deprecation';
 
 /** The default `validations.throwOn` — fail-fast is opt-in, so nothing throws unless a consumer asks for it. */
-const DEFAULT_THROW_ON: AgChartValidationLevel = 'none';
+const DEFAULT_THROW_ON: AgChartValidationSeverity = 'none';
 
 /**
  * A `validations.throwOn` fail-fast throw. Marks the error as already prefixed and already written to
@@ -306,7 +306,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
     // rather than captured, making the adopt order irrelevant.
     private validationSink?: (issue: ValidationIssue) => void;
 
-    private throwOn: AgChartValidationLevel = 'none';
+    private throwOn: AgChartValidationSeverity = 'none';
 
     // `validations.issueRaised`, resolved here rather than read off the chart because a fail-fast
     // throw aborts this constructor: the chart never adopts these issues, so this is the only
@@ -384,10 +384,10 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         // Must precede `slowSetup()`'s first validation pass so a user-supplied `'none'` suppresses the
         // first warning. Keyed on presence, not nullishness, so an explicit `null` still warns.
         const userValidations = getValidations(this.userOptions);
-        this.applyConsoleLogLevel(
-            isObjectWithProperty(userValidations, 'consoleLogLevel')
-                ? userValidations.consoleLogLevel
-                : getValidations(this.processedOverrides)?.consoleLogLevel
+        this.applyConsoleLogSeverity(
+            isObjectWithProperty(userValidations, 'consoleLogSeverity')
+                ? userValidations.consoleLogSeverity
+                : getValidations(this.processedOverrides)?.consoleLogSeverity
         );
         this.applyThrowOn(
             isObjectWithProperty(userValidations, 'throwOn')
@@ -471,7 +471,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
         this.activeTheme = activeTheme;
         this.processedOptions = processedOptions;
         // Re-apply from the merged result so a value arriving via a theme or preset also takes effect.
-        this.applyConsoleLogLevel(getValidations(this.processedOptions)?.consoleLogLevel);
+        this.applyConsoleLogSeverity(getValidations(this.processedOptions)?.consoleLogSeverity);
         // State consistency only: this runs after every `record*` call, so it arms nothing this pass.
         this.applyThrowOn(getValidations(this.processedOptions)?.throwOn);
         // As above: re-applied from the merged result so a theme- or preset-supplied listener also counts.
@@ -816,8 +816,8 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
      */
     adoptLogger(logger: Logger) {
         this.logger = logger;
-        // A pooled chart adopts a different Logger after validation, so the level must be re-applied.
-        this.applyConsoleLogLevel(getValidations(this.processedOptions)?.consoleLogLevel);
+        // A pooled chart adopts a different Logger after validation, so the severity must be re-applied.
+        this.applyConsoleLogSeverity(getValidations(this.processedOptions)?.consoleLogSeverity);
         // Likewise for the throw threshold and the issue listener.
         this.applyThrowOn(getValidations(this.processedOptions)?.throwOn);
         this.applyIssueListener(getValidations(this.processedOptions)?.issueRaised);
@@ -838,25 +838,27 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
     }
 
     /**
-     * Points the Logger at the requested level, falling back to the default for anything unrecognised.
+     * Points the Logger at the requested severity, falling back to the default for anything unrecognised.
      * The fallback is load-bearing: this runs before the union validator has, so an invalid value must
      * not silence the very warning that reports it.
      */
-    private applyConsoleLogLevel(level: unknown) {
-        // Typed as the public option so the two level unions stay pinned to each other at compile time.
-        const consoleLogLevel: AgChartValidationLevel = isLogLevel(level) ? level : DEFAULT_CONSOLE_LOG_LEVEL;
-        this.logger.setLevel(consoleLogLevel);
+    private applyConsoleLogSeverity(severity: unknown) {
+        // Typed as the public option so the two severity unions stay pinned to each other at compile time.
+        const consoleLogSeverity: AgChartValidationSeverity = isLogLevel(severity)
+            ? severity
+            : DEFAULT_CONSOLE_LOG_SEVERITY;
+        this.logger.setLevel(consoleLogSeverity);
     }
 
     /**
      * Resolves `validations.throwOn`, falling back to `'none'` for anything unrecognised. The fallback
-     * direction is the opposite of `applyConsoleLogLevel`'s deliberately: this runs before the union
+     * direction is the opposite of `applyConsoleLogSeverity`'s deliberately: this runs before the union
      * validator has, and an invalid value must not make the chart throw about itself — nor turn
      * fail-fast on for a consumer who never asked for it.
      */
-    private applyThrowOn(level: unknown) {
-        // Reuses `isLogLevel` so a new level cannot be missed by either union.
-        this.throwOn = isLogLevel(level) ? level : DEFAULT_THROW_ON;
+    private applyThrowOn(severity: unknown) {
+        // Reuses `isLogLevel` so a new severity cannot be missed by either union.
+        this.throwOn = isLogLevel(severity) ? severity : DEFAULT_THROW_ON;
     }
 
     /**
@@ -954,7 +956,7 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
     /**
      * Report an argument that could not be options at all (`create(undefined)`, `create(3)`, an empty
      * object) through the same feed as any option-validation error, so it reaches the console log, the
-     * `validations.overlayLevel` overlay, `validations.issueRaised` and `validations.throwOn`. Raised
+     * `validations.overlaySeverity` overlay, `validations.issueRaised` and `validations.throwOn`. Raised
      * at `error` severity - unlike a per-option problem, nothing of the caller's intent survives it.
      *
      * Pushed as a new array: the unchanged-options fast path aliases `validationIssues` to the base

--- a/packages/ag-charts-core/src/logging/logger.ts
+++ b/packages/ag-charts-core/src/logging/logger.ts
@@ -3,7 +3,7 @@
 // Minimum console severity a Logger emits (higher = quieter); the default of 0 admits every message.
 const SEVERITY = { deprecation: 1, warn: 2, error: 3 } as const;
 
-/** The public `validations.consoleLogLevel` scale, as an inclusive threshold. */
+/** The public `validations.consoleLogSeverity` scale, as an inclusive threshold. */
 export type LogLevel = 'deprecation' | 'warning' | 'error' | 'none';
 
 const LEVEL_SEVERITY: Record<LogLevel, number> = {

--- a/packages/ag-charts-types/src/chart/chartOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartOptions.ts
@@ -418,5 +418,5 @@ export interface AgChartValidationsOptions {
      *
      * Default: `undefined`
      */
-    onDiagnosticRaised?: (event: AgChartValidationIssueEvent) => void;
+    issueRaised?: (event: AgChartValidationIssueEvent) => void;
 }

--- a/packages/ag-charts-types/src/chart/chartOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartOptions.ts
@@ -378,7 +378,7 @@ export type AgChartValidationLevel = 'error' | 'warning' | 'deprecation' | 'none
 /** A single validation problem reported by the chart. */
 export interface AgChartValidationIssueEvent {
     /** The severity of the problem. */
-    level: 'error' | 'warning' | 'deprecation';
+    severity: 'error' | 'warning' | 'deprecation';
     /** A description of the problem, the same text reported to the console and the validation overlay. */
     message: string;
 }

--- a/packages/ag-charts-types/src/chart/chartOptions.ts
+++ b/packages/ag-charts-types/src/chart/chartOptions.ts
@@ -370,10 +370,10 @@ export interface AgBaseChartOptions<
 }
 
 /**
- * The severity of validation problem to report, as an inclusive threshold: each level also reports
- * every louder level. `'none'` reports nothing.
+ * The severity of validation problem to report, as an inclusive threshold: each severity also
+ * reports every louder one. `'none'` reports nothing.
  */
-export type AgChartValidationLevel = 'error' | 'warning' | 'deprecation' | 'none';
+export type AgChartValidationSeverity = 'error' | 'warning' | 'deprecation' | 'none';
 
 /** A single validation problem reported by the chart. */
 export interface AgChartValidationIssueEvent {
@@ -392,13 +392,13 @@ export interface AgChartValidationsOptions {
      *
      * Default: `'deprecation'`
      */
-    consoleLogLevel?: AgChartValidationLevel;
+    consoleLogSeverity?: AgChartValidationSeverity;
     /**
      * The minimum severity of validation problem to report in an overlay on the chart itself.
      *
      * Default: `'none'`
      */
-    overlayLevel?: AgChartValidationLevel;
+    overlaySeverity?: AgChartValidationSeverity;
     /**
      * The minimum severity of validation problem that causes the chart to throw instead of warning
      * and falling back to a default. `'none'` never throws, matching the behaviour of charts that do
@@ -409,12 +409,12 @@ export interface AgChartValidationsOptions {
      *
      * Default: `'none'`
      */
-    throwOn?: AgChartValidationLevel;
+    throwOn?: AgChartValidationSeverity;
     /**
      * Called for each validation problem the chart raises — an invalid option value or a runtime error
      * caught during a chart update. The reported problems are the same set the validation overlay
      * shows, not every diagnostic the chart can write to the console. Never gated by
-     * `consoleLogLevel` or `overlayLevel`.
+     * `consoleLogSeverity` or `overlaySeverity`.
      *
      * Default: `undefined`
      */

--- a/packages/ag-charts-website/src/content/docs/dev-validation/_examples/validation-overlay-dark/main.ts
+++ b/packages/ag-charts-website/src/content/docs/dev-validation/_examples/validation-overlay-dark/main.ts
@@ -37,7 +37,7 @@ const options: AgCartesianChartOptions = {
         y: { type: 'number' },
     },
     validations: {
-        overlayLevel: 'warning',
+        overlaySeverity: 'warning',
     },
 };
 

--- a/packages/ag-charts-website/src/content/docs/dev-validation/_examples/validation-overlay-multi/main.ts
+++ b/packages/ag-charts-website/src/content/docs/dev-validation/_examples/validation-overlay-multi/main.ts
@@ -36,7 +36,7 @@ const options: AgCartesianChartOptions = {
         y: { type: 'number' },
     },
     validations: {
-        overlayLevel: 'warning',
+        overlaySeverity: 'warning',
     },
 };
 

--- a/packages/ag-charts-website/src/content/docs/dev-validation/_examples/validation-overlay/main.ts
+++ b/packages/ag-charts-website/src/content/docs/dev-validation/_examples/validation-overlay/main.ts
@@ -35,7 +35,7 @@ const options: AgCartesianChartOptions = {
         y: { type: 'number' },
     },
     validations: {
-        overlayLevel: 'warning',
+        overlaySeverity: 'warning',
     },
 };
 

--- a/packages/ag-charts-website/src/content/docs/dev-validation/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/dev-validation/index.mdoc
@@ -6,19 +6,19 @@ Option misconfiguration and caught runtime errors are normally reported only to 
 
 ## Validation Overlay
 
-The overlay is opt-in and intended for development. Enable it with `validations.overlayLevel`, which defaults to `'none'`:
+The overlay is opt-in and intended for development. Enable it with `validations.overlaySeverity`, which defaults to `'none'`:
 
 {% chartExampleRunner title="Validation Overlay" name="validation-overlay" type="generated" /%}
 
 ```js format="snippet"
 {
     validations: {
-        overlayLevel: 'warning',
+        overlaySeverity: 'warning',
     },
 }
 ```
 
-`overlayLevel` is an inclusive severity threshold: each level also shows every louder one.
+`overlaySeverity` is an inclusive threshold: each severity also shows every louder one.
 
 - `'error'` — errors only.
 - `'warning'` — errors and warnings.


### PR DESCRIPTION
## Summary
- Renames the public option `validations.onDiagnosticRaised` to `validations.issueRaised`
- Renames the validation issue event's `level` field to `severity`
- Renames the validations severity threshold options to match

Clean recreation of #8010 based on the latest `b14.2.0`, containing only the three original `AG-17830` commits (the prior PR accumulated an unrelated merge conflict resolution in `donutSeries.ts` and was failing CI).

## Test plan
- [x] `yarn nx build:types` passes for ag-charts-community, ag-charts-types, ag-charts-core
- [x] `yarn nx lint` passes for ag-charts-community, ag-charts-types, ag-charts-core
- [x] `yarn nx format` — no changes