### PR TITLE
SE-186 Redirect /charts/sitemap.xml to the generated sitemap-0.xml

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/packages/ag-charts-website/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -70,6 +70,7 @@ RedirectMatch 301 "^/charts/angular/?$" "/charts/angular/quick-start/"
 Redirect 301 /charts/javascript/toolbar/ /charts/javascript/financial-charts-toolbar/
 Redirect 301 /charts/react/toolbar/ /charts/react/financial-charts-toolbar/
 Redirect 301 /charts/react/line/ /charts/react/line-series/
+Redirect 301 /charts/sitemap.xml /charts/sitemap-0.xml
 RedirectMatch 301 "^/charts/archive/?$" "/charts/documentation-archive/"
 RedirectMatch 410 "^/charts/privacy(/.*)?$"
 RedirectMatch 301 "^/charts/javascript-charts/javascript/(.+)$" "/charts/javascript/$1"
@@ -106,6 +107,7 @@ RedirectMatch 301 "^/charts/angular/?$" "/charts/angular/quick-start/"
 Redirect 301 /charts/javascript/toolbar/ /charts/javascript/financial-charts-toolbar/
 Redirect 301 /charts/react/toolbar/ /charts/react/financial-charts-toolbar/
 Redirect 301 /charts/react/line/ /charts/react/line-series/
+Redirect 301 /charts/sitemap.xml /charts/sitemap-0.xml
 RedirectMatch 301 "^/charts/archive/?$" "/charts/documentation-archive/"
 RedirectMatch 410 "^/charts/privacy(/.*)?$"
 RedirectMatch 301 "^/charts/javascript-charts/javascript/(.+)$" "/charts/javascript/$1"
@@ -193,6 +195,7 @@ RedirectMatch 301 "^/charts/angular/?$" "/charts/angular/quick-start/"
 Redirect 301 /charts/javascript/toolbar/ /charts/javascript/financial-charts-toolbar/
 Redirect 301 /charts/react/toolbar/ /charts/react/financial-charts-toolbar/
 Redirect 301 /charts/react/line/ /charts/react/line-series/
+Redirect 301 /charts/sitemap.xml /charts/sitemap-0.xml
 RedirectMatch 301 "^/charts/archive/?$" "/charts/documentation-archive/"
 RedirectMatch 410 "^/charts/privacy(/.*)?$"
 RedirectMatch 301 "^/charts/javascript-charts/javascript/(.+)$" "/charts/javascript/$1"

--- a/packages/ag-charts-website/src/utils/htaccess/redirects.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/redirects.ts
@@ -33,6 +33,10 @@ export const SITE_301_REDIRECTS: Redirect[] = [
     { from: '/react/toolbar/', to: '/react/financial-charts-toolbar/' },
     { from: '/react/line/', to: '/react/line-series/' },
 
+    // SE-186: this build only ever generates sitemap-0.xml; the conventional /sitemap.xml is
+    // never emitted, so crawlers probing it by convention (e.g. Bing) 404.
+    { from: '/sitemap.xml', to: '/sitemap-0.xml' },
+
     // --- SE-61: legacy AG Charts URLs that currently 404 ---
     // Rules are BASE-RELATIVE; getRedirectRules() splices in the /charts base for both pattern and target.
     // RedirectMatch is first-match-wins, so order is load-bearing: specific before broad.

--- a/packages/ag-charts-website/src/utils/htaccess/redirects.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/redirects.ts
@@ -12,7 +12,9 @@ export type Redirect = SimpleRedirectRule | RedirectMatchRule | GoneRule;
  */
 export const REDIRECTS_FILE = 'packages/ag-charts-website/src/utils/htaccess/redirects.ts';
 
-export const IGNORE_PAGES = [];
+// redirectsChecker assumes every non-trailing-slash target is a directory containing
+// index.html; sitemap-0.xml is a flat file, so it must be excluded from that check.
+export const IGNORE_PAGES = ['/sitemap-0.xml'];
 
 export const SITE_301_REDIRECTS: Redirect[] = [
     { from: '/javascript/bullet-series', to: '/javascript/linear-gauge/#bullet-series' },


### PR DESCRIPTION
## Summary
- Same fix as the b14.2.0 PR, applied to the b14.1.0 line: `www.ag-grid.com/charts/sitemap.xml` 404s — this build only ever generates `sitemap-0.xml` (the standard Astro sitemap integration output), never a plain `sitemap.xml`. Crawlers (notably Bing) still probe the conventional location.
- This also breaks the legacy `charts.ag-grid.com/sitemap.xml`, which redirects here and dead-ends.
- Adds `{ from: '/sitemap.xml', to: '/sitemap-0.xml' }` to `SITE_301_REDIRECTS` — base-relative, so it emits as `/charts/sitemap.xml` → `/charts/sitemap-0.xml` under the pinned `/charts` base.
- Updated the 3 `htaccessRules.test.ts` snapshots (production/staging/redirect-rules-only) for the one new line.

## Test plan
- [x] `yarn nx test ag-charts-website` — passes; one pre-existing, unrelated failure in `markdownPages.test.ts`
- [x] `yarn nx lint ag-charts-website` — clean (pre-existing warnings only)