### PR TITLE
Restructure module-registry docs, fix RTL numeric formatting text

### DIFF
--- a/packages/ag-charts-website/src/content/docs/module-registry/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/module-registry/index.mdoc
@@ -1,6 +1,6 @@
 ---
 title: 'Module Registry'
-description: 'Register AG Charts modules to enable chart types and features before creating charts.'
+description: 'Register $framework AG Charts modules to enable chart types and features before creating $framework charts.'
 ---
 
 Reduce bundle size by importing only the AG Chart modules required by your application, with treeshaking support.
@@ -20,9 +20,13 @@ Alternatively, if you are not concerned about bundle size and you want access to
 
 ## Registering AG Charts Modules
 
-Every module must be registered with the global `ModuleRegistry` **_*before*_** calling any AG Charts APIs such as `AgCharts.create`.
+Every module must be registered before a chart can use it, either [globally](#registering-globally) via `ModuleRegistry` or [per chart](#registering-per-chart) when that chart is created.
 
-Add your registration call near the bootstrap of your application so it runs exactly once.
+Global registration must run **before** any chart is created.
+
+{% note %}
+`ModuleRegistry.registerModules` is idempotent: registering the same module again is ignored unless a different version is detected.
+{% /note %}
 
 ### Importing the Module Registry
 
@@ -62,26 +66,33 @@ import { AnimationModule, HeatmapSeriesModule } from 'ag-charts-enterprise';
 ModuleRegistry.registerModules([AllCommunityModule, HeatmapSeriesModule, AnimationModule]);
 ```
 
-### Registering Modules
+### Registering Globally
+
+Add the `ModuleRegistry.registerModules` call near the bootstrap of your application so it runs exactly once.
 
 The example below registers the minimum set of Community modules required for a cartesian line chart:
 
 {% chartExampleRunner title="Minimal Line Chart Registration" name="minimal-line-registration" type="generated" /%}
 
 ```js
-import { AgCharts, ModuleRegistry } from 'ag-charts-community';
-import { CategoryAxisModule, LineSeriesModule, NumberAxisModule } from 'ag-charts-community';
+import {
+    AgCharts,
+    CategoryAxisModule,
+    LineSeriesModule,
+    ModuleRegistry,
+    NumberAxisModule,
+} from 'ag-charts-community';
 
 ModuleRegistry.registerModules([LineSeriesModule, NumberAxisModule, CategoryAxisModule]);
 ```
 
-{% note %}
-`ModuleRegistry.registerModules` is idempotent: registering the same module again is ignored unless a newer version is detected.
-{% /note %}
+### Registering per Chart
 
-## Registering Modules per Chart
+Modules can also be registered for a single chart instance. This is useful when different charts on a page use different features, or when an application prefers not to rely on a global registry.
 
-Modules can also be registered for a single chart instance by passing them in the second argument to `AgCharts.create`. This is useful when different charts on a page use different features, or when an application prefers not to rely on a global registry.
+{% if isFramework("javascript") %}
+
+Pass the modules in the second argument to `AgCharts.create`:
 
 ```js
 import { AgCharts, CategoryAxisModule, LineSeriesModule, NumberAxisModule } from 'ag-charts-community';
@@ -91,15 +102,10 @@ AgCharts.create(options, {
 });
 ```
 
-Modules passed to a chart are added to any registered globally, so a common baseline can be registered with `ModuleRegistry.registerModules` and extras supplied per chart. They stay registered for the lifetime of that chart, including across `update` calls, and are not visible to other charts.
-
-{% chartExampleRunner title="Per-Chart Registration" name="per-chart-registration" type="generated" /%}
-
-`AgCharts.createFinancialChart`, `AgCharts.createGauge` and `AgCharts.createQuadrantChart` accept the same second argument.
-
-The modules are read once, when the chart is created. Changing them afterwards, including through a framework property, has no effect on an existing chart.
+{% /if %}
 
 {% if isFramework("react") %}
+
 Pass the modules through the `modules` prop:
 
 ```jsx format="reactHooks"
@@ -109,6 +115,7 @@ Pass the modules through the `modules` prop:
 {% /if %}
 
 {% if isFramework("angular") %}
+
 Pass the modules through the `modules` input:
 
 ```html
@@ -118,6 +125,7 @@ Pass the modules through the `modules` input:
 {% /if %}
 
 {% if isFramework("vue") %}
+
 Pass the modules through the `modules` prop:
 
 ```html
@@ -126,9 +134,24 @@ Pass the modules through the `modules` prop:
 
 {% /if %}
 
-Use `chart.isModuleRegistered('LineSeriesModule')` to check whether a module is available to a chart, whether it was registered globally or passed to the chart.
+{% chartExampleRunner title="Per-Chart Registration" name="per-chart-registration" type="generated" /%}
 
-A chart is licensed by the modules available to it. A chart whose modules, global and per chart, are all from AG Charts Community is not licence checked and shows no watermark, even when AG Charts Enterprise is loaded on the same page.
+In this example:
+
+- The `CategoryAxisModule` and `NumberAxisModule` are registered globally, so they are available to both charts.
+- The `LineSeriesModule` and `BarSeriesModule` are registered per chart, so each chart only has the series it needs.
+- Per-chart modules stay registered for the lifetime of that chart, including across `update` calls, and are not visible to other charts.
+- The modules are read once, when the chart is created. Changing them afterwards, including through a framework property, has no effect on an existing chart.
+
+### Checking Registered Modules
+
+Use `chart.isModuleRegistered` to check whether a module is available to a chart, whether it was registered globally or passed to the chart.
+
+```js
+const chart = AgCharts.create(options);
+
+const isRegistered = chart.isModuleRegistered('LineSeriesModule');
+```
 
 ## Bundles
 

--- a/packages/ag-charts-website/src/content/docs/module-registry/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/module-registry/index.mdoc
@@ -20,9 +20,9 @@ Alternatively, if you are not concerned about bundle size and you want access to
 
 ## Registering AG Charts Modules
 
-Every module must be registered before a chart can use it, either [globally](#registering-globally) via `ModuleRegistry` or [per chart](#registering-per-chart) when that chart is created.
+Every module must be registered before a chart can use it, either [globally](#registering-globally) via `ModuleRegistry` or [per chart](#registering-per-chart) when that chart is created. These approaches can be mixed — register some modules globally and others per chart.
 
-Global registration must run **before** any chart is created.
+For simplicity, register modules globally before creating any charts.
 
 {% note %}
 `ModuleRegistry.registerModules` is idempotent: registering the same module again is ignored unless a different version is detected.
@@ -68,7 +68,7 @@ ModuleRegistry.registerModules([AllCommunityModule, HeatmapSeriesModule, Animati
 
 ### Registering Globally
 
-Add the `ModuleRegistry.registerModules` call near the bootstrap of your application so it runs exactly once.
+Add the `ModuleRegistry.registerModules` call near the bootstrap of your application — this is the simplest approach, though registering additional modules later is also supported (see the idempotent note above).
 
 The example below registers the minimum set of Community modules required for a cartesian line chart:
 

--- a/packages/ag-charts-website/src/content/docs/rtl/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/rtl/index.mdoc
@@ -36,14 +36,9 @@ In this example:
 - The RTL text in the title and subtitle wrap and truncate on the left.
 - The legend layout is mirrored as is the series order in the chart.
 - The tooltip and context menu layout are mirrored.
-- Both series have negative months, and those values keep their sign on the left in every language.
-- Tooltips use `mode: 'single'`. Sales growth uses the default tooltip, net profit a custom `renderer` that wraps its own number.
-
-## Numbers
-
-Numbers keep their left-to-right reading order in RTL mode, so the negative labels in the example above render as `-30` rather than `30-`. This covers the sign, the decimal and group separators, and any unit attached to the value, such as `-12.5 kg`. Text surrounding a number still reads right-to-left.
-
-The same ordering applies to axis and series labels, tooltips and crosshair labels, including any text a `formatter` returns. HTML returned from a `renderer` is inserted exactly as supplied and is never modified, so wrap numbers in it with `U+202A` and `U+202C` as the example does.
+- Both series have negative values in some months, and those values keep their sign on the left, rendering as `-30` rather than `30-`. This applies to the sign, the decimal and group separators, and any unit attached to the value, such as `-12.5 kg`.
+- The "Sales Growth" series uses the default tooltip which correctly displays the negative values.
+- The "Net Profit" series uses a custom `renderer`. As the returned HTML is inserted exactly as supplied, the numbers are wrapped with `U+202A` and `U+202C` to ensure the negative sign renders in the correct position.
 
 ## Axis Layout
 

--- a/packages/ag-charts-website/src/content/docs/rtl/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/rtl/index.mdoc
@@ -36,7 +36,7 @@ In this example:
 - The RTL text in the title and subtitle wrap and truncate on the left.
 - The legend layout is mirrored as is the series order in the chart.
 - The tooltip and context menu layout are mirrored.
-- Both series have negative values in some months, and those values keep their sign on the left, rendering as `-30` rather than `30-`. This applies to the sign, the decimal and group separators, and any unit attached to the value, such as `-12.5 kg`.
+- Both series have negative values in some months, and those values keep their sign on the left, rendering as `-30` rather than `30-`. This applies to the sign, the decimal and group separators, and any unit attached to the value, such as `-12.5kg`.
 - The "Sales Growth" series uses the default tooltip which correctly displays the negative values.
 - The "Net Profit" series uses a custom `renderer`. As the returned HTML is inserted exactly as supplied, the numbers are wrapped with `U+202A` and `U+202C` to ensure the negative sign renders in the correct position.
 


### PR DESCRIPTION
## Module Registry

- Collapse the four registration subsections (importing, global, per-chart, checking-registered) under one `## Registering AG Charts Modules` heading, instead of splitting "Registering Modules per Chart" out as a sibling H2.
- Fix a self-contradicting timing clause: the intro previously said modules must be registered "before calling `AgCharts.create`" for both the global and per-chart paths, but per-chart modules are passed *as an argument to* that call.
- Conditionalise the per-chart registration snippet per framework (javascript/react/angular/vue), matching the pattern used on the financial-charts page.
- Align the inline "Registering Globally" import snippet with the example source and the page's own Module Selector output (single import, not two from the same package).
- Add the missing `$framework` placeholder to the frontmatter description.

## RTL

Tighten the numeric-formatting bullets under "In this example" to name the two series shown (Sales Growth, Net Profit) directly, rather than referring to a separate "Numbers" section.