### PR TITLE
SE-182 Stop Disallowing pages whose own signal a Disallow would hide

### DIFF
--- a/packages/ag-charts-website/src/utils/sitemapPages.ts
+++ b/packages/ag-charts-website/src/utils/sitemapPages.ts
@@ -15,13 +15,10 @@ const getDocsExamplePaths = () => {
 
 const getInternalPages = () => {
     return [
-        urlWithBaseUrl('/*/*-test/'),
+        // SE-182: NOT /*/*-test/ or /demos/ — a Disallow would hide their own noindex/canonical signal.
         urlWithBaseUrl('/*/*-e2e/'),
         urlWithBaseUrl('/gallery-test'),
         urlWithBaseUrl('/*/benchmarks/'),
-        // Demo app examples: the routes and their built SPA assets are published but
-        // must stay out of search engines and AI crawlers.
-        urlWithBaseUrl('/demos/'),
         urlWithBaseUrl('/internal-demos/'),
     ];
 };
@@ -42,7 +39,7 @@ const getIgnoredPages = () => {
     return [
         urlWithBaseUrl('/404'),
         addTrailingSlash(urlWithBaseUrl('/gallery/examples')),
-        addTrailingSlash(urlWithBaseUrl('/archive')),
+        // SE-182: NOT /archive — a Disallow would hide its redirect to /charts/documentation-archive/.
 
         // NOTE: /r/ framework redirect pages are deliberately NOT disallowed: they are
         // crawlable so their static links to the framework pages can be followed for SEO. They


### PR DESCRIPTION
## What

Removes three entries from `getSitemapIgnorePaths()` (which drives the robots.txt Disallow list via `robots-disallow.json.ts` — confirmed its only consumer): `/*/*-test/`, `/demos/`, and `/archive`.

## Why

Flagged on [SE-182](https://ag-grid.atlassian.net/browse/SE-182): `/charts/demos/` is Disallowed and also carries `noindex`; `/charts/*/selection-test/` is Disallowed and self-canonical; `/charts/archive/` is Disallowed and 301s to `/charts/documentation-archive/`. A `Disallow` stops Google from ever crawling the page to read the other signal, so in each case the page-level signal was inert. Same principle already applied to the blog migration (SE-188): drop the Disallow and let the page signal do the work instead.

`/internal-demos/` is untouched — no known conflicting signal on it.

## Scope check

`getSitemapIgnorePaths()` has exactly one consumer (`robots-disallow.json.ts`), so this only changes the robots.txt Disallow list. Sitemap.xml exclusion for these same pages is independent (`isDemoPage`/`isInternalPage` in `sitemap.ts`) and unaffected — they'll still be excluded from the sitemap, just no longer blocked from being crawled directly.

## Companion PR

Same change targets both `latest` and `b14.2.0`.