### PR TITLE
Harden dev-prompts npm install against registry stalls

### DIFF
--- a/external/ag-shared/github/actions/install-ag-dev-prompts/action.yml
+++ b/external/ag-shared/github/actions/install-ag-dev-prompts/action.yml
@@ -49,8 +49,10 @@ runs:
                       "@ag-grid/dev-prompts@${DEV_PROMPTS_CHANNEL}"; then
                       exit 0
                   fi
-                  echo "::warning::npm install of @ag-grid/dev-prompts@${DEV_PROMPTS_CHANNEL} attempt ${attempt} timed out or failed; retrying"
-                  sleep 5
+                  if [ "$attempt" -lt 3 ]; then
+                      echo "::warning::npm install of @ag-grid/dev-prompts@${DEV_PROMPTS_CHANNEL} attempt ${attempt} timed out or failed; retrying"
+                      sleep 5
+                  fi
               done
 
               echo "::error::npm install of @ag-grid/dev-prompts@${DEV_PROMPTS_CHANNEL} failed after 3 attempts"

--- a/external/ag-shared/github/actions/install-ag-dev-prompts/action.yml
+++ b/external/ag-shared/github/actions/install-ag-dev-prompts/action.yml
@@ -36,6 +36,13 @@ runs:
               cd "$GITHUB_WORKSPACE/.ag-dev-prompts"
               echo '{"name":"ag-dev-prompts-install","private":true}' > package.json
 
+              # The runner's bundled npm 10.9 crashes/hangs resolving certain peer-dependency
+              # graphs (Arborist "Cannot read properties of null (reading 'edgesOut')"), a bug
+              # that started biting once vitest 5.0.0 hit the registry on 3 Sept. npm 11
+              # resolves it (see e51fe6603f9's npm bump in the package-test container for the
+              # same underlying bug).
+              npm install --global --silent npm@11
+
               # npm.pkg.github.com occasionally stalls a request mid-flight (observed:
               # zero output for 5+ minutes, no 4xx/5xx, just a hung DNS/connect phase)
               # rather than failing fast. `timeout` bounds each attempt so a stall

--- a/external/ag-shared/github/actions/install-ag-dev-prompts/action.yml
+++ b/external/ag-shared/github/actions/install-ag-dev-prompts/action.yml
@@ -35,4 +35,23 @@ runs:
               mkdir -p "$GITHUB_WORKSPACE/.ag-dev-prompts"
               cd "$GITHUB_WORKSPACE/.ag-dev-prompts"
               echo '{"name":"ag-dev-prompts-install","private":true}' > package.json
-              npm install --no-save --silent "@ag-grid/dev-prompts@${DEV_PROMPTS_CHANNEL}"
+
+              # npm.pkg.github.com occasionally stalls a request mid-flight (observed:
+              # zero output for 5+ minutes, no 4xx/5xx, just a hung DNS/connect phase)
+              # rather than failing fast. `timeout` bounds each attempt so a stall
+              # costs one retry instead of the whole job's timeout budget.
+              for attempt in 1 2 3; do
+                  if timeout 60 npm install --no-save --silent \
+                      --fetch-timeout=20000 \
+                      --fetch-retries=1 \
+                      --fetch-retry-mintimeout=2000 \
+                      --fetch-retry-maxtimeout=10000 \
+                      "@ag-grid/dev-prompts@${DEV_PROMPTS_CHANNEL}"; then
+                      exit 0
+                  fi
+                  echo "::warning::npm install of @ag-grid/dev-prompts@${DEV_PROMPTS_CHANNEL} attempt ${attempt} timed out or failed; retrying"
+                  sleep 5
+              done
+
+              echo "::error::npm install of @ag-grid/dev-prompts@${DEV_PROMPTS_CHANNEL} failed after 3 attempts"
+              exit 1


### PR DESCRIPTION
npm.pkg.github.com stalled the `@ag-grid/dev-prompts` install with no output for 5+ minutes (no 4xx/5xx) instead of failing fast, so the composite action's install ran until GitHub Actions' blunt 5-minute job timeout killed the whole job — cancelling `preflight` and/or `concurrency-key` before the pipeline ever reached the agent. Observed on AG-18413: 6+ consecutive dispatch failures over roughly 3 hours (09:02-11:55 UTC 2026-09-04).

**Root cause:** the runner's bundled npm 10.9.8 has an Arborist bug (`Cannot read properties of null (reading 'edgesOut')`) resolving certain peer-dependency graphs, which started biting once vitest 5.0.0 hit the npm registry on 3 Sept — the same underlying bug Ido's `e51fe6603f9` already upgraded npm to work around in the package-test container. It manifested there as a fast crash; here, under `--silent`, the same failure appears to leave the process hanging instead of exiting, which is why it read as a network stall at first.

**This PR:**
1. Upgrades the runner's npm to 11 before the install, which should prevent the underlying crash/hang rather than just recovering from it.
2. Wraps the install in a per-attempt `timeout` plus npm's own `--fetch-timeout`/`--fetch-retries` tuning as a bounded fallback (worst case ~3 min across 3 attempts instead of the full 5-minute job timeout), in case the hang has some other cause too.

Not included here: caching the install (e.g. via `actions/cache`) so a registry blip costs at most one cache-miss instead of blocking every job of every run identically — a reasonable follow-up but a separate change.