### PR TITLE
Redirect the apex ag-grid.com domain to www for /charts

### DIFF
--- a/packages/ag-charts-website/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
+++ b/packages/ag-charts-website/src/utils/htaccess/__snapshots__/htaccessRules.test.ts.snap
@@ -36,6 +36,14 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
 <IfModule mod_rewrite.c>
     RewriteEngine On
 
+    # Canonical host is www.ag-grid.com; the bare apex domain must not serve pages directly.
+    RewriteCond %{HTTP_HOST} ^ag-grid\\.com$ [NC]
+    RewriteRule ^ https://www.ag-grid.com%{REQUEST_URI} [R=301,L]
+</IfModule>
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
     RewriteCond %{HTTP_ACCEPT} text/markdown
     RewriteCond %{REQUEST_URI} ^/(charts/(?:(?:react|angular|vue|javascript)/[^/.]+|changelog|contact|documentation-archive|license-pricing|pipeline|roadmap|sitemap|whats-new|community(?:/(?:beyond-the-prompt|events|media|showcase|tools-extensions))?|session/[^/.]+|examples(?:-[^/.]+)?|gallery(?:/[^/.]+)?|(?:angular|enterprise|javascript|react|vue)-charts|options(?:/(?:axes|series|initialState/annotations|navigator/miniChart/series)/[^/.]+)?|themes-api(?:/overrides/[^/.]+)?))/?$
     RewriteCond %{DOCUMENT_ROOT}/%1.md -f

--- a/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
@@ -34,12 +34,28 @@ AddCharset utf-8 .md
 # env-split, so the policy is generated per environment.
 ${getCspContent(env)}
 
-${getMarkdownNegotiationRules()}
+${env === 'production' ? `${getHostCanonicalizationRules()}\n\n` : ''}${getMarkdownNegotiationRules()}
 
 ${getRedirectRules()}
 
 Options -Indexes
 `;
+}
+
+// Charts is served from /charts nested under the main ag-grid.com vhost's docroot, as this file's
+// own .htaccess. mod_rewrite rules are not inherited across .htaccess boundaries, so the parent
+// site's apex(ag-grid.com)-to-www host swap never reaches requests under /charts, and the bare
+// apex domain ends up serving pages directly instead of redirecting to www.
+// Only production splits apex/www; staging's only host is charts-staging.ag-grid.com, so this is
+// only spliced in for production (see the call site above).
+function getHostCanonicalizationRules(): string {
+    return `<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    # Canonical host is www.ag-grid.com; the bare apex domain must not serve pages directly.
+    RewriteCond %{HTTP_HOST} ^ag-grid\\.com$ [NC]
+    RewriteRule ^ https://www.ag-grid.com%{REQUEST_URI} [R=301,L]
+</IfModule>`;
 }
 
 function getCspContent(env: HtaccessEnv): string {

--- a/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
+++ b/packages/ag-charts-website/src/utils/htaccess/htaccessRules.ts
@@ -42,12 +42,7 @@ Options -Indexes
 `;
 }
 
-// Charts is served from /charts nested under the main ag-grid.com vhost's docroot, as this file's
-// own .htaccess. mod_rewrite rules are not inherited across .htaccess boundaries, so the parent
-// site's apex(ag-grid.com)-to-www host swap never reaches requests under /charts, and the bare
-// apex domain ends up serving pages directly instead of redirecting to www.
-// Only production splits apex/www; staging's only host is charts-staging.ag-grid.com, so this is
-// only spliced in for production (see the call site above).
+// The parent site's .htaccess apex-to-www swap isn't inherited into this nested .htaccess, so /charts needs its own (production only; staging has a single host).
 function getHostCanonicalizationRules(): string {
     return `<IfModule mod_rewrite.c>
     RewriteEngine On


### PR DESCRIPTION
The apex domain (`ag-grid.com/charts`) serves pages directly instead of redirecting to `www.ag-grid.com/charts`.

`charts.htaccess` (generated by `htaccessRules.ts`) never checked `HTTP_HOST`. It governs `/charts` as a nested `.htaccess` under the main `ag-grid.com` vhost, and mod_rewrite rules from the parent `.htaccess` (including its apex-to-www host swap) are not inherited into a child `.htaccess` without `RewriteOptions Inherit`, so the parent's redirect never reached requests under `/charts`.

Adds a production-only host-canonicalization rule that redirects the bare apex domain to `www.ag-grid.com`, preserving the path and query string. Staging is unaffected — its only host is `charts-staging.ag-grid.com`, so there's no apex/www split there.