### PR TITLE
AG-3390 Stop charts page verification waiting on third-party tags

### DIFF
--- a/packages/ag-charts-website/e2e/page-verification.spec.ts
+++ b/packages/ag-charts-website/e2e/page-verification.spec.ts
@@ -238,7 +238,33 @@ test.describe('Page Verification', () => {
             const body = (await response.text()).replace('</head>', `<script>${CSP_SELF_CHECK_SCRIPT}</script></head>`);
             await route.fulfill({ response, body });
         });
-        await page.reload();
+        // 'commit' for the same reason gotoUrl uses it: the reloaded page carries the same
+        // third-party tags, and waiting for its load event puts a vendor back on the path.
+        await page.reload({ waitUntil: 'commit' });
+        // 'commit' resolves before the parser has reached the injected <script>, so wait for the
+        // document to finish parsing - readyState leaves 'loading' ahead of the deferred scripts
+        // that block DOMContentLoaded.
+        await page.waitForFunction(() => document.readyState !== 'loading');
+        // The violation and the hash hint arrive over an exposeBinding round-trip and a console
+        // message, so wait for both rather than assuming they landed as parsing finished.
+        await expect
+            .poll(
+                () => {
+                    const recorded = annotations
+                        .slice(beforeInjection)
+                        .filter(
+                            (annotation) =>
+                                annotation.type === CSP_VIOLATION_ANNOTATION ||
+                                annotation.type === CSP_HASH_HINT_ANNOTATION
+                        );
+                    return {
+                        violation: recorded.some((a) => a.type === CSP_VIOLATION_ANNOTATION),
+                        hashHint: recorded.some((a) => a.type === CSP_HASH_HINT_ANNOTATION),
+                    };
+                },
+                { message: 'the blocked inline script reported a violation and a hash hint' }
+            )
+            .toEqual({ violation: true, hashHint: true });
 
         // Only the injected reload's violations are synthetic; the first navigation's are real and
         // stay in the report.

--- a/packages/ag-charts-website/e2e/util.ts
+++ b/packages/ag-charts-website/e2e/util.ts
@@ -258,7 +258,21 @@ export async function repeat(repCount: number, fn: () => void | Promise<void>): 
 const NETWORK_IDLE_TIMEOUT_MS = 5_000;
 
 export async function gotoUrl(page: Page, url: string) {
-    await page.goto(url);
+    // 'commit' rather than Playwright's default 'load'. The load event does not fire until every
+    // subresource in the document's delay-the-load-event set has settled, and on the deployed site
+    // that set reaches hosts nobody here controls - plausible.io and Google Tag Manager are on
+    // every page. One slow vendor otherwise times out a navigation to a page that rendered
+    // perfectly well: post-deploy verification lost 15 navigations that way on 2 September 2026,
+    // every one of them "waiting until load" against a site that was serving correctly.
+    //
+    // 'domcontentloaded' would not be enough - the Plausible tag is `defer`, and deferred scripts
+    // block DOMContentLoaded too. The bounded networkidle wait below is what settles the page, and
+    // a page that does settle still reaches it, so nothing here loosens for a healthy page.
+    await page.goto(url, { waitUntil: 'commit' });
+    // The title assertion reads the parsed document, and 'commit' resolves before the parser has
+    // reached <title>. readyState leaves 'loading' at the end of parsing, ahead of the deferred
+    // scripts that block DOMContentLoaded, so this waits for the document, not for a vendor.
+    await page.waitForFunction(() => document.readyState !== 'loading');
     await page.waitForLoadState('networkidle', { timeout: NETWORK_IDLE_TIMEOUT_MS }).catch(() => {});
     expect(await page.title()).not.toMatch(/Page Not Found/);
 }

--- a/packages/ag-charts-website/playwright.staging.config.ts
+++ b/packages/ag-charts-website/playwright.staging.config.ts
@@ -36,6 +36,11 @@ export default defineConfig({
     use: {
         ignoreHTTPSErrors: true,
         trace: 'on-first-retry',
+        // Well under the 30s test timeout, so a navigation that really is stuck fails naming the
+        // URL that never committed rather than spending the whole test budget to report only
+        // "Test timeout of 30000ms exceeded". gotoUrl navigates on 'commit', so reaching this at
+        // all means the document itself never arrived - a genuine site failure, not a slow tag.
+        navigationTimeout: 20_000,
     },
     projects: [
         {


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-3390

Port of ag-grid#15072.

**Problem.** Playwright's default `waitUntil: 'load'` does not resolve until every subresource in the document's delay-the-load-event set has settled. On charts-staging that set reaches hosts nobody here controls — plausible.io and Google Tag Manager are on every page — so one slow vendor times out a navigation to a page that rendered perfectly well. The post-deploy run on 2 September lost 15 navigations that way, every one of them "waiting until load" against a site that was serving correctly.

`domcontentloaded` would not fix it: the Plausible tag is `defer`, and deferred scripts block DOMContentLoaded too. `gotoUrl` now navigates on `'commit'` and lets the existing bounded `networkidle` wait settle the page, so a healthy page behaves exactly as before and only a page that can never settle proceeds instead of hanging.

**Verified** against charts-staging: 128 passed in 38.7s normally, and 128 passed in 41.0s with plausible.io, googletagmanager.com, enzuzo.com, img.youtube.com and img.shields.io all stalled indefinitely. That stall test is also what caught the CSP self-check's `page.reload()`, which needed the same treatment.

Draft until ag-grid#15072 lands and has been observed on a real post-deploy run — no point replicating the approach into a second repo before the first one is proven in CI.
