### PR TITLE
Cut the cost of the label collision shrink pass

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -67,7 +67,12 @@ import type { ChartAxis } from '../../chartAxis';
 import type { DataController } from '../../data/dataController';
 import { DataModel, type ProcessedData, fixNumericExtent } from '../../data/dataModel';
 import { createDatumId, processedDataIsAnimatable, valueProperty } from '../../data/processors';
-import { expandPlacementLabelBoxExtent, placedLabelTextOffset, styledLabelTextOffset } from '../../label';
+import {
+    expandPlacementLabelBoxExtent,
+    placedLabelTextOffset,
+    resolvePlacementLabelStyle,
+    styledLabelTextOffset,
+} from '../../label';
 import {
     boundLabelFit,
     compassCandidatePlacement,
@@ -1359,6 +1364,10 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
         // A styled label's reservation was sized from the style resolved at its winning placement, so its
         // offset comes from that same style rather than the two placements' shared reservation.
         const styled = label.itemStyler != null;
+        // OPTIMIZATION: without a styler the resolved style is datum-independent, so the placement merge
+        // is done once per placement here rather than once per label inside `getLabelStyles`.
+        const insideLabel = styled ? label : resolvePlacementLabelStyle(label, insideStyle);
+        const outsideLabel = styled ? label : resolvePlacementLabelStyle(label, outsideStyle);
 
         opts.labelSelection.each((text, datum) => {
             const isInside = datum.placement === 'inside';
@@ -1368,11 +1377,11 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
                 this,
                 datum,
                 params,
-                label,
+                isInside ? insideLabel : outsideLabel,
                 isHighlight,
                 activeHighlight,
                 undefined,
-                placementStyle,
+                styled ? placementStyle : undefined,
                 { placement: datum.placement }
             );
             if (!style.enabled) {

--- a/packages/ag-charts-community/src/chart/series/cartesian/labelShrinkCaps.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/labelShrinkCaps.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AgChartInstance } from 'ag-charts-types';
+
+import { AgCharts } from '../../../api/agCharts';
+import {
+    deproxy,
+    prepareTestOptions,
+    setupMockCanvas,
+    setupMockConsole,
+    waitForChartStability,
+} from '../../test/utils';
+
+// `truncate: false` with `collision.alwaysShow: false` is what the engine reads as
+// `overflowStrategy: 'hide'`; neither is on the line series' typed label surface, hence the casts.
+describe('label shrink pass overflow caps', () => {
+    setupMockConsole();
+
+    let chart: AgChartInstance;
+    setupMockCanvas();
+
+    afterEach(() => {
+        chart?.destroy();
+    });
+
+    // The first label placed becomes the second's only obstacle, so the second has to shrink to fit
+    // beside it; markers are off so nothing else obstructs, and the axes hold a pixel-like domain.
+    const renderTwoLabelledPoints = async (second: { x: number; y: number }, label: object) => {
+        const options = {
+            data: [{ x: 400, y: 200 }, second],
+            legend: { enabled: false },
+            axes: {
+                x: { type: 'number', position: 'bottom', min: 0, max: 800 },
+                y: { type: 'number', position: 'left', min: 0, max: 400 },
+            },
+            series: [
+                {
+                    type: 'line',
+                    xKey: 'x',
+                    yKey: 'y',
+                    marker: { enabled: false },
+                    label: {
+                        enabled: true,
+                        fontSize: 12,
+                        placement: ['top'],
+                        truncate: false,
+                        collision: { alwaysShow: false },
+                        ...label,
+                    },
+                },
+            ],
+        };
+        prepareTestOptions(options as any);
+        chart = AgCharts.create(options as any);
+        await waitForChartStability(chart);
+    };
+
+    // Rendered label text has no public accessor, so the label selection is the only channel for it.
+    const renderedLabelTexts = (): string[] => {
+        const series = deproxy(chart as any).series[0] as unknown as {
+            labelSelection: { nodes(): { visible: boolean; text?: unknown }[] };
+        };
+        expect(series).toHaveProperty('labelSelection');
+        return series.labelSelection
+            .nodes()
+            .filter((node) => node.visible)
+            .map((node) => String(node.text ?? ''));
+    };
+
+    // 'MMMM' is wider than the room left over, so its line is dropped without an ellipsis — not the
+    // truncation `'hide'` erases on — leaving 'i', which is narrower than a single 'M', to draw.
+    it('keeps the lines of a multi-line hide label that still fit the room an obstacle leaves', async () => {
+        await renderTwoLabelledPoints({ x: 408, y: 200 }, { wrapping: 'on-space', formatter: () => 'MMMM\ni' });
+
+        expect(renderedLabelTexts()).toEqual(['MMMM\ni', 'i']);
+    });
+
+    // A blank line ends a `'never'` wrap early, so losing a line of height leaves 'a' drawn whole.
+    it('keeps the first line of a hide label whose blank line ends the wrap', async () => {
+        await renderTwoLabelledPoints({ x: 400, y: 184 }, { wrapping: 'never', formatter: () => 'a\n\nb' });
+
+        expect(renderedLabelTexts()).toEqual(['a\n\nb', 'a']);
+    });
+});

--- a/packages/ag-charts-community/src/chart/series/cartesian/placedLabelCartesianSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/placedLabelCartesianSeries.ts
@@ -21,7 +21,12 @@ import type { AgMarkerShape } from 'ag-charts-types';
 import { PointerEvents } from '../../../scene/node';
 import type { Text } from '../../../scene/shape/text';
 import type { PlacedSeriesLabel } from '../../label';
-import { expandPlacementLabelBoxExtent, placedLabelTextOffset, styledLabelTextOffset } from '../../label';
+import {
+    expandPlacementLabelBoxExtent,
+    placedLabelTextOffset,
+    resolvePlacementLabelStyle,
+    styledLabelTextOffset,
+} from '../../label';
 import {
     boundLabelFit,
     compassCandidatePlacement,
@@ -212,6 +217,10 @@ export abstract class PlacedLabelCartesianSeries<
         // A styled label's reservation was sized from the style resolved at its winning placement, so its
         // offset comes from that same style rather than the two placements' shared reservation.
         const styled = label.itemStyler != null;
+        // OPTIMIZATION: without a styler the resolved style is datum-independent, so the placement merge
+        // is done once per placement here rather than once per label inside `getLabelStyles`.
+        const insideLabel = styled ? label : resolvePlacementLabelStyle(label, insideStyle);
+        const outsideLabel = styled ? label : resolvePlacementLabelStyle(label, outsideStyle);
 
         opts.labelSelection.each((text, datum) => {
             const isInside = datum.placement === 'inside';
@@ -221,11 +230,11 @@ export abstract class PlacedLabelCartesianSeries<
                 this,
                 datum,
                 params,
-                label,
+                isInside ? insideLabel : outsideLabel,
                 isHighlight,
                 activeHighlight,
                 undefined,
-                placementStyle,
+                styled ? placementStyle : undefined,
                 { placement: datum.placement }
             );
             const { enabled, fontStyle, fontWeight, fontSize, fontFamily, color } = style;

--- a/packages/ag-charts-core/src/utils/geometry/labelPlacement.test.ts
+++ b/packages/ag-charts-core/src/utils/geometry/labelPlacement.test.ts
@@ -2342,6 +2342,40 @@ describe('placeLabels obstacle-driven shrink', () => {
             placeLabels(new Map([['s', seriesLabels([datum])]]), bounds, 0, []).get('s')![0].text;
         expect(textAt(insideLabel({ threshold: 6 }))).toBe(textAt(insideLabel()));
     });
+
+    // With no `overflowStrategy` the re-fit hands back drawable text however little room is left, so
+    // the reduction must stay uncapped for such a policy however narrow the glyph already is.
+    it('keeps a label with no overflow strategy that an obstacle clips by more than its glyph width', () => {
+        const text = 'WW WW';
+        // `maxWidth` wraps this to 'WW\nWW' up front: a 20px glyph inside a 28px box.
+        const preserving: PointLabelDatum = {
+            point: { x: 200, y: 200, size: 1 },
+            label: { text, width: 50, height: 20 },
+            fit: {
+                text,
+                policy: { maxWidth: 30 },
+                font: FONT,
+                boxPadding: { top: 2, right: 4, bottom: 2, left: 4 },
+                boundByRegion: false,
+            },
+            anchor: undefined,
+            placement: 'inside',
+            placements: ['inside'],
+            gap: 1,
+            spacing: 0,
+            alwaysShow: false,
+        };
+        // Reaches 26px in: past the 20px glyph, but not past the box, so the retreat is affordable.
+        const clipping: LabelObstacle = {
+            kind: 'rect',
+            box: { x: 180, y: 217, width: 33, height: 35 },
+            category: 'label',
+        };
+
+        const placed = placeLabels(new Map([['s', seriesLabels([preserving])]]), bounds, 0, [clipping]).get('s')!;
+
+        expect(placed).toHaveLength(1);
+    });
 });
 
 describe('placeLabels candidate styles', () => {

--- a/packages/ag-charts-core/src/utils/geometry/labelPlacement.ts
+++ b/packages/ag-charts-core/src/utils/geometry/labelPlacement.ts
@@ -698,8 +698,9 @@ let cascadeStyle: CandidateStyleResolver | undefined;
 let cascadeFitSource: { width: number; height: number } | undefined;
 // Measurer for the configured font, looked up once per label rather than per shrink attempt.
 let cascadeMeasurer: TextMeasurer | undefined;
-// Narrowest glyph budget the unstyled source text can still be drawn whole in, or NaN until first needed.
-let cascadeMinRefitWidth = Number.NaN;
+// Narrowest glyph budget a re-fit of the unstyled source text can keep a character in, `undefined` until
+// first needed and `Infinity` once it is known that the text has no floor that can be told cheaply.
+let cascadeMinRefitWidth: number | undefined;
 let cascadeGap = 0;
 let cascadeSpacing = 0;
 let cascadeInflate = 0;
@@ -1606,72 +1607,98 @@ function shrunkCandidateIsClear(region: BoxBounds, inflate: number): boolean {
 }
 
 /**
- * The narrowest glyph budget a re-fit of the label's text can leave a character in, or 0 when that cannot
- * be told cheaply. `textWrap` breaks on the per-grapheme estimate and then confirms against the measured
- * width, so the smaller of the two is what a budget has to reach. Under `'hide'` a word broken by the
- * budget erases the label, so the widest word (the widest line, when wrapping is off) is the floor. Under
- * `'ellipsis'` a truncation keeps a prefix of the line, so a character survives only when a line's first
- * word fits whole or its first grapheme fits ahead of the ellipsis, and the cheapest line is the floor.
- * Only an unstyled plain string at the configured font qualifies: a segmented or shape-bound label wraps
- * by other rules and a hyphenating one can break inside a word.
+ * The narrowest glyph budget a re-fit of the label's text can leave a character in, or `Infinity` when
+ * that cannot be told cheaply. `textWrap` breaks on the per-grapheme estimate and then confirms against the
+ * measured width, so the smaller of the two is what a budget has to reach. Under `'hide'` a word broken by
+ * the budget erases the label, so the widest word (the whole line, when wrapping is off) is the floor, but
+ * only for a single line: a line whose first grapheme overflows is dropped without an ellipsis, leaving the
+ * rest of a multi-line label drawn. Under `'ellipsis'` a truncation keeps a prefix of the line, so a
+ * character survives only when a line's first word fits whole or its first grapheme fits ahead of the
+ * ellipsis, and the cheapest line is the floor. Only an unstyled plain string at the configured font
+ * qualifies: a segmented or shape-bound label wraps by other rules and a hyphenating one can break inside a
+ * word.
  */
 function minRefitWidth(fit: LabelFitDescriptor): number {
-    if (!Number.isNaN(cascadeMinRefitWidth)) return cascadeMinRefitWidth;
+    if (cascadeMinRefitWidth != null) return cascadeMinRefitWidth;
     const { policy, text } = fit;
     const { wrapping, overflowStrategy } = policy;
-    let floor = 0;
+    const hide = overflowStrategy === 'hide';
+    let floor = Infinity;
     if (
-        (overflowStrategy === 'hide' || overflowStrategy === 'ellipsis') &&
+        (hide || overflowStrategy === 'ellipsis') &&
         fit.fitOverflow == null &&
         policy.region == null &&
         !isArray(text) &&
         (wrapping == null || wrapping === 'on-space' || wrapping === 'never')
     ) {
-        const measurer = cascadeMeasurer ?? cachedTextMeasurer(fit.font);
-        const hide = overflowStrategy === 'hide';
-        const ellipsisWidth = hide ? 0 : measurer.textWidth(EllipsisChar);
-        let widestUnit = 0;
-        let narrowestLead = Infinity;
-        for (const line of toTextString(text).split(LineSplitter)) {
-            for (const unit of wrapping === 'never' ? [line.trimEnd()] : line.split(' ')) {
-                if (unit === '') continue;
-                const graphemes = graphemeSegments(unit);
-                let estimate = 0;
-                for (const grapheme of graphemes) {
-                    estimate += measurer.textWidth(grapheme);
-                }
-                const unitWidth = Math.min(estimate, measurer.textWidth(unit));
-                if (hide) {
-                    widestUnit = Math.max(widestUnit, unitWidth);
-                    continue;
-                }
-                // Only the line's leading word can survive a truncation, so the rest of the line is moot.
-                narrowestLead = Math.min(narrowestLead, unitWidth, measurer.textWidth(graphemes[0]) + ellipsisWidth);
-                break;
-            }
-        }
-        if (hide) {
-            floor = widestUnit;
-        } else if (narrowestLead !== Infinity) {
-            floor = narrowestLead;
+        const lines = toTextString(text).split(LineSplitter);
+        if (!hide) {
+            floor = narrowestLeadWidth(lines, wrapping);
+        } else if (lines.length === 1) {
+            floor = widestWordWidth(lines[0], wrapping);
         }
     }
     cascadeMinRefitWidth = floor;
     return floor;
 }
 
+type FitWrapping = LabelFitDescriptor['policy']['wrapping'];
+
+/** Width of `line`'s widest word, or of the whole line when wrapping is off; see {@link minRefitWidth}. */
+function widestWordWidth(line: string, wrapping: FitWrapping): number {
+    const measurer = cascadeMeasurer!;
+    let widest = 0;
+    for (const unit of wrapping === 'never' ? [line.trimEnd()] : line.split(' ')) {
+        if (unit !== '') {
+            widest = Math.max(widest, wordWidth(measurer, unit));
+        }
+    }
+    return widest;
+}
+
+/**
+ * The cheapest budget any of `lines` keeps a character in ahead of an ellipsis, or `Infinity` when none
+ * has a word; see {@link minRefitWidth}.
+ */
+function narrowestLeadWidth(lines: string[], wrapping: FitWrapping): number {
+    const measurer = cascadeMeasurer!;
+    const ellipsisWidth = measurer.textWidth(EllipsisChar);
+    let narrowest = Infinity;
+    for (const line of lines) {
+        // Only the line's leading word can survive a truncation, so the rest of the line is moot.
+        const lead = (wrapping === 'never' ? [line.trimEnd()] : line.split(' ')).find((unit) => unit !== '');
+        if (lead == null) continue;
+        const first = measurer.textWidth(graphemeSegments(lead)[0]) + ellipsisWidth;
+        narrowest = Math.min(narrowest, wordWidth(measurer, lead), first);
+    }
+    return narrowest;
+}
+
+/** The smaller of a word's per-grapheme estimate and its measured width, as `textWrap` judges a fit. */
+function wordWidth(measurer: TextMeasurer, word: string): number {
+    let estimate = 0;
+    for (const grapheme of graphemeSegments(word)) {
+        estimate += measurer.textWidth(grapheme);
+    }
+    return Math.min(estimate, measurer.textWidth(word));
+}
+
 /**
  * Whether losing a line of height is certain to erase the label's text. A height reduction only counts
- * from a whole line up, a narrower re-wrap never needs fewer lines than the current fit, and `'hide'`
- * erases the text once a line is clipped; so for a plain string with no overflow fallback the re-fit can
- * be failed without wrapping anything.
+ * from a whole line up, a single line re-wrapped narrower never needs fewer lines than the current fit,
+ * and `'hide'` erases the text once a line is clipped; so for a one-line plain string with no overflow
+ * fallback the re-fit can be failed without wrapping anything. A multi-line string is exempt: the wrap
+ * can drop whole lines silently (a line whose first grapheme overflows, or everything after a blank line
+ * when wrapping is off), so it may need fewer lines than it has now.
  */
 function erasesOnLostLine(fit: LabelFitDescriptor): boolean {
+    const { policy, text } = fit;
     return (
-        fit.policy.overflowStrategy === 'hide' &&
+        policy.overflowStrategy === 'hide' &&
         fit.fitOverflow == null &&
-        fit.policy.region == null &&
-        !isArray(fit.text)
+        policy.region == null &&
+        !isArray(text) &&
+        !toTextString(text).includes('\n')
     );
 }
 
@@ -1705,8 +1732,10 @@ function shrinkCompassCandidate(
     const floorX = upright ? 0 : lineHeight;
     const floorY = upright ? lineHeight : 0;
     // Most re-fits fail by breaking a word the budget cannot hold, so the reduction the text can afford
-    // caps the query and rejects the candidate before any text is wrapped.
-    const affordableWidth = unstyled ? candidateLabel.glyphWidth - minRefitWidth(fit) : Infinity;
+    // caps the query and rejects the candidate before any text is wrapped. A floor that cannot be told
+    // leaves the reduction uncapped: a preserving policy hands back its text however little room is left.
+    const floor = unstyled ? minRefitWidth(fit) : Infinity;
+    const affordableWidth = floor === Infinity ? Infinity : candidateLabel.glyphWidth - floor;
     const affordableHeight = unstyled && erasesOnLostLine(fit) ? 0 : Infinity;
     const widthCap = upright ? affordableWidth : affordableHeight;
     const heightCap = upright ? affordableHeight : affordableWidth;
@@ -2144,7 +2173,7 @@ function placeAvoidingLabel(
     const styled = resolveCandidateStyle != null;
     cascadeFitSource = fit == null || styled ? undefined : measureLabelText(fit.text, fit.font);
     styledSourceFont = '';
-    cascadeMinRefitWidth = Number.NaN;
+    cascadeMinRefitWidth = undefined;
     cascadeMeasurer = fit == null ? undefined : cachedTextMeasurer(fit.font);
     cascadeDatum = d;
     cascadeIndex = index;

--- a/packages/ag-charts-core/src/utils/geometry/labelPlacement.ts
+++ b/packages/ag-charts-core/src/utils/geometry/labelPlacement.ts
@@ -1609,11 +1609,11 @@ function shrunkCandidateIsClear(region: BoxBounds, inflate: number): boolean {
  * The narrowest glyph budget a re-fit of the label's text can leave a character in, or 0 when that cannot
  * be told cheaply. `textWrap` breaks on the per-grapheme estimate and then confirms against the measured
  * width, so the smaller of the two is what a budget has to reach. Under `'hide'` a word broken by the
- * budget erases the label, so the widest word (the widest line, when wrapping is off) is the floor; under
- * `'ellipsis'` a character survives only whole in a word that fits or ahead of an ellipsis, so the floor is
- * the cheaper of the narrowest word and the narrowest grapheme plus the ellipsis. Only an unstyled plain
- * string at the configured font qualifies: a segmented or shape-bound label wraps by other rules and a
- * hyphenating one can break inside a word.
+ * budget erases the label, so the widest word (the widest line, when wrapping is off) is the floor. Under
+ * `'ellipsis'` a truncation keeps a prefix of the line, so a character survives only when a line's first
+ * word fits whole or its first grapheme fits ahead of the ellipsis, and the cheapest line is the floor.
+ * Only an unstyled plain string at the configured font qualifies: a segmented or shape-bound label wraps
+ * by other rules and a hyphenating one can break inside a word.
  */
 function minRefitWidth(fit: LabelFitDescriptor): number {
     if (!Number.isNaN(cascadeMinRefitWidth)) return cascadeMinRefitWidth;
@@ -1622,37 +1622,57 @@ function minRefitWidth(fit: LabelFitDescriptor): number {
     let floor = 0;
     if (
         (overflowStrategy === 'hide' || overflowStrategy === 'ellipsis') &&
+        fit.fitOverflow == null &&
         policy.region == null &&
         !isArray(text) &&
         (wrapping == null || wrapping === 'on-space' || wrapping === 'never')
     ) {
         const measurer = cascadeMeasurer ?? cachedTextMeasurer(fit.font);
         const hide = overflowStrategy === 'hide';
+        const ellipsisWidth = hide ? 0 : measurer.textWidth(EllipsisChar);
         let widestUnit = 0;
-        let narrowestUnit = Infinity;
-        let narrowestGrapheme = Infinity;
+        let narrowestLead = Infinity;
         for (const line of toTextString(text).split(LineSplitter)) {
             for (const unit of wrapping === 'never' ? [line.trimEnd()] : line.split(' ')) {
                 if (unit === '') continue;
+                const graphemes = graphemeSegments(unit);
                 let estimate = 0;
-                for (const grapheme of graphemeSegments(unit)) {
-                    const width = measurer.textWidth(grapheme);
-                    estimate += width;
-                    narrowestGrapheme = Math.min(narrowestGrapheme, width);
+                for (const grapheme of graphemes) {
+                    estimate += measurer.textWidth(grapheme);
                 }
                 const unitWidth = Math.min(estimate, measurer.textWidth(unit));
-                widestUnit = Math.max(widestUnit, unitWidth);
-                narrowestUnit = Math.min(narrowestUnit, unitWidth);
+                if (hide) {
+                    widestUnit = Math.max(widestUnit, unitWidth);
+                    continue;
+                }
+                // Only the line's leading word can survive a truncation, so the rest of the line is moot.
+                narrowestLead = Math.min(narrowestLead, unitWidth, measurer.textWidth(graphemes[0]) + ellipsisWidth);
+                break;
             }
         }
         if (hide) {
             floor = widestUnit;
-        } else if (narrowestUnit !== Infinity) {
-            floor = Math.min(narrowestUnit, narrowestGrapheme + measurer.textWidth(EllipsisChar));
+        } else if (narrowestLead !== Infinity) {
+            floor = narrowestLead;
         }
     }
     cascadeMinRefitWidth = floor;
     return floor;
+}
+
+/**
+ * Whether losing a line of height is certain to erase the label's text. A height reduction only counts
+ * from a whole line up, a narrower re-wrap never needs fewer lines than the current fit, and `'hide'`
+ * erases the text once a line is clipped; so for a plain string with no overflow fallback the re-fit can
+ * be failed without wrapping anything.
+ */
+function erasesOnLostLine(fit: LabelFitDescriptor): boolean {
+    return (
+        fit.policy.overflowStrategy === 'hide' &&
+        fit.fitOverflow == null &&
+        fit.policy.region == null &&
+        !isArray(fit.text)
+    );
 }
 
 /**
@@ -1687,8 +1707,11 @@ function shrinkCompassCandidate(
     // Most re-fits fail by breaking a word the budget cannot hold, so the reduction the text can afford
     // caps the query and rejects the candidate before any text is wrapped.
     const affordableWidth = unstyled ? candidateLabel.glyphWidth - minRefitWidth(fit) : Infinity;
-    const widthCap = upright ? affordableWidth : Infinity;
-    const heightCap = upright ? Infinity : affordableWidth;
+    const affordableHeight = unstyled && erasesOnLostLine(fit) ? 0 : Infinity;
+    const widthCap = upright ? affordableWidth : affordableHeight;
+    const heightCap = upright ? affordableHeight : affordableWidth;
+    // Neither axis can give anything up, so no reduction the obstacles ask for is worth measuring.
+    if (widthCap <= 0 && heightCap <= 0) return false;
     if (!measureShrinkReduction(vec?.x ?? 0, vec?.y ?? 0, cascadeInflate, floorX, floorY, widthCap, heightCap)) {
         return false;
     }

--- a/packages/ag-charts-core/src/utils/geometry/labelPlacement.ts
+++ b/packages/ag-charts-core/src/utils/geometry/labelPlacement.ts
@@ -1,10 +1,11 @@
 import type { AgChartLabelOrientation, OverflowStrategy, PaddingOptions, TextWrap } from 'ag-charts-types';
 
-import { cachedTextMeasurer, measureTextSegments } from '../../rendering/textMeasurer';
+import { type TextMeasurer, cachedTextMeasurer, measureTextSegments } from '../../rendering/textMeasurer';
 import type { NormalisedTextOrSegments } from '../../types/normalised-options/normalisedCommonOptions';
 import type { Point, SizedPoint } from '../../types/scene';
 import type { FontOptions } from '../../types/text';
-import { toFontString, toTextString } from '../text/textUtils';
+import { LineSplitter } from '../../types/text';
+import { EllipsisChar, graphemeSegments, toFontString, toTextString } from '../text/textUtils';
 import {
     type LabelFit,
     type RegionAlign,
@@ -695,6 +696,10 @@ let cascadeOrientations: AgChartLabelOrientation[] | undefined;
 let cascadeSingleOrientation: AgChartLabelOrientation | undefined;
 let cascadeStyle: CandidateStyleResolver | undefined;
 let cascadeFitSource: { width: number; height: number } | undefined;
+// Measurer for the configured font, looked up once per label rather than per shrink attempt.
+let cascadeMeasurer: TextMeasurer | undefined;
+// Narrowest glyph budget the unstyled source text can still be drawn whole in, or NaN until first needed.
+let cascadeMinRefitWidth = Number.NaN;
 let cascadeGap = 0;
 let cascadeSpacing = 0;
 let cascadeInflate = 0;
@@ -852,6 +857,9 @@ type RetreatSide = 'left' | 'right' | 'top' | 'bottom';
 const shrinkIntrusion: Record<RetreatSide, number> = { left: 0, right: 0, top: 0, bottom: 0 };
 // Extent reduction and post-recentre translation those intrusions add up to.
 const shrinkReduction = { width: 0, height: 0 };
+// Intrusion beyond which the re-fit is known to erase the text, so the reduction query can stop early.
+let shrinkWidthCap = Infinity;
+let shrinkHeightCap = Infinity;
 const shrinkSlide: Point = { x: 0, y: 0 };
 // Which edge of the box the placement pins against its anchor: positive the min edge (left/top), negative
 // the max edge (right/bottom), zero neither — a centred box, whose every edge a shrink can move.
@@ -916,7 +924,7 @@ function affordableRetreat(retreat: number, extent: number, allowed: boolean, fl
 // Never returns a verdict: unlike the collision test this visits every obstacle, since the reduction has
 // to answer all of them. An obstacle sits in every grid cell it spans, so this visitor can see it more
 // than once: accumulating with `max` keeps the measurement idempotent.
-function accumulateObstacleReduction(o: LabelObstacle): void {
+function accumulateObstacleReduction(o: LabelObstacle): boolean | void {
     if (obstacleExcluded(o)) return;
     const testBox = candidateTestBox();
     if (testBox == null || !obstacleOverlapsBox(o, testBox)) return;
@@ -953,6 +961,14 @@ function accumulateObstacleReduction(o: LabelObstacle): void {
     // letting one unclearable obstacle suppress the reduction the others do have an answer for.
     if (best == null) return;
     shrinkIntrusion[best] = Math.max(shrinkIntrusion[best], sideRetreat[best]);
+    return shrinkExceedsCap();
+}
+
+function shrinkExceedsCap(): boolean {
+    return (
+        shrinkIntrusion.left + shrinkIntrusion.right > shrinkWidthCap ||
+        shrinkIntrusion.top + shrinkIntrusion.bottom > shrinkHeightCap
+    );
 }
 
 function spendableRetreat(retreat: number, floor: number): number {
@@ -987,7 +1003,8 @@ function accumulateRegionIntrusion(region: BoxBounds) {
 /**
  * Measures how far the candidate box has to shrink to clear the obstacles it hits and to come inside
  * `region`, into {@link shrinkReduction} and {@link shrinkSlide}. `false` when nothing it can shrink out
- * of the way intrudes.
+ * of the way intrudes, or when the intrusion passes `widthCap`/`heightCap`: the reduction the text can
+ * afford, beyond which the re-fit is known to fail and the remaining obstacles need not be visited.
  */
 function measureShrinkReduction(
     pinX: number,
@@ -995,8 +1012,12 @@ function measureShrinkReduction(
     inflate: number,
     floorX: number,
     floorY: number,
+    widthCap: number,
+    heightCap: number,
     region?: BoxBounds
 ): boolean {
+    shrinkWidthCap = widthCap;
+    shrinkHeightCap = heightCap;
     shrinkIntrusion.left = 0;
     shrinkIntrusion.right = 0;
     shrinkIntrusion.top = 0;
@@ -1009,7 +1030,7 @@ function measureShrinkReduction(
         accumulateRegionIntrusion(region);
     }
     inflateBoxInto(queryBox, candidateBox, inflate);
-    obstacleIndex.query(queryBox, accumulateObstacleReduction);
+    if (obstacleIndex.query(queryBox, accumulateObstacleReduction) || shrinkExceedsCap()) return false;
     shrinkReduction.width = shrinkIntrusion.left + shrinkIntrusion.right;
     shrinkReduction.height = shrinkIntrusion.top + shrinkIntrusion.bottom;
     // Only a centred box is moved: `positionCandidate` already re-hangs a pinned one off the same edge, so
@@ -1585,6 +1606,56 @@ function shrunkCandidateIsClear(region: BoxBounds, inflate: number): boolean {
 }
 
 /**
+ * The narrowest glyph budget a re-fit of the label's text can leave a character in, or 0 when that cannot
+ * be told cheaply. `textWrap` breaks on the per-grapheme estimate and then confirms against the measured
+ * width, so the smaller of the two is what a budget has to reach. Under `'hide'` a word broken by the
+ * budget erases the label, so the widest word (the widest line, when wrapping is off) is the floor; under
+ * `'ellipsis'` a character survives only whole in a word that fits or ahead of an ellipsis, so the floor is
+ * the cheaper of the narrowest word and the narrowest grapheme plus the ellipsis. Only an unstyled plain
+ * string at the configured font qualifies: a segmented or shape-bound label wraps by other rules and a
+ * hyphenating one can break inside a word.
+ */
+function minRefitWidth(fit: LabelFitDescriptor): number {
+    if (!Number.isNaN(cascadeMinRefitWidth)) return cascadeMinRefitWidth;
+    const { policy, text } = fit;
+    const { wrapping, overflowStrategy } = policy;
+    let floor = 0;
+    if (
+        (overflowStrategy === 'hide' || overflowStrategy === 'ellipsis') &&
+        policy.region == null &&
+        !isArray(text) &&
+        (wrapping == null || wrapping === 'on-space' || wrapping === 'never')
+    ) {
+        const measurer = cascadeMeasurer ?? cachedTextMeasurer(fit.font);
+        const hide = overflowStrategy === 'hide';
+        let widestUnit = 0;
+        let narrowestUnit = Infinity;
+        let narrowestGrapheme = Infinity;
+        for (const line of toTextString(text).split(LineSplitter)) {
+            for (const unit of wrapping === 'never' ? [line.trimEnd()] : line.split(' ')) {
+                if (unit === '') continue;
+                let estimate = 0;
+                for (const grapheme of graphemeSegments(unit)) {
+                    const width = measurer.textWidth(grapheme);
+                    estimate += width;
+                    narrowestGrapheme = Math.min(narrowestGrapheme, width);
+                }
+                const unitWidth = Math.min(estimate, measurer.textWidth(unit));
+                widestUnit = Math.max(widestUnit, unitWidth);
+                narrowestUnit = Math.min(narrowestUnit, unitWidth);
+            }
+        }
+        if (hide) {
+            floor = widestUnit;
+        } else if (narrowestUnit !== Infinity) {
+            floor = Math.min(narrowestUnit, narrowestGrapheme + measurer.textWidth(EllipsisChar));
+        }
+    }
+    cascadeMinRefitWidth = floor;
+    return floor;
+}
+
+/**
  * Second chance for a compass candidate that fits its region but hits an obstacle: the text is re-fitted to
  * the room the obstacles leave, and the candidate repositioned and re-tested. `true` leaves the shrunk
  * candidate in {@link candidateLabel}/{@link candidateBox} for the caller to record — a candidate that only
@@ -1609,11 +1680,19 @@ function shrinkCompassCandidate(
     // quarter-turned candidate.
     const upright = rotation % 180 === 0;
     const font = candidateFontAt(style?.font ?? fit.font);
-    const lineHeight = cachedTextMeasurer(font).lineHeight();
+    const unstyled = style == null && candidateTrialFontSize == null;
+    const lineHeight = (unstyled ? cascadeMeasurer! : cachedTextMeasurer(font)).lineHeight();
     const floorX = upright ? 0 : lineHeight;
     const floorY = upright ? lineHeight : 0;
-    if (!measureShrinkReduction(vec?.x ?? 0, vec?.y ?? 0, cascadeInflate, floorX, floorY)) return false;
-    const source = style == null && candidateTrialFontSize == null ? cascadeFitSource : styledFitSource(fit, font);
+    // Most re-fits fail by breaking a word the budget cannot hold, so the reduction the text can afford
+    // caps the query and rejects the candidate before any text is wrapped.
+    const affordableWidth = unstyled ? candidateLabel.glyphWidth - minRefitWidth(fit) : Infinity;
+    const widthCap = upright ? affordableWidth : Infinity;
+    const heightCap = upright ? Infinity : affordableWidth;
+    if (!measureShrinkReduction(vec?.x ?? 0, vec?.y ?? 0, cascadeInflate, floorX, floorY, widthCap, heightCap)) {
+        return false;
+    }
+    const source = unstyled ? cascadeFitSource : styledFitSource(fit, font);
     const reduceWidth = upright ? shrinkReduction.width : shrinkReduction.height;
     const reduceHeight = upright ? shrinkReduction.height : shrinkReduction.width;
     if (!refitCandidateShrunk(fit, font, source, style?.boxPadding ?? fit.boxPadding, reduceWidth, reduceHeight)) {
@@ -1660,7 +1739,18 @@ function shrinkPositionedCandidate(
     const fitTo = c.fitTo;
     if (fit == null || fitTo == null || (c.rotation ?? 0) % 360 !== 0) return false;
     const lineHeight = cachedTextMeasurer(fitTo.font ?? fit.font).lineHeight();
-    if (!measureShrinkReduction(anchorPinX(fitTo.anchor), anchorPinY(fitTo.anchor), inflate, 0, lineHeight, region)) {
+    if (
+        !measureShrinkReduction(
+            anchorPinX(fitTo.anchor),
+            anchorPinY(fitTo.anchor),
+            inflate,
+            0,
+            lineHeight,
+            Infinity,
+            Infinity,
+            region
+        )
+    ) {
         return false;
     }
     const styledFont = fitTo.font;
@@ -2031,6 +2121,8 @@ function placeAvoidingLabel(
     const styled = resolveCandidateStyle != null;
     cascadeFitSource = fit == null || styled ? undefined : measureLabelText(fit.text, fit.font);
     styledSourceFont = '';
+    cascadeMinRefitWidth = Number.NaN;
+    cascadeMeasurer = fit == null ? undefined : cachedTextMeasurer(fit.font);
     cascadeDatum = d;
     cascadeIndex = index;
     cascadePlacements = placements;

--- a/packages/ag-charts-core/src/utils/text/textUtils.test.ts
+++ b/packages/ag-charts-core/src/utils/text/textUtils.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
 import { LtrEmbedding, PopDirectionalFormatting } from '../../types/text';
-import { forceLtrNumbers, forceLtrNumbersIn, isDirectionNeutral, resolveTextAlign, toFontString } from './textUtils';
+import {
+    forceLtrNumbers,
+    forceLtrNumbersIn,
+    graphemeSegments,
+    isDirectionNeutral,
+    resolveTextAlign,
+    toFontString,
+} from './textUtils';
 
 const mark = (text: string) => LtrEmbedding + text + PopDirectionalFormatting;
 
@@ -222,6 +229,26 @@ describe('forceLtrNumbersIn', () => {
 
     it('marks an LTR-only number leading the text in an RTL paragraph', () => {
         expect(forceLtrNumbersIn('33ms', true)).toBe(mark('33ms'));
+    });
+});
+
+describe('graphemeSegments', () => {
+    it('splits printable ASCII into single characters', () => {
+        expect(graphemeSegments('Point 12')).toEqual(['P', 'o', 'i', 'n', 't', ' ', '1', '2']);
+        expect(graphemeSegments('')).toEqual([]);
+    });
+
+    it('keeps a surrogate pair together', () => {
+        expect(graphemeSegments('a\u{1F600}b')).toEqual(['a', '\u{1F600}', 'b']);
+    });
+
+    it('keeps a combining mark with its base character', () => {
+        expect(graphemeSegments('e\u0301x')).toEqual(['e\u0301', 'x']);
+    });
+
+    it('keeps a ZWJ emoji sequence whole', () => {
+        const family = '\u{1F468}\u200D\u{1F469}\u200D\u{1F467}';
+        expect(graphemeSegments(`${family}!`)).toEqual([family, '!']);
     });
 });
 

--- a/packages/ag-charts-core/src/utils/text/textUtils.ts
+++ b/packages/ag-charts-core/src/utils/text/textUtils.ts
@@ -207,7 +207,17 @@ const graphemeSegmenter =
         ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
         : undefined;
 
+/** Printable ASCII: every code unit is its own grapheme, so the segmenter has nothing to join. */
+function isPrintableAscii(text: string): boolean {
+    for (let i = 0; i < text.length; i++) {
+        const code = text.charCodeAt(i);
+        if (code < 0x20 || code > 0x7e) return false;
+    }
+    return true;
+}
+
 export function graphemeSegments(text: string): string[] {
+    if (isPrintableAscii(text)) return text.split('');
     if (graphemeSegmenter) {
         return Array.from(graphemeSegmenter.segment(text), (s) => s.segment);
     }


### PR DESCRIPTION
The `series-labels-collision` benchmark regressed against 14.1.0 (scatter single placement +24%, hover highlight +25%, bar cascade +50%). The cost is in the obstacle-driven shrink pass in `labelPlacement.ts`, which re-fits a colliding label's text via `textWrap` per candidate, plus a per-label style merge on every render. Independent, behaviour-preserving commits:

1. `graphemeSegments` splits printable ASCII directly instead of calling `Intl.Segmenter` per line and per truncation step. Non-ASCII text still goes through the segmenter.
2. The narrowest budget a re-fit can leave a character in is measured once per label and caps the obstacle-reduction query, so shrink attempts that `textWrap` would erase anyway are rejected before wrapping. The floor is derived from the same per-grapheme estimate and measured width `textWrap` decides with, so no placement decision changes.
3. Bubble and placed-label cartesian series resolve the inside/outside placement style once per placement rather than deep-merging it for every label on every render (styler path unchanged).
4. The caps are tightened: under `'ellipsis'` only a line's leading word or first grapheme plus the ellipsis can survive a truncation, and under `'hide'` losing a line of height always erases the text, so the query aborts on the first vertical intrusion.
5. Regression tests from #8123 pin three cases the caps got wrong (a preserving policy capped at its glyph width; multi-line `'hide'` labels whose wrap drops lines silently), and the follow-up commit confines the caps to the cases they can prove: an unknown floor leaves the reduction uncapped, and the `'hide'` width floor and height cap apply to single-line text only.

No snapshot moved. Benchmark numbers are in the PR comments.
