### PR TITLE
SE-182 Stop Disallowing pages whose own signal a Disallow would hide

### DIFF
--- a/packages/ag-charts-website/src/utils/sitemapPages.ts
+++ b/packages/ag-charts-website/src/utils/sitemapPages.ts
@@ -15,13 +15,13 @@ const getDocsExamplePaths = () => {
 
 const getInternalPages = () => {
     return [
-        urlWithBaseUrl('/*/*-test/'),
+        // SE-182: NOT /*/*-test/ or /demos/ — both carry their own page-level signal
+        // (self-canonical, noindex) that a Disallow would stop Google from ever reading,
+        // since it can't crawl the page to see it. Let the page signal do the work instead,
+        // same principle as the blog migration (SE-188).
         urlWithBaseUrl('/*/*-e2e/'),
         urlWithBaseUrl('/gallery-test'),
         urlWithBaseUrl('/*/benchmarks/'),
-        // Demo app examples: the routes and their built SPA assets are published but
-        // must stay out of search engines and AI crawlers.
-        urlWithBaseUrl('/demos/'),
         urlWithBaseUrl('/internal-demos/'),
     ];
 };
@@ -42,7 +42,9 @@ const getIgnoredPages = () => {
     return [
         urlWithBaseUrl('/404'),
         addTrailingSlash(urlWithBaseUrl('/gallery/examples')),
-        addTrailingSlash(urlWithBaseUrl('/archive')),
+        // SE-182: NOT /archive — it 301s to /charts/documentation-archive/, and a Disallow
+        // would hide that redirect from Google instead of letting it transfer. Same
+        // principle as the blog migration (SE-188).
 
         // NOTE: /r/ framework redirect pages are deliberately NOT disallowed: they are
         // crawlable so their static links to the framework pages can be followed for SEO. They

--- a/packages/ag-charts-website/src/utils/sitemapPages.ts
+++ b/packages/ag-charts-website/src/utils/sitemapPages.ts
@@ -15,10 +15,7 @@ const getDocsExamplePaths = () => {
 
 const getInternalPages = () => {
     return [
-        // SE-182: NOT /*/*-test/ or /demos/ — both carry their own page-level signal
-        // (self-canonical, noindex) that a Disallow would stop Google from ever reading,
-        // since it can't crawl the page to see it. Let the page signal do the work instead,
-        // same principle as the blog migration (SE-188).
+        // SE-182: NOT /*/*-test/ or /demos/ — a Disallow would hide their own noindex/canonical signal.
         urlWithBaseUrl('/*/*-e2e/'),
         urlWithBaseUrl('/gallery-test'),
         urlWithBaseUrl('/*/benchmarks/'),
@@ -42,9 +39,7 @@ const getIgnoredPages = () => {
     return [
         urlWithBaseUrl('/404'),
         addTrailingSlash(urlWithBaseUrl('/gallery/examples')),
-        // SE-182: NOT /archive — it 301s to /charts/documentation-archive/, and a Disallow
-        // would hide that redirect from Google instead of letting it transfer. Same
-        // principle as the blog migration (SE-188).
+        // SE-182: NOT /archive — a Disallow would hide its redirect to /charts/documentation-archive/.
 
         // NOTE: /r/ framework redirect pages are deliberately NOT disallowed: they are
         // crawlable so their static links to the framework pages can be followed for SEO. They


### PR DESCRIPTION
## What

Removes three entries from `getSitemapIgnorePaths()` (which drives the robots.txt Disallow list via `robots-disallow.json.ts` — confirmed its only consumer): `/*/*-test/`, `/demos/`, and `/archive`.

## Why

Flagged on [SE-182](https://ag-grid.atlassian.net/browse/SE-182): `/charts/demos/` is Disallowed and also carries `noindex`; `/charts/*/selection-test/` is Disallowed and self-canonical; `/charts/archive/` is Disallowed and 301s to `/charts/documentation-archive/`. A `Disallow` stops Google from ever crawling the page to read the other signal, so in each case the page-level signal was inert. Same principle already applied to the blog migration (SE-188): drop the Disallow and let the page signal do the work instead.

`/internal-demos/` is untouched — no known conflicting signal on it.

## Scope check

`getSitemapIgnorePaths()` has exactly one consumer (`robots-disallow.json.ts`), so this only changes the robots.txt Disallow list. Sitemap.xml exclusion for these same pages is independent (`isDemoPage`/`isInternalPage` in `sitemap.ts`) and unaffected — they'll still be excluded from the sitemap, just no longer blocked from being crawled directly.

## Companion PR

Same change targets both `latest` and `b14.2.0`.