### PR TITLE
Move the footer legal links into their own strip under the columns

### DIFF
--- a/external/ag-website-shared/src/components/footer/Footer.module.scss
+++ b/external/ag-website-shared/src/components/footer/Footer.module.scss
@@ -186,3 +186,56 @@
     padding-top: $spacing-size-4;
     color: var(--color-text-secondary);
 }
+
+// Legal and policy links in their own strip under the menu columns, so they no longer compete with
+// navigation. Left-aligned with pipe separators on desktop; centred and separated by the gap alone
+// below that, since clipping the leading separator of a wrapped row relies on left alignment.
+.legalBar {
+    display: flex;
+    justify-content: center;
+    max-width: calc(var(--layout-max-width-small) + var(--layout-horizontal-margins) * 2);
+    margin-right: auto;
+    margin-left: auto;
+    padding: $spacing-size-6 $spacing-size-2 0;
+}
+
+.legalLinks {
+    $legal-links-gap: $spacing-size-4;
+
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: $spacing-size-2 $legal-links-gap;
+    margin: 0;
+    // Clips the separator of whichever link starts a wrapped row, since it sits left of the list edge.
+    overflow: hidden;
+
+    li {
+        position: relative;
+    }
+
+    a {
+        color: var(--color-text-secondary);
+        font-weight: var(--text-regular);
+
+        &:hover {
+            color: var(--color-text-primary);
+            opacity: 0.6;
+        }
+    }
+
+    @media screen and (min-width: $breakpoint-site-footer-five-column) {
+        justify-content: flex-start;
+
+        // Pipe separators, centred in the gap before each link and drawn in CSS with an empty
+        // alternative text so they are never announced.
+        li::before {
+            content: '|' #{'/'} '';
+            position: absolute;
+            left: calc(#{$legal-links-gap} / -2);
+            transform: translateX(-50%);
+            color: var(--color-text-secondary);
+            opacity: 0.4;
+        }
+    }
+}

--- a/external/ag-website-shared/src/components/footer/Footer.tsx
+++ b/external/ag-website-shared/src/components/footer/Footer.tsx
@@ -9,11 +9,18 @@ import GithubSlugger from 'github-slugger';
 import styles from './Footer.module.scss';
 
 /**
+ * A footer link, plus the cookie-preferences flag that opens the consent dialog instead of
+ * navigating. Declared here so a site whose footer type predates `showCookiesPrefs` still
+ * type-checks this component.
+ */
+type FooterLink = FooterItem['links'][number] & { showCookiesPrefs?: boolean };
+
+/**
  * A footer group renders as a menu column unless its `placement` moves it into the legal strip
  * under the columns. Declared here so a site whose footer type predates `placement` still renders
  * every group as a column.
  */
-type FooterGroup = FooterItem & { placement?: 'legal' };
+type FooterGroup = Omit<FooterItem, 'links'> & { placement?: 'legal'; links: FooterLink[] };
 
 interface FooterProps {
     showMicrosoftMessage?: boolean;
@@ -67,7 +74,7 @@ const LegalLinks = ({ group }: { group: FooterGroup }) => {
 
     return (
         <ul className={classNames('list-style-none', 'text-sm', styles.legalLinks)} aria-label={group.title}>
-            {group.links.map(({ name, url, newTab, showCookiesPrefs }) => (
+            {group.links.map(({ name, url, newTab, showCookiesPrefs }: FooterLink) => (
                 <li key={name}>
                     <a
                         id={`${slugger.slug(name)}-nav`}

--- a/external/ag-website-shared/src/components/footer/Footer.tsx
+++ b/external/ag-website-shared/src/components/footer/Footer.tsx
@@ -8,16 +8,9 @@ import GithubSlugger from 'github-slugger';
 
 import styles from './Footer.module.scss';
 
-/**
- * A footer group renders as a menu column unless its `placement` moves it into the legal strip
- * under the columns. Declared here so a site whose footer type predates `placement` still renders
- * every group as a column.
- */
-type FooterGroup = FooterItem & { placement?: 'legal' };
-
 interface FooterProps {
     showMicrosoftMessage?: boolean;
-    footerItems: FooterGroup[];
+    footerItems: FooterItem[];
 }
 
 const toggleCookiesPrefs = (event) => {
@@ -28,7 +21,7 @@ const toggleCookiesPrefs = (event) => {
     window.__enzuzoApi.prefCenter.show();
 };
 
-const MenuColumns = ({ footerItems }: { footerItems: FooterGroup[] }) => {
+const MenuColumns = ({ footerItems }: { footerItems: FooterItem[] }) => {
     const slugger = new GithubSlugger();
 
     return footerItems.map(({ title, links }) => {
@@ -62,7 +55,7 @@ const MenuColumns = ({ footerItems }: { footerItems: FooterGroup[] }) => {
 };
 
 // Separators between the links are drawn in CSS so they stay out of the accessibility tree.
-const LegalLinks = ({ group }: { group: FooterGroup }) => {
+const LegalLinks = ({ group }: { group: FooterItem }) => {
     const slugger = new GithubSlugger();
 
     return (

--- a/external/ag-website-shared/src/components/footer/Footer.tsx
+++ b/external/ag-website-shared/src/components/footer/Footer.tsx
@@ -8,21 +8,28 @@ import GithubSlugger from 'github-slugger';
 
 import styles from './Footer.module.scss';
 
+/**
+ * A footer group renders as a menu column unless its `placement` moves it into the legal strip
+ * under the columns. Declared here so a site whose footer type predates `placement` still renders
+ * every group as a column.
+ */
+type FooterGroup = FooterItem & { placement?: 'legal' };
+
 interface FooterProps {
     showMicrosoftMessage?: boolean;
-    footerItems: FooterItem[];
+    footerItems: FooterGroup[];
 }
 
-const MenuColumns = ({ footerItems }: { footerItems: FooterItem[] }) => {
+const toggleCookiesPrefs = (event) => {
+    event.preventDefault();
+
+    if (!window.__enzuzoApi) return;
+
+    window.__enzuzoApi.prefCenter.show();
+};
+
+const MenuColumns = ({ footerItems }: { footerItems: FooterGroup[] }) => {
     const slugger = new GithubSlugger();
-
-    const toggleCookiesPrefs = (event) => {
-        event.preventDefault();
-
-        if (!window.__enzuzoApi) return;
-
-        window.__enzuzoApi.prefCenter.show();
-    };
 
     return footerItems.map(({ title, links }) => {
         // Associate each link list with its (non-heading) title so assistive tech still announces the
@@ -54,7 +61,33 @@ const MenuColumns = ({ footerItems }: { footerItems: FooterItem[] }) => {
     });
 };
 
+// Separators between the links are drawn in CSS so they stay out of the accessibility tree.
+const LegalLinks = ({ group }: { group: FooterGroup }) => {
+    const slugger = new GithubSlugger();
+
+    return (
+        <ul className={classNames('list-style-none', 'text-sm', styles.legalLinks)} aria-label={group.title}>
+            {group.links.map(({ name, url, newTab, showCookiesPrefs }) => (
+                <li key={name}>
+                    <a
+                        id={`${slugger.slug(name)}-nav`}
+                        tabIndex={0}
+                        href={urlWithBaseUrl(url)}
+                        onClick={showCookiesPrefs ? toggleCookiesPrefs : undefined}
+                        {...(newTab ? { target: '_blank', rel: 'noreferrer' } : {})}
+                    >
+                        {name}
+                    </a>
+                </li>
+            ))}
+        </ul>
+    );
+};
+
 export const Footer = ({ showMicrosoftMessage, footerItems }: FooterProps) => {
+    const columns = footerItems.filter((item) => !item.placement);
+    const legalGroup = footerItems.find((item) => item.placement === 'legal');
+
     return (
         <footer className={styles.footer}>
             <div className={classNames(styles.footerColumns, 'layout-grid')}>
@@ -93,8 +126,13 @@ export const Footer = ({ showMicrosoftMessage, footerItems }: FooterProps) => {
                         )}
                     </div>
                 </div>
-                <MenuColumns footerItems={footerItems} />
+                <MenuColumns footerItems={columns} />
             </div>
+            {legalGroup && (
+                <div className={classNames(styles.legalBar, 'layout-grid')}>
+                    <LegalLinks group={legalGroup} />
+                </div>
+            )}
         </footer>
     );
 };

--- a/external/ag-website-shared/src/components/footer/Footer.tsx
+++ b/external/ag-website-shared/src/components/footer/Footer.tsx
@@ -1,4 +1,4 @@
-import type { FooterItem } from '@ag-grid-types';
+import type { FooterItem, FooterLink } from '@ag-grid-types';
 import { DevToolsToggle } from '@ag-website-shared/components/dev-tools/DevTools';
 import { Icon } from '@ag-website-shared/components/icon/Icon';
 import { SiteLogo } from '@components/SiteLogo';
@@ -9,18 +9,11 @@ import GithubSlugger from 'github-slugger';
 import styles from './Footer.module.scss';
 
 /**
- * A footer link, plus the cookie-preferences flag that opens the consent dialog instead of
- * navigating. Declared here so a site whose footer type predates `showCookiesPrefs` still
- * type-checks this component.
- */
-type FooterLink = FooterItem['links'][number] & { showCookiesPrefs?: boolean };
-
-/**
  * A footer group renders as a menu column unless its `placement` moves it into the legal strip
  * under the columns. Declared here so a site whose footer type predates `placement` still renders
  * every group as a column.
  */
-type FooterGroup = Omit<FooterItem, 'links'> & { placement?: 'legal'; links: FooterLink[] };
+type FooterGroup = FooterItem & { placement?: 'legal' };
 
 interface FooterProps {
     showMicrosoftMessage?: boolean;
@@ -48,7 +41,7 @@ const MenuColumns = ({ footerItems }: { footerItems: FooterGroup[] }) => {
                     {title}
                 </span>
                 <ul className="list-style-none" aria-labelledby={titleId}>
-                    {links.map(({ name, url, newTab, iconName, showCookiesPrefs }: any) => (
+                    {links.map(({ name, url, newTab, iconName, showCookiesPrefs }: FooterLink) => (
                         <li key={`${title}_${name}`}>
                             <a
                                 id={`${slugger.slug(name)}-nav`}

--- a/packages/ag-charts-website/src/content.config.ts
+++ b/packages/ag-charts-website/src/content.config.ts
@@ -1,3 +1,4 @@
+import type { IconName } from '@ag-website-shared/components/icon/Icon';
 import { FRAMEWORKS, INTERNAL_FRAMEWORKS } from '@constants';
 // NOTE: Use glob, instead of file for single object files unless the file is an
 // array of objects
@@ -91,7 +92,9 @@ const footer = defineCollection({
                     url: z.string(),
                     newTab: z.boolean().optional(),
                     showCookiesPrefs: z.boolean().optional(),
-                    iconName: z.string().optional(),
+                    // Typed as IconName without importing the icon map, which would pull the SVG and React icon
+                    // modules into content config loading. Names are not validated at load time.
+                    iconName: z.custom<IconName>((value) => typeof value === 'string').optional(),
                 })
             ),
         })

--- a/packages/ag-charts-website/src/content.config.ts
+++ b/packages/ag-charts-website/src/content.config.ts
@@ -83,6 +83,8 @@ const footer = defineCollection({
     schema: z.array(
         z.object({
             title: z.string(),
+            /** Where the group renders: the legal strip under the columns, or (default) a menu column. */
+            placement: z.enum(['legal']).optional(),
             links: z.array(
                 z.object({
                     name: z.string(),

--- a/packages/ag-charts-website/src/content/footer/footer.json
+++ b/packages/ag-charts-website/src/content/footer/footer.json
@@ -69,31 +69,6 @@
             {
                 "name": "Contact Us",
                 "url": "/contact/"
-            },
-            {
-                "name": "Terms of Use",
-                "url": "https://www.ag-grid.com/terms-of-use/"
-            },
-            {
-                "name": "Privacy Policy",
-                "url": "https://www.ag-grid.com/privacy/"
-            },
-            {
-                "name": "Cookies Policy",
-                "url": "https://www.ag-grid.com/cookies/"
-            },
-            {
-                "name": "Manage Cookies",
-                "url": "#manage_cookies",
-                "showCookiesPrefs": true
-            },
-            {
-                "name": "Modern Slavery",
-                "url": "https://www.ag-grid.com/modern-slavery/"
-            },
-            {
-                "name": "Sitemap",
-                "url": "https://www.ag-grid.com/charts/sitemap/"
             }
         ]
     },
@@ -119,6 +94,37 @@
                 "name": "LinkedIn",
                 "url": "https://www.linkedin.com/company/ag-grid",
                 "iconName": "linkedin"
+            }
+        ]
+    },
+    {
+        "title": "Legal",
+        "placement": "legal",
+        "links": [
+            {
+                "name": "Terms of Use",
+                "url": "https://www.ag-grid.com/terms-of-use/"
+            },
+            {
+                "name": "Privacy Policy",
+                "url": "https://www.ag-grid.com/privacy/"
+            },
+            {
+                "name": "Cookies Policy",
+                "url": "https://www.ag-grid.com/cookies/"
+            },
+            {
+                "name": "Manage Cookies",
+                "url": "#manage_cookies",
+                "showCookiesPrefs": true
+            },
+            {
+                "name": "Modern Slavery",
+                "url": "https://www.ag-grid.com/modern-slavery/"
+            },
+            {
+                "name": "Sitemap",
+                "url": "https://www.ag-grid.com/charts/sitemap/"
             }
         ]
     }

--- a/packages/ag-charts-website/src/types/ag-grid.d.ts
+++ b/packages/ag-charts-website/src/types/ag-grid.d.ts
@@ -54,6 +54,8 @@ export interface ApiMenuItem {
 
 export interface FooterItem {
     title: string;
+    /** Where the group renders: the legal strip under the columns, or (default) a menu column. */
+    placement?: 'legal';
     links: {
         name: string;
         url: string;

--- a/packages/ag-charts-website/src/types/ag-grid.d.ts
+++ b/packages/ag-charts-website/src/types/ag-grid.d.ts
@@ -52,15 +52,17 @@ export interface ApiMenuItem {
     path: string;
 }
 
+export interface FooterLink {
+    name: string;
+    url: string;
+    newTab?: boolean;
+    showCookiesPrefs?: boolean;
+    iconName: string;
+}
+
 export interface FooterItem {
     title: string;
     /** Where the group renders: the legal strip under the columns, or (default) a menu column. */
     placement?: 'legal';
-    links: {
-        name: string;
-        url: string;
-        newTab?: boolean;
-        showCookiesPrefs?: boolean;
-        iconName: string;
-    }[];
+    links: FooterLink[];
 }

--- a/packages/ag-charts-website/src/types/ag-grid.d.ts
+++ b/packages/ag-charts-website/src/types/ag-grid.d.ts
@@ -57,7 +57,7 @@ export interface FooterLink {
     url: string;
     newTab?: boolean;
     showCookiesPrefs?: boolean;
-    iconName: string;
+    iconName?: IconName;
 }
 
 export interface FooterItem {

--- a/packages/ag-charts-website/src/utils/markdown-pages/chartsFrontmatter.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/chartsFrontmatter.test.ts
@@ -14,11 +14,15 @@ describe('getFooterRelatedLinks', () => {
         expect(titlesFor('/roadmap/')).toContain('Changelog');
         expect(titlesFor('/roadmap/')).toContain('Documentation Archive');
         expect(titlesFor('/contact/')).toContain('About');
-        expect(titlesFor('/contact/')).toContain('Privacy Policy');
+        expect(titlesFor('/sitemap/')).toContain('Privacy Policy');
+    });
+
+    test('keeps legal pages out of the company group now that the footer lists them separately', () => {
+        expect(titlesFor('/sitemap/')).not.toContain('About');
     });
 
     test('excludes the cookie-preferences control, which opens a dialog rather than a page', () => {
-        expect(titlesFor('/contact/')).not.toContain('Manage Cookies');
+        expect(titlesFor('/sitemap/')).not.toContain('Manage Cookies');
     });
 
     test('excludes the page itself', () => {
@@ -37,7 +41,7 @@ describe('getFooterRelatedLinks', () => {
     test('matches a footer entry written with the origin and the /charts base path', () => {
         // The footer lists the sitemap as a full production URL, so the comparison has to ignore
         // both the origin and the base path the charts site is served under.
-        expect(titlesFor('/sitemap/')).toContain('About');
+        expect(titlesFor('/sitemap/')).toContain('Privacy Policy');
     });
 
     test('returns nothing for a page the footer does not list, or when no page is given', () => {


### PR DESCRIPTION
## Summary

Stacked on #8127, which adds the Manage Cookies link. Ports ag-grid/ag-grid#15159 to the charts site. The legal and policy links (Terms of Use, Privacy Policy, Cookies Policy, Manage Cookies, Modern Slavery, Sitemap) move out of **The Company** column into a pipe-separated strip under the footer columns. Everything else about the footer is unchanged.

- Footer groups in `footer.json` gain an optional `placement: "legal"`. Groups without it render as columns as before.
- Existing links are only regrouped; nothing is removed.
- The shared `Footer` component change is identical to the grid one, so the next `ag-website-shared` subrepo sync will be a no-op for these files.
- The markdown related-links test is updated for the new grouping.
- Types footer link `iconName` as the icon component's `IconName` in the site types and the footer content schema, so the shared component's `<Icon name>` prop type-checks. Fixes the site types' import path for `IconName` where it was wrong or missing.

## Test plan

- [x] `yarn nx run-many -t lint,test -p ag-charts-website` passes