### PR TITLE
Cover the label shrink pass' overflow caps with regression tests

### DIFF
--- a/packages/ag-charts-community/src/chart/series/cartesian/labelShrinkCaps.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/labelShrinkCaps.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { AgChartInstance } from 'ag-charts-types';
+
+import { AgCharts } from '../../../api/agCharts';
+import {
+    deproxy,
+    prepareTestOptions,
+    setupMockCanvas,
+    setupMockConsole,
+    waitForChartStability,
+} from '../../test/utils';
+
+// `truncate: false` with `collision.alwaysShow: false` is what the engine reads as
+// `overflowStrategy: 'hide'`; neither is on the line series' typed label surface, hence the casts.
+describe('label shrink pass overflow caps', () => {
+    setupMockConsole();
+
+    let chart: AgChartInstance;
+    setupMockCanvas();
+
+    afterEach(() => {
+        chart?.destroy();
+    });
+
+    // The first label placed becomes the second's only obstacle, so the second has to shrink to fit
+    // beside it; markers are off so nothing else obstructs, and the axes hold a pixel-like domain.
+    const renderTwoLabelledPoints = async (second: { x: number; y: number }, label: object) => {
+        const options = {
+            data: [{ x: 400, y: 200 }, second],
+            legend: { enabled: false },
+            axes: {
+                x: { type: 'number', position: 'bottom', min: 0, max: 800 },
+                y: { type: 'number', position: 'left', min: 0, max: 400 },
+            },
+            series: [
+                {
+                    type: 'line',
+                    xKey: 'x',
+                    yKey: 'y',
+                    marker: { enabled: false },
+                    label: {
+                        enabled: true,
+                        fontSize: 12,
+                        placement: ['top'],
+                        truncate: false,
+                        collision: { alwaysShow: false },
+                        ...label,
+                    },
+                },
+            ],
+        };
+        prepareTestOptions(options as any);
+        chart = AgCharts.create(options as any);
+        await waitForChartStability(chart);
+    };
+
+    // Rendered label text has no public accessor, so the label selection is the only channel for it.
+    const renderedLabelTexts = (): string[] => {
+        const series = deproxy(chart as any).series[0] as unknown as {
+            labelSelection: { nodes(): { visible: boolean; text?: unknown }[] };
+        };
+        expect(series).toHaveProperty('labelSelection');
+        return series.labelSelection
+            .nodes()
+            .filter((node) => node.visible)
+            .map((node) => String(node.text ?? ''));
+    };
+
+    // 'MMMM' is wider than the room left over, so its line is dropped without an ellipsis — not the
+    // truncation `'hide'` erases on — leaving 'i', which is narrower than a single 'M', to draw.
+    it('keeps the lines of a multi-line hide label that still fit the room an obstacle leaves', async () => {
+        await renderTwoLabelledPoints({ x: 408, y: 200 }, { wrapping: 'on-space', formatter: () => 'MMMM\ni' });
+
+        expect(renderedLabelTexts()).toEqual(['MMMM\ni', 'i']);
+    });
+
+    // A blank line ends a `'never'` wrap early, so losing a line of height leaves 'a' drawn whole.
+    it('keeps the first line of a hide label whose blank line ends the wrap', async () => {
+        await renderTwoLabelledPoints({ x: 400, y: 184 }, { wrapping: 'never', formatter: () => 'a\n\nb' });
+
+        expect(renderedLabelTexts()).toEqual(['a\n\nb', 'a']);
+    });
+});

--- a/packages/ag-charts-core/src/utils/geometry/labelPlacement.test.ts
+++ b/packages/ag-charts-core/src/utils/geometry/labelPlacement.test.ts
@@ -2342,6 +2342,40 @@ describe('placeLabels obstacle-driven shrink', () => {
             placeLabels(new Map([['s', seriesLabels([datum])]]), bounds, 0, []).get('s')![0].text;
         expect(textAt(insideLabel({ threshold: 6 }))).toBe(textAt(insideLabel()));
     });
+
+    // With no `overflowStrategy` the re-fit hands back drawable text however little room is left, so
+    // the reduction must stay uncapped for such a policy however narrow the glyph already is.
+    it('keeps a label with no overflow strategy that an obstacle clips by more than its glyph width', () => {
+        const text = 'WW WW';
+        // `maxWidth` wraps this to 'WW\nWW' up front: a 20px glyph inside a 28px box.
+        const preserving: PointLabelDatum = {
+            point: { x: 200, y: 200, size: 1 },
+            label: { text, width: 50, height: 20 },
+            fit: {
+                text,
+                policy: { maxWidth: 30 },
+                font: FONT,
+                boxPadding: { top: 2, right: 4, bottom: 2, left: 4 },
+                boundByRegion: false,
+            },
+            anchor: undefined,
+            placement: 'inside',
+            placements: ['inside'],
+            gap: 1,
+            spacing: 0,
+            alwaysShow: false,
+        };
+        // Reaches 26px in: past the 20px glyph, but not past the box, so the retreat is affordable.
+        const clipping: LabelObstacle = {
+            kind: 'rect',
+            box: { x: 180, y: 217, width: 33, height: 35 },
+            category: 'label',
+        };
+
+        const placed = placeLabels(new Map([['s', seriesLabels([preserving])]]), bounds, 0, [clipping]).get('s')!;
+
+        expect(placed).toHaveLength(1);
+    });
 });
 
 describe('placeLabels candidate styles', () => {


### PR DESCRIPTION
The shrink pass rejects an obstacle re-fit up front when the room the obstacles leave is judged too small for the text. Three of those judgements are wrong, and nothing currently pins them. These tests fail on the shrink-cap changes and pass on b14.2.0.

labelShrinkCaps.test.ts drives two charts through AgCharts.create, each a line series whose first placed label is the only obstacle the second has to shrink around:

- A multi-line label under `overflowStrategy: 'hide'` is failed when the room cannot hold its widest word. That holds for a single line, but a line whose first character alone overflows is dropped without an ellipsis, which is not the truncation `'hide'` erases on, so the remaining lines still draw.
- The same rejection on the height axis treats losing a line as erasing the label. A blank line ends a `'never'` wrap early, so the first line still draws.

labelPlacement.test.ts adds the third case at the engine level, because no combination of public chart options was found that reaches it: a policy with no `overflowStrategy` never erases its text, so the reduction must stay uncapped, but it is capped at the glyph width and the label is dropped instead.