### PR TITLE
Upgrade npm in the package-test container to unblock ng new

### DIFF
--- a/tests/shared/run.sh
+++ b/tests/shared/run.sh
@@ -143,6 +143,13 @@ fi
 
 npm config set cache ${project}/.npm-cache
 
+if [[ ${mode} == "container" ]] ; then
+    # The Playwright image ships npm 10.9, whose resolver crashes with "Cannot read properties of null
+    # (reading 'edgesOut')" on the vitest 4.x peer set that `ng new` installs. npm 11 resolves it.
+    echo ">>> npm i -g npm@11"
+    npm i -g npm@11
+fi
+
 if [[ ${test_type} == "ssr" ]] ; then
     install_fw
     echo ">>> npm i ${ssr_test_deps}"


### PR DESCRIPTION
The Framework Package Tests (angular) job fails on every b14.2.0 push since 3 Sept 12:22 UTC, blocking #8037. Inside the `mcr.microsoft.com/playwright:v1.52.0` container, `ng new` runs `npm install` with npm 10.9.2, whose resolver crashes with `Cannot read properties of null (reading 'edgesOut')` on the `vitest@^4.0.8` peer set now that the vitest 5.0.0 family exists on the registry. Reproduced in the same image: `vitest@4.0.x` installs, `4.1.x` crashes, npm 11 installs it cleanly.

`tests/shared/run.sh` now runs `npm i -g npm@11` after configuring the npm cache, guarded to container mode so native (`-n`) runs do not touch the host's npm. npm 11 rather than 12 because the image ships Node 22.14 and npm 12 requires 22.22+.

Verified locally with `yarn nx run angular-package-tests:test:package:modules:local-latest`, the previously failing target, which now passes end to end.