### PR TITLE
Raise jira-agent-pipeline preflight timeout to 10m

### DIFF
--- a/.github/workflows/jira-agent-pipeline.yml
+++ b/.github/workflows/jira-agent-pipeline.yml
@@ -113,7 +113,13 @@ jobs:
             (github.event_name == 'workflow_dispatch'   && inputs.stage == 'resume') ||
             (github.event_name == 'workflow_run'        && github.event.workflow_run.conclusion == 'failure')
         runs-on: ubuntu-latest
-        timeout-minutes: 5
+        # GitHub Packages' npm registry resolves @ag-grid/dev-prompts@latest with
+        # highly variable latency (observed 4s-7m across ag-grid/ag-charts/ag-studio
+        # on 2026-09-04, not tied to any recent change) — 5m left no slack and this
+        # job was intermittently timing out mid-install. 10m covers the worst
+        # observed case with headroom; the job itself finishes in seconds once the
+        # install completes.
+        timeout-minutes: 10
         permissions:
             contents: read
             pull-requests: read


### PR DESCRIPTION
## What's broken

`jira-agent-pipeline.yml`'s `preflight` job intermittently times out mid-install on `jira-resume` dispatches, same as ag-grid/ag-grid#15084 and #8050.

## Root cause

The `Install @ag-grid/dev-prompts` step resolves the `@latest` dist-tag from GitHub Packages (`npm.pkg.github.com`). Its latency is highly variable — timed across `ag-grid`, `ag-charts`, and `ag-studio` within the same ~10 minute window on 2026-09-04:

| repo | duration | outcome |
|---|---|---|
| ag-grid | 5m11s | timed out (5m job limit) |
| ag-charts | 4s | success |
| ag-charts | 2m08s | success |
| ag-studio | 7m03s | success (no tight timeout on that job at the time) |

Shared GitHub Packages registry latency for this package, affecting every consumer at the same time — not specific to any one repo's recent changes. This repo's `preflight` job carries the same `timeout-minutes: 5` with no slack for it.

## Fix

Raise `preflight`'s `timeout-minutes` from 5 to 10 — covers the worst latency observed (7m03s) with headroom. Same change as #8050, this time targeting `latest` since the workflow file also lives there.