### PR TITLE
SE-169 Link to the Terms of Use page from the footer (b14.2.0)

### DIFF
--- a/packages/ag-charts-website/src/content/footer/footer.json
+++ b/packages/ag-charts-website/src/content/footer/footer.json
@@ -71,6 +71,10 @@
                 "url": "/contact/"
             },
             {
+                "name": "Terms of Use",
+                "url": "https://www.ag-grid.com/terms-of-use/"
+            },
+            {
                 "name": "Privacy Policy",
                 "url": "https://www.ag-grid.com/privacy/"
             },


### PR DESCRIPTION
## Summary

Adds a "Terms of Use" link to "The Company" group in the footer, pointing at the production grid page `https://www.ag-grid.com/terms-of-use/`. It sits before "Privacy Policy", matching the grid footer (ag-grid/ag-grid#15136).

The grid page is not live yet but is due shortly (ag-grid/ag-grid#15140 carries it on `b36.1.0`), so this link should ship alongside or after that release.

## Testing

- `chartsFrontmatter` vitest suite passes, which reads the real `footer.json`
