### PR TITLE
SE-186 Drop the sitemap.xml redirect for archive builds

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/htaccessRules.test.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/htaccessRules.test.ts
@@ -185,6 +185,46 @@ describe('htaccessRules redirects (SE-60/SE-61)', () => {
         expect(Object.keys(astro).some((k) => k.includes('archive') || k.includes('privacy'))).toBe(false);
         expect(Object.keys(astro).some((k) => k.includes('(.*)'))).toBe(false);
     });
+
+    it('emits the SE-186 sitemap.xml redirect for a normal (non-archive) build', () => {
+        expect(rules).toContain(`Redirect 301 ${base}/sitemap.xml ${base}/sitemap-0.xml`);
+        expect(getAstroRedirectRules()).toMatchObject({ '/sitemap.xml': `${base}/sitemap-0.xml` });
+    });
+});
+
+describe('htaccessRules redirects (SE-186): archive builds never generate sitemap-0.xml', () => {
+    // Archive builds omit the `sitemap()` integration (see astro.config.mjs), so a redirect
+    // whose target is that generated file must not be emitted there either — it would 301 to a
+    // file the archive build never produces, and the link checker (correctly) flags the
+    // resulting broken anchor.
+    beforeEach(() => {
+        vi.resetModules();
+        vi.doMock('../../constants', async (importActual) => {
+            const actual = await importActual<typeof import('../../constants')>();
+            return { ...actual, SITE_BASE_URL: '/charts/archive/14.1.0/' };
+        });
+    });
+
+    afterEach(() => {
+        vi.doUnmock('../../constants');
+    });
+
+    it('drops the sitemap.xml redirect from the generated .htaccess', async () => {
+        const archiveHtaccessRules = await import('./htaccessRules');
+        expect(archiveHtaccessRules.getRedirectRules()).not.toContain('sitemap.xml');
+    });
+
+    it('drops the sitemap.xml redirect from the Astro redirect map', async () => {
+        const archiveHtaccessRules = await import('./htaccessRules');
+        expect(archiveHtaccessRules.getAstroRedirectRules()).not.toHaveProperty('/sitemap.xml');
+    });
+
+    it('keeps unrelated redirects', async () => {
+        const archiveHtaccessRules = await import('./htaccessRules');
+        expect(archiveHtaccessRules.getRedirectRules()).toContain(
+            '/charts/archive/14.1.0/react/line/ /charts/archive/14.1.0/react/line-series/'
+        );
+    });
 });
 
 describe('htaccessRules markdown content negotiation', () => {

--- a/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
@@ -5,7 +5,7 @@ import { markdownPathAlternation } from '../markdownPages';
 import { urlWithBaseUrl } from '../urlWithBaseUrl';
 import type { CspEnv } from './cspRules';
 import { getCspHtaccessBlock, getScopedCspHtaccessBlock } from './cspRules';
-import { SITE_301_REDIRECTS, type SimpleRedirectRule } from './redirects';
+import { type Redirect, SITE_301_REDIRECTS, type SimpleRedirectRule } from './redirects';
 
 export type HtaccessEnv = Extract<CspEnv, 'staging' | 'production'>;
 
@@ -58,6 +58,15 @@ function getCspContent(env: HtaccessEnv): string {
 ${getScopedCspHtaccessBlock({ env }, 'report-only')}`;
 }
 
+// Archive builds omit the `sitemap()` integration (see astro.config.mjs) and are the only
+// builds whose base URL carries `archive`, so this is the same signal used there.
+const isArchiveBuild = () => (SITE_BASE_URL ?? '').includes('archive');
+
+const dropArchiveOnlyRedirects = (redirects: Redirect[]) =>
+    isArchiveBuild()
+        ? redirects.filter((redirect) => !(redirect as { skipForArchive?: true }).skipForArchive)
+        : redirects;
+
 export function getRedirectRules() {
     // mod_alias `RedirectMatch` matches against the full request URL-path (e.g. `/charts/react/`),
     // even when the .htaccess lives inside the base folder — unlike mod_rewrite, it does not strip
@@ -67,29 +76,30 @@ export function getRedirectRules() {
     const basePath = (SITE_BASE_URL ?? '').replace(/\/$/, '');
     const toBaseAwarePattern = (fromPattern: string) =>
         fromPattern.startsWith('^') ? `^${basePath}${fromPattern.slice(1)}` : `${basePath}${fromPattern}`;
-    return `${SITE_301_REDIRECTS.map((redirect) => {
-        const { from, fromPattern, to, gone } = redirect as any;
-        if (!from && !fromPattern) {
-            // eslint-disable-next-line no-console
-            console.warn('Missing `from` in redirect', redirect);
-            return;
-        }
-        // 410 Gone: permanently removed, no target.
-        if (gone) {
-            return from
-                ? `Redirect 410 ${urlWithBaseUrl(from)}`
-                : `RedirectMatch 410 "${toBaseAwarePattern(fromPattern)}"`;
-        }
-        if (!to) {
-            // eslint-disable-next-line no-console
-            console.warn('Missing `to` in redirect', redirect);
-            return;
-        }
-        if (from) {
-            return `Redirect 301 ${urlWithBaseUrl(from)} ${urlWithBaseUrl(to)}`;
-        }
-        return `RedirectMatch 301 "${toBaseAwarePattern(fromPattern)}" "${urlWithBaseUrl(to)}"`;
-    })
+    return `${dropArchiveOnlyRedirects(SITE_301_REDIRECTS)
+        .map((redirect) => {
+            const { from, fromPattern, to, gone } = redirect as any;
+            if (!from && !fromPattern) {
+                // eslint-disable-next-line no-console
+                console.warn('Missing `from` in redirect', redirect);
+                return;
+            }
+            // 410 Gone: permanently removed, no target.
+            if (gone) {
+                return from
+                    ? `Redirect 410 ${urlWithBaseUrl(from)}`
+                    : `RedirectMatch 410 "${toBaseAwarePattern(fromPattern)}"`;
+            }
+            if (!to) {
+                // eslint-disable-next-line no-console
+                console.warn('Missing `to` in redirect', redirect);
+                return;
+            }
+            if (from) {
+                return `Redirect 301 ${urlWithBaseUrl(from)} ${urlWithBaseUrl(to)}`;
+            }
+            return `RedirectMatch 301 "${toBaseAwarePattern(fromPattern)}" "${urlWithBaseUrl(to)}"`;
+        })
         .filter(Boolean)
         .join('\n')}`;
 }
@@ -143,7 +153,7 @@ export function getMarkdownNegotiationRules() {
 
 export function getAstroRedirectRules(): AstroUserConfig['redirects'] {
     // Only for simple redirects, not pattern matches. Gone rules have no `to`, so skip them.
-    const simpleRedirects = SITE_301_REDIRECTS.filter(
+    const simpleRedirects = dropArchiveOnlyRedirects(SITE_301_REDIRECTS).filter(
         (redirect) => Boolean((redirect as SimpleRedirectRule).from) && !(redirect as { gone?: true }).gone
     ) as SimpleRedirectRule[];
 

--- a/packages/ag-charts-website/src/utils/htaccess/redirects.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/redirects.ts
@@ -1,4 +1,13 @@
-export type SimpleRedirectRule = { from: string; to: string };
+export type SimpleRedirectRule = {
+    from: string;
+    to: string;
+    /**
+     * Drop this redirect for archive builds. Archive builds omit the `sitemap()` integration
+     * entirely (they're noindex), so a redirect whose target only exists when that integration
+     * ran would 301 to a file the archive build never generates.
+     */
+    skipForArchive?: true;
+};
 export type RedirectMatchRule = { fromPattern: string; to: string };
 // A 410 Gone rule: the page is permanently removed with no equivalent. Has no `to`; emitted
 // as `Redirect 410 <from>` or `RedirectMatch 410 "<fromPattern>"`.
@@ -36,8 +45,9 @@ export const SITE_301_REDIRECTS: Redirect[] = [
     { from: '/react/line/', to: '/react/line-series/' },
 
     // SE-186: this build only ever generates sitemap-0.xml; the conventional /sitemap.xml is
-    // never emitted, so crawlers probing it by convention (e.g. Bing) 404.
-    { from: '/sitemap.xml', to: '/sitemap-0.xml' },
+    // never emitted, so crawlers probing it by convention (e.g. Bing) 404. Archive builds never
+    // generate sitemap-0.xml either (see skipForArchive doc), so this redirect is dropped there.
+    { from: '/sitemap.xml', to: '/sitemap-0.xml', skipForArchive: true },
 
     // --- SE-61: legacy AG Charts URLs that currently 404 ---
     // Rules are BASE-RELATIVE; getRedirectRules() splices in the /charts base for both pattern and target.


### PR DESCRIPTION
## Summary
- The SE-186 `/sitemap.xml → /sitemap-0.xml` redirect is emitted unconditionally, but archive builds skip Astro's `sitemap()` integration entirely and so never generate `sitemap-0.xml` — the link checker correctly fails these builds with `File link to sitemap-0.xml does not exist.` (same failure mode seen on the `b14.2.0` archive build; this redirect was cherry-picked here unmodified so b14.1.0 has the identical bug).
- Tags that one redirect `skipForArchive: true` and drops it from both the generated `.htaccess` and Astro's own `redirects` config whenever `SITE_BASE_URL` indicates an archive build, matching the existing archive-skip pattern already used for the `sitemap()` integration itself.

## Test plan
- [x] Added regression tests covering both the normal (redirect present) and archive (redirect dropped) cases in `htaccessRules.test.ts`
- [x] `ag-charts-website` unit suite passes
- [x] `build:types` / `lint` clean