### PR TITLE
AG-3390 Hydrate docs example runners when they scroll into view (b14.2.0)

### DIFF
--- a/packages/ag-charts-website/e2e/example-runner-lazy-hydration.spec.ts
+++ b/packages/ag-charts-website/e2e/example-runner-lazy-hydration.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from './fixture';
+import { gotoUrl, toPageUrl } from './util';
+
+// Example runners hydrate when they scroll into view (`client:visible`), so a page with many
+// examples only mounts, and only fetches source for, the runners near the viewport. Off-screen
+// runners keep their reserved height and mount when the reader reaches them.
+
+test.use({ viewport: { width: 1280, height: 800 } });
+
+// Eighteen runners, among the most rendered on any docs page
+const PAGE_PATH = 'javascript/zoom/';
+
+test.describe('Example runner lazy hydration', () => {
+    test('mounts and fetches source only for runners the reader reaches', async ({ page }) => {
+        const contentsRequests = new Set<string>();
+        page.on('request', (request) => {
+            if (/\/examples\/.*\/contents\.json/.test(request.url())) {
+                contentsRequests.add(request.url());
+            }
+        });
+
+        await gotoUrl(page, toPageUrl(PAGE_PATH));
+        const runners = page.locator('.example-runner-outer');
+        const codeButtons = page.getByRole('button', { name: 'Code', exact: true });
+        await expect(runners.first()).toBeAttached();
+        const runnerCount = await runners.count();
+        expect(runnerCount).toBeGreaterThan(5);
+
+        // Give any eager hydration time to happen before counting
+        await page.waitForTimeout(2000);
+        expect(await codeButtons.count(), 'runners mounted on load').toBeLessThan(runnerCount);
+        expect(contentsRequests.size, 'contents.json requests on load').toBeLessThan(runnerCount);
+
+        // Reaching a runner mounts it and loads its source
+        const firstRunner = runners.first();
+        await firstRunner.scrollIntoViewIfNeeded();
+        await expect(firstRunner.getByRole('button', { name: 'Code', exact: true })).toBeVisible();
+        await expect.poll(() => contentsRequests.size).toBeGreaterThan(0);
+        const mountedAtFirst = await codeButtons.count();
+        expect(mountedAtFirst, 'runners mounted with the first in view').toBeLessThan(runnerCount);
+
+        const lastRunner = runners.last();
+        await lastRunner.scrollIntoViewIfNeeded();
+        await expect(lastRunner.getByRole('button', { name: 'Code', exact: true })).toBeVisible();
+        expect(await codeButtons.count()).toBeGreaterThan(mountedAtFirst);
+
+        // The reserved height keeps the layout stable while runners hydrate and switch views.
+        // Document-relative, since the click may scroll the page.
+        const documentTop = (element: HTMLElement) => element.getBoundingClientRect().top + window.scrollY;
+        const topBefore = await lastRunner.evaluate(documentTop);
+        await lastRunner.getByRole('button', { name: 'Code', exact: true }).click();
+        await expect(lastRunner.getByRole('button', { name: 'Preview', exact: true })).toBeVisible();
+        expect(await lastRunner.evaluate(documentTop)).toBe(topBefore);
+    });
+});

--- a/packages/ag-charts-website/src/components/docs/components/DocsExampleRunner.astro
+++ b/packages/ag-charts-website/src/components/docs/components/DocsExampleRunner.astro
@@ -45,7 +45,7 @@ const hasExampleConsoleLog = contents?.hasExampleConsoleLog;
     hasExampleConsoleLog={hasExampleConsoleLog}
 >
     <DocsExampleRunner
-        client:only="react"
+        client:visible={{ rootMargin: '200px' }}
         title={title}
         name={name}
         exampleType={type}

--- a/packages/ag-charts-website/src/components/docs/components/DocsExampleRunner.tsx
+++ b/packages/ag-charts-website/src/components/docs/components/DocsExampleRunner.tsx
@@ -2,11 +2,12 @@ import type { InternalFramework } from '@ag-grid-types';
 import { getLoadingIFrameId } from '@ag-website-shared/components/loading-logo/getElementId';
 import { excludeHiddenFiles } from '@components/docs/utils/excludeHiddenFiles';
 import type { ExampleType } from '@components/example-generator/types';
-import { ExampleRunner } from '@components/example-runner/components/ExampleRunner';
+import { DEFAULT_HEIGHT, ExampleRunner } from '@components/example-runner/components/ExampleRunner';
 import { ExternalLinks } from '@components/example-runner/components/ExternalLinks';
 import type { ExampleOptions } from '@components/example-runner/types';
 import { useStore } from '@nanostores/react';
 import { $internalFramework } from '@stores/frameworkStore';
+import { useHasMounted } from '@utils/hooks/useHasMounted';
 import { useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider, useQuery } from 'react-query';
 
@@ -202,6 +203,17 @@ const DocsExampleRunnerInner = ({
 };
 
 export const DocsExampleRunner = (props: Props) => {
+    // The island hydrates when scrolled into view, so it is also rendered on the server. The
+    // runner's framework and dark mode live in localStorage and its contents come from a client
+    // query, so until mounted render a placeholder rather than a default that hydration would
+    // replace. It has the example's height because Astro's visibility observer watches the
+    // island's children: an empty island would never hydrate.
+    const hasMounted = useHasMounted();
+
+    if (!hasMounted) {
+        return <div style={{ height: props.options?.exampleHeight ?? DEFAULT_HEIGHT }} />;
+    }
+
     return (
         <QueryClientProvider client={queryClient}>
             <DocsExampleRunnerInner {...props} />

--- a/packages/ag-charts-website/src/components/example-runner/components/ExampleRunner.tsx
+++ b/packages/ag-charts-website/src/components/example-runner/components/ExampleRunner.tsx
@@ -39,7 +39,7 @@ interface Props {
     initialLoadDeferred?: boolean;
 }
 
-const DEFAULT_HEIGHT = 500;
+export const DEFAULT_HEIGHT = 500;
 const MIN_HEIGHT = 320;
 export const ExampleRunner: FunctionComponent<Props> = ({
     id,

--- a/packages/ag-charts-website/src/components/landing-pages/sections/example-runner/ExampleRunner.astro
+++ b/packages/ag-charts-website/src/components/landing-pages/sections/example-runner/ExampleRunner.astro
@@ -47,7 +47,7 @@ try {
             hasExampleConsoleLog={hasExampleConsoleLog}
         >
             <DocsExampleRunner
-                client:only="react"
+                client:visible={{ rootMargin: '200px' }}
                 title={title}
                 name={name}
                 exampleHeight={exampleHeight}

--- a/packages/ag-charts-website/src/utils/hooks/useHasMounted.ts
+++ b/packages/ag-charts-website/src/utils/hooks/useHasMounted.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * `false` on the server and for the first client render, `true` once the component has mounted.
+ *
+ * For islands whose UI depends on browser-only state (localStorage stores, client queries): the
+ * server render and the hydrating render agree on an empty tree, and the real UI follows at once.
+ */
+export const useHasMounted = () => {
+    const [hasMounted, setHasMounted] = useState(false);
+
+    useEffect(() => {
+        setHasMounted(true);
+    }, []);
+
+    return hasMounted;
+};


### PR DESCRIPTION
## Summary

Port of ag-grid/ag-grid#15132 to `b14.2.0`.

The docs example runner island switches from `client:only="react"` to `client:visible={{ rootMargin: '200px' }}`, on docs pages and on the landing-page wrapper. Runners below the fold no longer hydrate, fetch their `contents.json`, register scroll listeners or load the shiki highlighter until the reader is within 200px of them.

### How the server render is made safe

- `useHasMounted` (new hook, `src/utils/hooks/useHasMounted.ts`): `false` on the server and for the hydrating render, `true` after mount. `DocsExampleRunner` renders a placeholder until then, so server and client agree and the real UI mounts right after hydration with the visitor's stored framework.
- The placeholder is a `<div>` with the example's height, not `null`: Astro's `client:visible` directive observes the island's **children** with an IntersectionObserver, so an empty island never hydrates. `DEFAULT_HEIGHT` is exported from `ExampleRunner.tsx` for this.
- The layout shift that made `client:only` feel necessary is already handled by `ExampleRunnerContainer.astro` reserving the runner's height.

The CSP hash for the `client:visible` bootstrap script is already in `cspRules.ts`.

### Differences from the grid PR

- The example height comes from `options.exampleHeight`, which is where this runner takes it.
- No `react-hooks/set-state-in-effect` disable comment in the hook: this repo's `eslint-plugin-react-hooks` predates that rule, so the comment would itself fail lint.
- The Playwright spec lives in `e2e/` with the other website specs and uses the `zoom` docs page (18 runners).

## Testing

- New Playwright spec `e2e/example-runner-lazy-hydration.spec.ts`: on the zoom page, asserts fewer runners are mounted and fewer `contents.json` requests made than runners on load; scrolling the first runner into view mounts it and fetches its source while the rest stay unmounted; scrolling to the last runner mounts it; and clicking **Code** on it does not move the runner. Passing against a local dev server (2/2 with `--repeat-each=2`).
- `yarn nx lint ag-charts-website` passes; `tsc --noEmit` reports nothing for the changed files.
