### PR TITLE
AG-3390 Add framework links to /r/ redirect pages and unblock them in robots disallow list (b14.2.0)

### DIFF
--- a/packages/ag-charts-website/src/pages/r/[pageName].astro
+++ b/packages/ag-charts-website/src/pages/r/[pageName].astro
@@ -3,6 +3,9 @@ import { getCollection } from 'astro:content';
 import Layout from '@layouts/Layout.astro';
 import FrameworkRedirectPage from '@ag-website-shared/components/framework-redirect-page/FrameworkRedirectPage.astro';
 import { getDocsPages } from '@components/docs/utils/pageData';
+import { FRAMEWORKS } from '@constants';
+import { getFrameworkDisplayText } from '@utils/framework';
+import { urlWithPrefix } from '@utils/urlWithPrefix';
 
 export async function getStaticPaths() {
     const pages = await getCollection('docs');
@@ -12,6 +15,13 @@ export async function getStaticPaths() {
 const { page } = Astro.props;
 const { title } = page.data;
 const { pageName } = Astro.params;
+
+// Static links to every framework version of this page, so crawlers landing on the
+// framework-agnostic redirect page can discover and pass link equity to the real pages.
+const frameworkLinks = FRAMEWORKS.map((framework) => ({
+    href: urlWithPrefix({ framework, url: `./${pageName}` }),
+    text: `${getFrameworkDisplayText(framework)} Charts: ${title}`,
+}));
 ---
 
 <Layout
@@ -19,8 +29,18 @@ const { pageName } = Astro.params;
     description={'View the AG Grid Documentation - a feature-rich datagrid for major JavaScript frameworks, offering filtering, grouping, pivoting, and more.'}
     showSearchBar={false}
     showDocsNav={false}
+    noIndex={true}
 >
     <FrameworkRedirectPage redirectPageName={pageName}>
         <h1>Redirecting to "{title}" page</h1>
+        <ul>
+            {
+                frameworkLinks.map(({ href, text }) => (
+                    <li>
+                        <a href={href}>{text}</a>
+                    </li>
+                ))
+            }
+        </ul>
     </FrameworkRedirectPage>
 </Layout>

--- a/packages/ag-charts-website/src/utils/sitemapPages.ts
+++ b/packages/ag-charts-website/src/utils/sitemapPages.ts
@@ -1,6 +1,5 @@
 import { getDocsPages } from '@components/docs/utils/pageData';
 import { getExamplePageUrl } from '@components/docs/utils/urlPaths';
-import { FRAMEWORK_REDIRECT_PATH } from '@constants';
 import { getCollection } from 'astro:content';
 
 import { getDebugPageUrls } from './pages';
@@ -44,8 +43,11 @@ const getIgnoredPages = () => {
         urlWithBaseUrl('/404'),
         addTrailingSlash(urlWithBaseUrl('/gallery/examples')),
         addTrailingSlash(urlWithBaseUrl('/archive')),
-        // Redirects
-        addTrailingSlash(urlWithBaseUrl(`/${FRAMEWORK_REDIRECT_PATH}`)),
+
+        // NOTE: /r/ framework redirect pages are deliberately NOT disallowed: they are
+        // crawlable so their static links to the framework pages can be followed for SEO. They
+        // are still excluded from the sitemap (see sitemap.ts `isRedirectPage`).
+
         // Release note stubs — minimal content, crawl waste
         addTrailingSlash(urlWithBaseUrl('/changelog/releases')),
         // Contact form result pages — post-submission confirmations, nothing to index


### PR DESCRIPTION
Port of https://github.com/ag-grid/ag-grid/pull/15108 for AG Charts.

## Summary

- `/r/[pageName]` redirect pages now render static links to all four framework versions of each page, so crawlers landing on the framework-agnostic URL can discover and pass link equity to the real framework pages. (Charts generates every docs page for all four frameworks, so no per-page filtering is needed.)
- Removed the `/r/` entry from the generated robots disallow list (`getSitemapIgnorePaths` only feeds `robots-disallow.json` — the sitemap filters redirect pages separately via `isRedirectPage`, so they stay out of the sitemap).
- The redirect pages are marked `noIndex` (follow), so the thin "Redirecting to…" pages don't get indexed while their links remain followable.

## Testing

- `yarn nx lint ag-charts-website` green.