### PR TITLE
AG-3390 - Label the Dev Tools checkboxes for the form-label accessibility audit (b14.2.0)

### DIFF
--- a/external/ag-website-shared/src/components/dev-tools/DevTools.tsx
+++ b/external/ag-website-shared/src/components/dev-tools/DevTools.tsx
@@ -77,8 +77,9 @@ export const DevTools: FunctionComponent = () => {
             <h2>Dev Tools</h2>
             <div className={styles.options}>
                 <div>
-                    <label>Example Dev Toolbar:</label>
+                    <label htmlFor={`${DEV_TOOLS_ID}-exampleDevToolbar`}>Example Dev Toolbar:</label>
                     <input
+                        id={`${DEV_TOOLS_ID}-exampleDevToolbar`}
                         type="checkbox"
                         defaultChecked={exampleDevToolbar}
                         onClick={() => {
@@ -87,8 +88,9 @@ export const DevTools: FunctionComponent = () => {
                     />
                 </div>
                 <div>
-                    <label>Open Links In New Tab:</label>
+                    <label htmlFor={`${DEV_TOOLS_ID}-openLinksInNewTab`}>Open Links In New Tab:</label>
                     <input
+                        id={`${DEV_TOOLS_ID}-openLinksInNewTab`}
                         type="checkbox"
                         defaultChecked={openLinksInNewTab}
                         onClick={() => {
@@ -97,8 +99,9 @@ export const DevTools: FunctionComponent = () => {
                     />
                 </div>
                 <div>
-                    <label>Copy Framework Agnostic Links:</label>
+                    <label htmlFor={`${DEV_TOOLS_ID}-copyFrameworkAgnosticLinks`}>Copy Framework Agnostic Links:</label>
                     <input
+                        id={`${DEV_TOOLS_ID}-copyFrameworkAgnosticLinks`}
                         type="checkbox"
                         defaultChecked={copyFrameworkAgnosticLinks}
                         onClick={() => {
@@ -107,8 +110,9 @@ export const DevTools: FunctionComponent = () => {
                     />
                 </div>
                 <div>
-                    <label>FPS Monitor:</label>
+                    <label htmlFor={`${DEV_TOOLS_ID}-fpsMonitor`}>FPS Monitor:</label>
                     <input
+                        id={`${DEV_TOOLS_ID}-fpsMonitor`}
                         type="checkbox"
                         defaultChecked={fpsMonitor}
                         onClick={() => {


### PR DESCRIPTION
## Summary

Lighthouse's Agentic Browsing audit reports `Form elements must have labels` on docs pages (seen on `/charts/archive/14.2.0/javascript/bar-series/`). The offending controls are the four checkboxes in the hidden Dev Tools panel, which renders when `devTools` is set in localStorage. Each checkbox sits next to a `<label>` that has no `for` attribute and does not wrap the input, so nothing associates the two and the checkbox has no accessible name.

## Changes

- Give each Dev Tools checkbox an `id` derived from `DEV_TOOLS_ID` and point its `<label>` at it with `htmlFor`, in `external/ag-website-shared/src/components/dev-tools/DevTools.tsx`.
- The same change is being applied to the other ag-website-shared copies: ag-grid \`latest\` and ag-studio \`latest\`.

## Test plan

- [x] `prettier --check` clean on the changed file.
- [x] `eslint` on the changed file reports only the pre-existing `no-floating-promises` warning on the FPS monitor import, unrelated to this change.
- [ ] Toggle Dev Tools on a docs page (click the trigger five times) and confirm clicking each label toggles its checkbox, and Lighthouse no longer reports the label audit.