### PR TITLE
AG-18287 Port the Launch Week banner and link-checker query fix from ag-grid

### DIFF
--- a/external/ag-website-shared/plugins/agLinkChecker.ts
+++ b/external/ag-website-shared/plugins/agLinkChecker.ts
@@ -22,12 +22,21 @@ type Options = {
 
 const IGNORED_PATHS = ['/archive'];
 const HREF_PATTERNS_TO_IGNORE = [
-    '?', // Links with queries
     '#reference-', // API references, as they are rendered client side
     '#example-', // Example references, as they aren't headings
     '#contact-section', // Contact form on about page
     '#manage_cookies', // Footer link to open cookies management
 ];
+
+// Keeps any fragment after the query, so anchor checks still see it.
+const stripQueryString = (href: string): string => {
+    const queryIndex = href.indexOf('?');
+    if (queryIndex === -1) {
+        return href;
+    }
+    const hashIndex = href.indexOf('#', queryIndex);
+    return hashIndex === -1 ? href.slice(0, queryIndex) : href.slice(0, queryIndex) + href.slice(hashIndex);
+};
 
 const isCI =
     process.env.NX_TASK_TARGET_CONFIGURATION === 'ci' || process.env.NX_TASK_TARGET_CONFIGURATION === 'staging';
@@ -90,8 +99,8 @@ const checkLinks = async (dir: string, files: string[], options: Options) => {
     const linksToValidate: Record<string, { filePaths: Set<string> }> = {};
     // Links whose shape alone would cost a redirect (no trailing slash, non-canonical host, ...),
     // keyed by the offending href. Recorded for every internal link, including the absolute
-    // `https://www.ag-grid.com/...` ones and the query/fragment links the existence checks below
-    // leave alone, because the redirect happens before the target is consulted.
+    // `https://www.ag-grid.com/...` ones and the client-side-injected fragment links the existence
+    // checks below leave alone, because the redirect happens before the target is consulted.
     const shapeIssues: Record<string, { message: string; filePaths: Set<string> }> = {};
     const { prefix, frameworkRedirect } = options;
 
@@ -132,9 +141,10 @@ const checkLinks = async (dir: string, files: string[], options: Options) => {
         const recordUsage = (href: string) => {
             recordShapeIssues(href);
 
-            // Query links and anchors injected client-side (API/example
-            // references, the about-page contact form) have no static target
-            // to resolve against.
+            href = stripQueryString(href);
+
+            // Anchors injected client-side (API/example references, the
+            // about-page contact form) have no static target to resolve against.
             if (HREF_PATTERNS_TO_IGNORE.some((pattern) => href.includes(pattern))) {
                 return;
             }

--- a/external/ag-website-shared/plugins/agLinkChecker.ts
+++ b/external/ag-website-shared/plugins/agLinkChecker.ts
@@ -28,6 +28,33 @@ const HREF_PATTERNS_TO_IGNORE = [
     '#manage_cookies', // Footer link to open cookies management
 ];
 
+// Attribute values are read out of the raw HTML, so character references are
+// still encoded. They have to be decoded before the href is picked apart, or the
+// `#` of a reference such as `&#38;` (the `&` between query parameters) reads as
+// a fragment marker.
+const NAMED_HTML_ENTITIES: Record<string, string> = {
+    amp: '&',
+    apos: "'",
+    gt: '>',
+    lt: '<',
+    nbsp: '\u00a0',
+    quot: '"',
+};
+
+const decodeHtmlEntities = (value: string): string =>
+    value.replace(/&(#x[0-9a-f]+|#\d+|[a-z][a-z0-9]*);/gi, (reference, body: string) => {
+        if (!body.startsWith('#')) {
+            return NAMED_HTML_ENTITIES[body.toLowerCase()] ?? reference;
+        }
+        const isHex = body[1].toLowerCase() === 'x';
+        const codePoint = parseInt(isHex ? body.slice(2) : body.slice(1), isHex ? 16 : 10);
+        // Lone surrogates and out-of-range values would throw; leave them as they were.
+        if (!Number.isInteger(codePoint) || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) {
+            return reference;
+        }
+        return String.fromCodePoint(codePoint);
+    });
+
 // Keeps any fragment after the query, so anchor checks still see it.
 const stripQueryString = (href: string): string => {
     const queryIndex = href.indexOf('?');
@@ -195,7 +222,7 @@ const checkLinks = async (dir: string, files: string[], options: Options) => {
 
                 const hrefMatch = /(?:^|\s)href=(["'])(.*?)\1/i.exec(tag);
                 if (hrefMatch) {
-                    recordUsage(hrefMatch[2]);
+                    recordUsage(decodeHtmlEntities(hrefMatch[2]));
                 }
             }
         };

--- a/external/ag-website-shared/src/components/announcement-banner/AnnouncementBanner.module.scss
+++ b/external/ag-website-shared/src/components/announcement-banner/AnnouncementBanner.module.scss
@@ -133,7 +133,7 @@
 }
 
 .description {
-    opacity: 0.8;
+    color: var(--color-brand-200);
 
     // Keep the headline on its own line on very small viewports where wrapping
     // becomes messy.

--- a/packages/ag-charts-website/src/content/announcement-banner/announcement-banner.json
+++ b/packages/ag-charts-website/src/content/announcement-banner/announcement-banner.json
@@ -1,10 +1,10 @@
 {
     "enabled": true,
-    "href": "https://app.livestorm.co/ag-grid/ag-studio-build-dashboards-using-native-components-in-web-apps-webinar?utm_source=ag-grid-website&utm_medium=banner&utm_campaign=webinar_AMA_AG_STUDIO_28_jul2026&utm_content=homepage_banner",
-    "title": "AG Studio: Build dashboards using native components in web apps.",
-    "description": "Join us for a webinar on 28th July at 2pm UTC+1",
-    "ctaLabel": "Register",
-    "external": true,
-    "untilDate": "2026-07-29",
+    "href": "https://www.ag-grid.com/studio/campaigns/launch-week/?promo=banner-studio-launch-week",
+    "title": "AG Studio Launch Week",
+    "description": "🚀🚀🚀 28 Sep - 2 Oct 2026 🚀🚀🚀",
+    "ctaLabel": "Join now",
+    "external": false,
+    "untilDate": "2026-10-02",
     "showDate": null
 }


### PR DESCRIPTION
Brings the shared-tree changes from ag-grid#15130 across to the charts site:

- `agLinkChecker` no longer skips internal links carrying a query string. The `'?'` entry is dropped from `HREF_PATTERNS_TO_IGNORE` and `stripQueryString()` removes the query while keeping any trailing fragment, so both the target and the anchor of a link such as `/charts/changelog/?fixVersion=14.1.0` are checked.
- The announcement banner description takes its colour from `--color-brand-200` rather than an opacity, matching ag-studio.
- The banner content is swapped from the expired July webinar to Launch Week. The href is same-origin (`www.ag-grid.com/studio/...`), hence `external: false`.

Verified: `nx format`, `nx lint ag-charts-website` clean. A `CHECK_LINKS=true nx build ag-charts-website` run was started but cancelled before it reached the link-checker stage, so the newly-checked query links have not been validated against the charts build output yet.
