### PR TITLE
Fix ESM bundle rewriting className statics to temp identifiers

### DIFF
--- a/esbuild.config.cjs
+++ b/esbuild.config.cjs
@@ -178,11 +178,16 @@ function renameReferences(code, node, from, to) {
             return;
         }
         if (!n.type) return;
+        if (n.type === 'Property' && n.shorthand && n.value.type === 'Identifier') {
+            // `{ Foo }` shares one range between key and value, so expand it to `Foo: _c$0`.
+            if (n.value.name === from) ranges.push([n.start, n.end, `${from}: ${to}`]);
+            return;
+        }
         if (n.type === 'Identifier') {
             const isPropertyName =
                 (parent?.type === 'MemberExpression' && key === 'property' && !parent.computed) ||
-                (parent?.type === 'Property' && key === 'key' && !parent.computed && !parent.shorthand);
-            if (n.name === from && !isPropertyName) ranges.push([n.start, n.end]);
+                (parent?.type === 'Property' && key === 'key' && !parent.computed);
+            if (n.name === from && !isPropertyName) ranges.push([n.start, n.end, to]);
             return;
         }
         for (const childKey of Object.keys(n)) {
@@ -193,10 +198,10 @@ function renameReferences(code, node, from, to) {
     visit(node, null, null);
 
     let result = code.slice(node.start, node.end);
-    for (const [start, end] of ranges.reverse()) {
+    for (const [start, end, text] of ranges.reverse()) {
         const s = start - node.start;
         const e = end - node.start;
-        result = result.slice(0, s) + to + result.slice(e);
+        result = result.slice(0, s) + text + result.slice(e);
     }
     return result;
 }

--- a/esbuild.config.cjs
+++ b/esbuild.config.cjs
@@ -122,6 +122,12 @@ const pureTopLevelSideEffectsPlugin = {
 
                 const code = fsSync.readFileSync(file, 'utf8');
                 const annotated = annotatePureToplevel(code);
+                const corrupted = annotated.match(/\.className = "_c\$\d+"/);
+                if (corrupted) {
+                    throw new Error(
+                        `pure-toplevel-side-effects rewrote a className literal in ${file}: ${corrupted[0]}`
+                    );
+                }
                 if (annotated !== code) {
                     await fs.writeFile(file, annotated);
                 }
@@ -158,8 +164,41 @@ function hasSideEffect(node) {
     return false;
 }
 
-function escapeRegExp(s) {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+/**
+ * Rename every reference to `from` inside `node` to `to`, using identifier positions from
+ * the AST. Property names and string contents are left alone, so a static such as
+ * `Foo.className = "Foo"` keeps its literal.
+ */
+function renameReferences(code, node, from, to) {
+    const ranges = [];
+    const visit = (n, parent, key) => {
+        if (!n || typeof n !== 'object') return;
+        if (Array.isArray(n)) {
+            for (const item of n) visit(item, parent, key);
+            return;
+        }
+        if (!n.type) return;
+        if (n.type === 'Identifier') {
+            const isPropertyName =
+                (parent?.type === 'MemberExpression' && key === 'property' && !parent.computed) ||
+                (parent?.type === 'Property' && key === 'key' && !parent.computed && !parent.shorthand);
+            if (n.name === from && !isPropertyName) ranges.push([n.start, n.end]);
+            return;
+        }
+        for (const childKey of Object.keys(n)) {
+            if (childKey === 'type' || childKey === 'start' || childKey === 'end') continue;
+            visit(n[childKey], n, childKey);
+        }
+    };
+    visit(node, null, null);
+
+    let result = code.slice(node.start, node.end);
+    for (const [start, end] of ranges.reverse()) {
+        const s = start - node.start;
+        const e = end - node.start;
+        result = result.slice(0, s) + to + result.slice(e);
+    }
+    return result;
 }
 
 const CALL_LIKE = new Set(['CallExpression', 'NewExpression', 'TaggedTemplateExpression']);
@@ -247,10 +286,7 @@ function annotatePureToplevel(code) {
                     //        var _Foo = /*#__PURE__*/ (() => { var _c$0 = <init>; <expr1_rewritten>; return _c$0; })();
                     const initCode = code.slice(decl.init.start, decl.init.end);
                     const tmpVar = `_c$${tmpVarCounter++}`;
-                    const varNameRe = new RegExp(`\\b${escapeRegExp(varName)}\\b`, 'g');
-                    const exprsCode = trailingExprs
-                        .map((e) => code.slice(e.start, e.end).replace(varNameRe, tmpVar))
-                        .join(' ');
+                    const exprsCode = trailingExprs.map((e) => renameReferences(code, e, varName, tmpVar)).join(' ');
                     const lastExpr = trailingExprs[trailingExprs.length - 1];
                     edits.push({
                         pos: decl.init.start,


### PR DESCRIPTION
The `pure-toplevel-side-effects` esbuild plugin renamed a class variable inside its trailing static assignments with a text regex, which also matched string literals. Any class whose variable name equals its `className` string ended up in `main.esm.mjs` as `_c$91.className = "_c$91"`, so `createId()` yields series ids like `_c$91-1` for ESM consumers. The bug has been latent since the plugin landed (#6589) and was surfaced on the docs site when AG-17103 switched the TypeScript and framework example runners from the CJS entry to `main.esm.mjs`: clicking a bar node in the `seriesNodeClick` example logs `Series: _c$91-1`.

This renames references via acorn identifier positions, skipping property names and string contents, and fails the build if a `className` literal is ever rewritten again.

Verified: rebuilt community and enterprise bundles have zero corrupted `className` statics (previously 25 and 38), `test:validate-size` passes, community and enterprise tests pass apart from a quadrant preset snapshot that also fails on unmodified `b14.2.0`.