### PR TITLE
SE-182 Drop the hidden flag from the two pages it actually affects

### DIFF
--- a/packages/ag-charts-website/src/content/docs/selection-test/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/selection-test/index.mdoc
@@ -2,7 +2,6 @@
 title: 'Data Selection'
 description: 'placeholder description'
 enterprise: true
-hidden: true
 ---
 
 Placeholder

--- a/packages/ag-charts-website/src/content/docs/sparklines/index.mdoc
+++ b/packages/ag-charts-website/src/content/docs/sparklines/index.mdoc
@@ -1,6 +1,5 @@
 ---
 title: 'Sparklines - Overview'
-hidden: true
 ---
 
 A Sparkline condenses data trends into small, inline charts, for embedding in tables or dashboards.


### PR DESCRIPTION
Follow-up to #8056/#8057. Those PRs removed the `/*/*-test/` wildcard from `getInternalPages()`, but that wasn't the actual source of the `/charts/*/selection-test/` Disallow entries -- verified via a real full production build (`NX_NO_CLOUD=true yarn nx build ag-charts-website -c production`) that they were unaffected.

**Real cause:** `getHiddenPages()` in `sitemapPages.ts` independently Disallows any docs page flagged `hidden: true`, regardless of the wildcard. Six pages carry that flag. Of those, four (`active-e2e`, `rtl-e2e`, `selection-e2e`, `benchmarks`) are *also* caught by the surviving `/*/*-e2e/` and `/*/benchmarks/` wildcards in `getInternalPages()` -- deliberately left in place by #8056's own comment, which only called out `/*/*-test/` and `/demos/`. Touching those four would be a no-op (still Disallowed either way) and would silently expand this ticket's scope into a separate decision about whether e2e/benchmark test pages should ever be crawlable.

Only `selection-test` and `sparklines` don't match any surviving wildcard, so those are the two pages this change actually makes crawlable -- letting Google read their self-canonical tag, same principle as the rest of SE-182.

Confirmed via the real build's generated `dist/packages/ag-charts-website/robots-disallow.json`, not source inspection.

One unrelated local test failure observed (`markdownPages.test.ts > leaves the contact result pages out of the sitemap entirely`) -- traced to this build's sitemap-cache script falling back to a live fetch of production's current sitemap on a cold cache, which right now genuinely lacks `/contact/` (verified directly against the live site, independent of this change). Not caused by this diff.