### PR TITLE
Document highlight mode for series highlighting

### DIFF
--- a/packages/ag-charts-website/e2e/example-options.ts
+++ b/packages/ag-charts-website/e2e/example-options.ts
@@ -64,6 +64,9 @@ export const EXAMPLE_OPTIONS: Record<string, Record<string, ExampleOverrides>> =
     'range-bar-series': {
         'range-bar-missing-data': { ignoreConsoleWarnings: true },
     },
+    'series-highlighting': {
+        'highlight-mode': { skipCanvasUpdateCheck: true },
+    },
     themes: {
         'advanced-theme': { frameworks: [] },
     },

--- a/packages/ag-charts-website/src/content/docs/module-registry/_examples/minimal-line-registration/main.ts
+++ b/packages/ag-charts-website/src/content/docs/module-registry/_examples/minimal-line-registration/main.ts
@@ -2,7 +2,6 @@ import {
     AgChartOptions,
     AgCharts,
     CategoryAxisModule,
-    LegendModule,
     LineSeriesModule,
     ModuleRegistry,
     NumberAxisModule,
@@ -10,7 +9,7 @@ import {
 
 import { getData } from './data';
 
-ModuleRegistry.registerModules([CategoryAxisModule, LegendModule, LineSeriesModule, NumberAxisModule]);
+ModuleRegistry.registerModules([CategoryAxisModule, LineSeriesModule, NumberAxisModule]);
 
 const options: AgChartOptions = {
     container: document.getElementById('myChart'),

--- a/packages/ag-charts-website/src/content/docs/series-highlighting/_examples/highlight-mode/data.ts
+++ b/packages/ag-charts-website/src/content/docs/series-highlighting/_examples/highlight-mode/data.ts
@@ -1,0 +1,8 @@
+export function getData() {
+    return [
+        { quarter: 'Q1', productA: 120, productB: 90, productC: 60 },
+        { quarter: 'Q2', productA: 132, productB: 101, productC: 78 },
+        { quarter: 'Q3', productA: 101, productB: 137, productC: 95 },
+        { quarter: 'Q4', productA: 134, productB: 120, productC: 110 },
+    ];
+}

--- a/packages/ag-charts-website/src/content/docs/series-highlighting/_examples/highlight-mode/index.html
+++ b/packages/ag-charts-website/src/content/docs/series-highlighting/_examples/highlight-mode/index.html
@@ -1,0 +1,24 @@
+<div class="example-controls">
+    <div class="controls-row">
+        <div class="button-group" role="group" aria-label="Highlight Mode">
+            <input
+                type="radio"
+                id="highlight-mode-single"
+                name="highlight-mode"
+                value="single"
+                checked
+                onchange="setHighlightMode(event)"
+            />
+            <label for="highlight-mode-single">Single</label>
+            <input
+                type="radio"
+                id="highlight-mode-shared"
+                name="highlight-mode"
+                value="shared"
+                onchange="setHighlightMode(event)"
+            />
+            <label for="highlight-mode-shared">Shared</label>
+        </div>
+    </div>
+</div>
+<div id="myChart"></div>

--- a/packages/ag-charts-website/src/content/docs/series-highlighting/_examples/highlight-mode/main.ts
+++ b/packages/ag-charts-website/src/content/docs/series-highlighting/_examples/highlight-mode/main.ts
@@ -1,0 +1,35 @@
+import {
+    AgCartesianChartOptions,
+    AgChartHighlightMode,
+    AgCharts,
+    BarSeriesModule,
+    CategoryAxisModule,
+    LegendModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
+
+import { getData } from './data';
+
+ModuleRegistry.registerModules([BarSeriesModule, CategoryAxisModule, LegendModule, NumberAxisModule]);
+
+const options: AgCartesianChartOptions = {
+    container: document.getElementById('myChart'),
+    data: getData(),
+    highlight: {
+        mode: 'single',
+    },
+    series: [
+        { type: 'bar', xKey: 'quarter', yKey: 'productA', yName: 'Product A', stacked: true },
+        { type: 'bar', xKey: 'quarter', yKey: 'productB', yName: 'Product B', stacked: true },
+        { type: 'bar', xKey: 'quarter', yKey: 'productC', yName: 'Product C', stacked: true },
+    ],
+};
+
+const chart = AgCharts.create(options);
+
+function setHighlightMode(event: Event) {
+    const mode = (event.target as HTMLInputElement).value as AgChartHighlightMode;
+    options.highlight!.mode = mode;
+    chart.update(options);
+}

--- a/packages/ag-charts-website/src/content/docs/series-highlighting/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/series-highlighting/index.mdoc
@@ -33,7 +33,7 @@ The options for `mode` are:
 - `single` - highlights the hovered item only.
 - `shared` - highlights the item of every other series that shares the hovered item's category.
 
-See [Highlight Modes](./series-highlighting/#highlight-modes) to apply the same shared grouping to series highlighting.
+See [Tooltip Modes](./tooltips/#tooltip-modes) to apply the same shared grouping to series highlighting.
 
 ## Bring to Front
 

--- a/packages/ag-charts-website/src/content/docs/series-highlighting/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/series-highlighting/index.mdoc
@@ -14,6 +14,27 @@ In the above example:
 
 Highlighting is enabled by default. Use `highlight.enabled` to configure it globally, or `series[].highlight.enabled` to override it per series.
 
+## Highlight Modes
+
+By default, hovering an item highlights only that item. Use `highlight.mode: 'shared'` to also highlight the item of every other series that shares the hovered item's category.
+
+{% chartExampleRunner title="Highlight Mode" name="highlight-mode" type="generated" /%}
+
+```js format="snippet"
+{
+    highlight: {
+        mode: 'shared', // or 'single'
+    },
+}
+```
+
+The options for `mode` are:
+
+- `single` - highlights the hovered item only.
+- `shared` - highlights the item of every other series that shares the hovered item's category.
+
+See [Highlight Modes](./series-highlighting/#highlight-modes) to apply the same shared grouping to series highlighting.
+
 ## Bring to Front
 
 By default, the highlighted series is brought to the front to make it stand out, especially when multiple series overlap.

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/inner-circle/main.ts
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/_examples/inner-circle/main.ts
@@ -29,7 +29,7 @@ const options: AgChartOptions = {
             sizeName: 'Budget',
             innerRadiusRatio: 0.4,
             innerCircle: {
-                fill: 'white',
+                fill: '#c9fdc9',
             },
             innerLabels: [
                 {

--- a/packages/ag-charts-website/src/content/docs/sunburst-series/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sunburst-series/index.mdoc
@@ -173,6 +173,49 @@ In this configuration:
 - `padding` adds space between the edge of a sector and its contents.
 - `formatter` allows customising the value of a label using a function.
 
+## Inner Circle
+
+Provide an `innerRadiusRatio` to display additional information in the centre of the chart.
+
+{% chartExampleRunner title="Inner Circle" name="inner-circle" type="generated" /%}
+
+```js format="snippet"
+{
+    series: [
+        {
+            type: 'sunburst',
+            labelKey: 'name',
+            sizeKey: 'budget',
+            sizeName: 'Budget',
+            innerRadiusRatio: 0.4,
+            innerCircle: {
+                fill: '#c9fdc9',
+            },
+            innerLabels: [
+                {
+                    text: 'Total Budget',
+                    fontSize: 12,
+                    color: 'gray',
+                },
+                {
+                    text: '$1.3M',
+                    fontSize: 24,
+                    fontWeight: 'bold',
+                    spacing: 6,
+                },
+            ],
+        },
+    ],
+}
+```
+
+In this example:
+
+- An optional `innerRadiusRatio` is provided. This should be a value between `0` and `1` and defines the radius of the inner circle as a ratio of the outer radius of the series.
+- Use `innerRadiusSize` instead to set a fixed pixel radius.
+- The `innerLabels` property is used to add several lines of text into this space.
+- The colour of the centre area can be changed by using `innerCircle.fill`.
+
 ## Highlighting
 
 {% chartExampleRunner title="Highlighting" name="highlight" type="generated" /%}

--- a/packages/ag-charts-website/src/content/docs/tooltips/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/tooltips/index.mdoc
@@ -54,6 +54,8 @@ The options for `mode` are:
 - `shared` - shows a merged tooltip, combining the tooltips of all series sharing the same x-value.
 - `compact` - shows fewer data fields and uses less padding.
 
+See [Highlight Modes](./series-highlighting/#highlight-modes) to apply the same shared grouping to series highlighting.
+
 ## Tooltip Position
 
 By default the tooltip is anchored to the hovered datapoint. Use `placement`, `anchorTo` and `offset` to customise this.

--- a/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
+++ b/packages/ag-charts-website/src/content/versions/ag-charts-versions.json
@@ -8,6 +8,10 @@
                 "path": "./quadrant-chart/"
             },
             {
+                "text": "Background Regions",
+                "path": "./background-regions/"
+            },
+            {
                 "text": "Additional Click Events",
                 "path": "./events/"
             },


### PR DESCRIPTION
## Summary
- Add a "Highlight Modes" section and `highlight-mode` example to the series-highlighting docs, covering `highlight.mode: 'shared'` vs `'single'`
- Cross-link the tooltips shared-mode docs to the new series-highlighting section
- Drop an unused `LegendModule` import from the module-registry `minimal-line-registration` example
- Update the sunburst `inner-circle` example's inner circle fill colour
- Add a "Background Regions" entry to the what's-new nav (`ag-charts-versions.json`)