### PR TITLE
SE-182 Serve a real robots.txt in production for the charts site

### DIFF
--- a/packages/ag-charts-website/src/pages/robots.txt.ts
+++ b/packages/ag-charts-website/src/pages/robots.txt.ts
@@ -1,14 +1,13 @@
 import { getIsStaging } from '@utils/env';
 
+import { CHARTS_SITE_URL } from '../constants';
+
 const disallowAllRobotsTxt = () => 'User-agent: *\nDisallow: /';
 
-export function GET() {
-    // Only generate robots.txt in staging environments
-    if (!getIsStaging()) {
-        return new Response('Not Found', { status: 404 });
-    }
+const productionRobotsTxt = () => `User-agent: *\nAllow: /\n\nSitemap: ${CHARTS_SITE_URL}/sitemap-0.xml`;
 
-    const output = disallowAllRobotsTxt();
+export function GET() {
+    const output = getIsStaging() ? disallowAllRobotsTxt() : productionRobotsTxt();
 
     return new Response(output, {
         status: 200,


### PR DESCRIPTION
## Summary
- Same fix as the b14.2.0 PR, applied to the b14.1.0 line: `charts.ag-grid.com/robots.txt` and `www.ag-grid.com/charts/robots.txt` currently return HTTP 200 with body `Not Found` — a soft-404, because `robots.txt.ts` only generates real content on staging and returns a `404` Response for production, which Astro's static export bakes into a served file with the literal body text but a real 200 status.
- Adds `productionRobotsTxt()`, a minimal valid robots.txt (`Allow: /` plus a `Sitemap:` reference) served in production, alongside the existing staging behaviour.
- Deliberately does not add `Disallow: /archive/` here — that's gated on Search Console confirming the archived pages have dropped from the index first.

