### PR TITLE
Render an empty chart when the lead series type has no registered module

### DIFF
--- a/packages/ag-charts-community/src/api/agCharts.test.ts
+++ b/packages/ag-charts-community/src/api/agCharts.test.ts
@@ -581,55 +581,84 @@ describe('AgCharts', () => {
             return messages;
         }
 
-        it('reports the implicit `line` default and renders nothing instead of crashing', async () => {
-            await withOnlyBarRegistered(() => {
-                expect(() => (chart = AgCharts.create({ container } as AgChartOptions))).not.toThrow();
+        // No series survive, yet the captions and chart-level defaults are resolved and applied.
+        function expectEmptyChartWithDefaults(title: string) {
+            const chartInstance = deproxy(chart);
+            expect(chartInstance.series).toHaveLength(0);
+            expect(chartInstance.ctx.chartState.getValue('options', 'title')?.text).toBe(title);
+            expect(chartInstance.ctx.chartState.getValue('options', 'padding')).toBeDefined();
+            expect(chartInstance.ctx.chartState.getValue('options', 'touch')).toBeDefined();
+        }
+
+        it('reports the implicit `line` default and renders an empty chart', async () => {
+            await withOnlyBarRegistered(async () => {
+                expect(
+                    () => (chart = AgCharts.create({ container, title: { text: 'Implicit' } } as AgChartOptions))
+                ).not.toThrow();
+                await chart.waitForUpdate();
             });
 
             const messages = takeErrorMessages();
             expect(messages.some((m) => m.includes('required modules are not registered'))).toBe(true);
             expect(messages.some((m) => m.includes('LineSeriesModule'))).toBe(true);
-            expect(messages.some((m) => m.includes("reading 'dragAction'"))).toBe(false);
-            expect(deproxy(chart).series).toHaveLength(0);
+            expect(messages).toHaveLength(1);
+            expectEmptyChartWithDefaults('Implicit');
         });
 
-        it('reports an explicit series type with no module and renders nothing instead of crashing', async () => {
-            await withOnlyBarRegistered(() => {
+        it('reports an explicit series type with no module and renders an empty chart', async () => {
+            await withOnlyBarRegistered(async () => {
                 expect(
                     () =>
                         (chart = AgCharts.create({
                             container,
+                            title: { text: 'Explicit' },
                             data: [{ x: 'a', y: 1 }],
                             series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
                         } as AgChartOptions))
                 ).not.toThrow();
+                await chart.waitForUpdate();
             });
 
             const messages = takeErrorMessages();
             expect(messages.some((m) => m.includes('LineSeriesModule'))).toBe(true);
-            expect(messages.some((m) => m.includes("reading 'dragAction'"))).toBe(false);
-            expect(deproxy(chart).series).toHaveLength(0);
+            expect(messages).toHaveLength(1);
+            expectEmptyChartWithDefaults('Explicit');
         });
 
-        it('replaces the refresh listener, so a refresh after the module is registered applies the latest options', async () => {
-            let created: AgChartInstance | undefined;
+        it('reports an enterprise series type with no module and renders an empty chart', async () => {
+            expect(
+                () =>
+                    (chart = AgCharts.create({
+                        container,
+                        title: { text: 'Enterprise' },
+                        data: [{ month: 'Jan', region: 'North', revenue: 130 }],
+                        series: [{ type: 'heatmap', xKey: 'month', yKey: 'region', colorKey: 'revenue' }],
+                    } as AgChartOptions))
+            ).not.toThrow();
+            await chart.waitForUpdate();
+
+            const messages = takeErrorMessages();
+            expect(messages.some((m) => m.includes('HeatmapSeriesModule'))).toBe(true);
+            expect(messages).toHaveLength(1);
+            expectEmptyChartWithDefaults('Enterprise');
+        });
+
+        it('applies the latest options once the module is registered and a refresh is requested', async () => {
             await withOnlyBarRegistered(async () => {
-                created = AgCharts.create({
+                chart = AgCharts.create({
                     container,
                     data: [{ x: 'a', y: 1 }],
                     series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
                 } as AgChartOptions);
-                chart = created!;
                 await chart.waitForUpdate();
 
-                // Skipped — no line module yet — but it must still own the refresh listener.
                 await chart.update({
                     container,
                     data: [{ x: 'a', y: 1 }],
                     series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
                 } as AgChartOptions);
                 takeErrorMessages();
-                expect(deproxy(chart).series.map((s) => s.type)).toEqual(['bar']);
+                expect(deproxy(chart).series).toHaveLength(0);
 
                 ModuleRegistry.registerModules([LineSeriesModule]);
                 deproxy(chart).ctx.eventsHub.emit('chart:request-refresh', null);
@@ -637,68 +666,6 @@ describe('AgCharts', () => {
             });
 
             expect(deproxy(chart).series.map((s) => s.type)).toEqual(['line']);
-        });
-
-        it('keeps the skipped options as the base, so a later delta update recovers them', async () => {
-            await withOnlyBarRegistered(async () => {
-                chart = AgCharts.create({
-                    container,
-                    data: [{ x: 'a', y: 1 }],
-                    series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
-                } as AgChartOptions);
-                await chart.waitForUpdate();
-
-                await chart.update({
-                    container,
-                    data: [{ x: 'a', y: 1 }],
-                    series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
-                } as AgChartOptions);
-                takeErrorMessages();
-
-                ModuleRegistry.registerModules([LineSeriesModule]);
-                // A delta cannot restate the series, so it must merge onto the skipped options.
-                await chart.updateDelta({ data: [{ x: 'a', y: 2 }] });
-                await chart.waitForUpdate();
-            });
-
-            expect(deproxy(chart).series.map((s) => s.type)).toEqual(['line']);
-        });
-
-        it('resolves the lead series type from the post-sentinel options on a full update()', async () => {
-            await withOnlyBarRegistered(async () => {
-                ModuleRegistry.registerModules([LineSeriesModule]);
-                chart = AgCharts.create({
-                    container,
-                    title: { text: 'Dropped by the next update' },
-                    data: [{ x: 'a', y: 1 }],
-                    series: [{ type: 'bar', xKey: 'x', yKey: 'y' }],
-                } as AgChartOptions);
-                await chart.waitForUpdate();
-
-                // Omitting `title` makes the diff carry removal sentinels, so the lead type has to be
-                // read from options the sentinels have already been cleaned out of.
-                await chart.update({
-                    container,
-                    data: [{ x: 'a', y: 1 }],
-                    series: [{ type: 'line', xKey: 'x', yKey: 'y' }],
-                } as AgChartOptions);
-                await chart.waitForUpdate();
-            });
-
-            expect(console.error).not.toHaveBeenCalled();
-            expect(deproxy(chart).series.map((s) => s.type)).toEqual(['line']);
-        });
-
-        it('skips a chart-driven update instead of crashing on the pruned chart-level defaults', async () => {
-            // The constructor updates (via `parentResize`) before `AgCharts.create()` can short-circuit,
-            // so the skip has to hold inside `Chart.update()` too.
-            await withOnlyBarRegistered(() => {
-                chart = AgCharts.create({ container } as AgChartOptions);
-                expect(() => deproxy(chart).update()).not.toThrow();
-            });
-
-            takeErrorMessages();
-            expect(deproxy(chart).series).toHaveLength(0);
         });
 
         it('still renders a series type that is registered', async () => {

--- a/packages/ag-charts-community/src/api/agCharts.ts
+++ b/packages/ag-charts-community/src/api/agCharts.ts
@@ -466,7 +466,6 @@ class AgChartsInternal {
 
         chart.ctx.domManager.updateCSSVariableWatchers(chartOptions.processedCSSVariables);
 
-        // Must precede the short-circuit below: each listener closes over its own update's options.
         chart.setRequestRefreshListener(() => {
             const refreshedChartOptions = new ChartOptions(
                 baseOptions,
@@ -480,16 +479,9 @@ class AgChartsInternal {
                 Debug.check('scene:stats', 'scene:stats:verbose') ? performance.now() : undefined,
                 chart.ctx
             );
-            // Re-derived per refresh, so registering the module later recovers.
-            if (refreshedChartOptions.unusableLeadSeriesType != null) return;
             AgChartsInternal.licenseCheck(chartProxy, refreshedChartOptions);
             AgChartsInternal.requestFactoryUpdate(chart, refreshedChartOptions);
         });
-
-        if (chartOptions.unusableLeadSeriesType != null) {
-            AgChartsInternal.queueSkippedUpdate(chart, chartOptions);
-            return proxy;
-        }
 
         AgChartsInternal.requestFactoryUpdate(chart, chartOptions);
 
@@ -587,24 +579,6 @@ class AgChartsInternal {
             this.destroy,
             Infinity // Unbounded, so Grid sorting cannot exhaust the pool.
         );
-    }
-
-    private static readonly skippedChartOptions = new WeakSet<ChartOptions>();
-
-    // Only an applied update splices its entry off the queue, so replace the last skipped one.
-    private static queueSkippedUpdate(chart: Chart, chartOptions: ChartOptions) {
-        const queued = chart.queuedChartOptions.at(-1);
-        if (queued != null && AgChartsInternal.skippedChartOptions.has(queued)) {
-            chart.queuedChartOptions.pop();
-            chart.queuedUserOptions.pop();
-        }
-        AgChartsInternal.skippedChartOptions.add(chartOptions);
-        chart.queuedUserOptions.push(chartOptions.userOptions);
-        chart.queuedChartOptions.push(chartOptions);
-        // No `applyOptions()` follows, so a revalidated pass hands its issues over here.
-        if (chartOptions.revalidated) {
-            chart.ctx.validations.beginCycle(chartOptions.issues, chartOptions.validations);
-        }
     }
 
     private static requestFactoryUpdate(chart: Chart, chartOptions: ChartOptions) {

--- a/packages/ag-charts-community/src/chart/chart.ts
+++ b/packages/ag-charts-community/src/chart/chart.ts
@@ -906,9 +906,6 @@ export abstract class Chart implements ModuleInstance, ChartService {
     });
     public update(type = ChartUpdateType.FULL, opts?: UpdateOpts) {
         if (this.destroyed) return;
-        // The theme prunes an unusable lead series type's entry, and with it the chart-level defaults an
-        // update dereferences. Guarded here too: the constructor updates before `create()` can skip it.
-        if (this.chartOptions.unusableLeadSeriesType != null) return;
 
         const {
             forceNodeDataRefresh = false,

--- a/packages/ag-charts-community/src/module/optionsGraph.ts
+++ b/packages/ag-charts-community/src/module/optionsGraph.ts
@@ -242,7 +242,7 @@ export class OptionsGraph extends Graph<unknown, string> implements OptionsGraph
         this.paletteType = isObject(userOptions?.theme) ? paletteType(userOptions.theme?.palette) : 'inbuilt';
 
         // Extract the primary series type, bypassing the graph so we have it ready immediately.
-        const seriesType = userOptions.series?.[0]?.type ?? 'line';
+        const seriesType = this.resolveSeriesType();
         this.seriesType = seriesType;
 
         // Build the initial user options, defaults, common and series overrides graphs on the root.
@@ -292,7 +292,7 @@ export class OptionsGraph extends Graph<unknown, string> implements OptionsGraph
                 $applyTheme: [
                     ['/$seriesType/axes/$axisType/$position', '/$seriesType/axes/$axisType'],
                     {
-                        seriesType: { $path: ['/series/0/type', 'line'] },
+                        seriesType: { $path: ['/series/0/type', seriesType] },
                         axisType: { $path: ['./type', 'category'] },
                         position: { $path: ['./position'] },
                     },
@@ -352,6 +352,18 @@ export class OptionsGraph extends Graph<unknown, string> implements OptionsGraph
             this.annotations = undefined;
             debug('cleared');
         });
+    }
+
+    // The theme only has entries for registered series types; any registered type shares the chart-level defaults.
+    private resolveSeriesType(): string {
+        const seriesType = this.userOptions.series?.[0]?.type ?? 'line';
+        if (seriesType in this.config) return seriesType;
+        const registeredTypes = Object.keys(this.config);
+        return (
+            registeredTypes.find((type) => this.moduleRegistry.getSeriesModule(type)?.chartType === 'cartesian') ??
+            registeredTypes[0] ??
+            seriesType
+        );
     }
 
     clearSafe() {

--- a/packages/ag-charts-community/src/module/optionsModule.ts
+++ b/packages/ag-charts-community/src/module/optionsModule.ts
@@ -235,12 +235,6 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
     activeTheme: ChartTheme;
     processedOptions: T;
     userOptions: Partial<T>;
-    /**
-     * The chart's lead series type when no module is registered to draw it — an explicit
-     * `series[0].type`, or the implicit `'line'` when `series` is absent. The theme keys a chart's whole
-     * default set off that entry, so `processedOptions` then carries no chart-level defaults.
-     */
-    readonly unusableLeadSeriesType: string | undefined;
     processedOverrides: Partial<T>;
     specialOverrides: ChartSpecialOverrides;
     optionMetadata: ChartInternalOptionMetadata;
@@ -362,9 +356,6 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
             if (stripSymbols) {
                 this.removeLeftoverSymbols(this.userOptions);
             }
-            // After the sentinels, so the lead type is the one the update actually resolves to.
-            this.unusableLeadSeriesType = this.resolveUnusableLeadSeriesType();
-
             const dataChangedLength =
                 currentUserOptions instanceof ChartOptions &&
                 deltaOptions?.data !== undefined &&
@@ -381,8 +372,6 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
                 deltaOptions !== undefined &&
                 ChartOptions.isFastPathDelta(deltaOptions, presetDef?.fastUpdateKeys) &&
                 baseChartOptions != null &&
-                // The base carries no chart-level defaults, so the fast path would skip re-deriving them.
-                baseChartOptions.unusableLeadSeriesType == null &&
                 !dataChangedLength
             ) {
                 ({ activeTheme, processedOptions, fastDelta } = this.fastSetup(deltaOptions, baseChartOptions));
@@ -1013,13 +1002,6 @@ export class ChartOptions<T extends AgChartOptions = AgChartOptions> {
 
     private optionsType(options: Partial<T>) {
         return options.series?.[0]?.type ?? 'line';
-    }
-
-    private resolveUnusableLeadSeriesType(): string | undefined {
-        // Presets supply their own series, so the user options' lead type says nothing about them.
-        if (this.optionMetadata.presetType != null) return undefined;
-        const seriesType = this.optionsType(this.userOptions);
-        return this.moduleRegistry.getSeriesModule(seriesType) == null ? seriesType : undefined;
     }
 
     private processSeriesOptions(options: T) {


### PR DESCRIPTION
An enterprise series type in the community package (e.g. `heatmap`) now renders a blank canvas instead of the empty chart an empty `series` array gives.

**Cause.** The theme only builds a defaults entry per registered series type, so a lead type with no module left the chart with no chart-level defaults and the first update crashed on `touch.dragAction`. AG-18240 worked around that by skipping the update entirely whenever the lead type had no module, and its check read the raw user options, so a dropped enterprise series short-circuited the whole chart.

**Fix.** `OptionsGraph` resolves its lead type to a registered theme entry when the requested one has none, so every unusable series ends up as the same empty chart `series: []` gives: missing-module error reported, no series, captions and defaults intact. The AG-18240 skip machinery (`unusableLeadSeriesType`, `queueSkippedUpdate`, the guard in `Chart.update`, the fast-path exclusion) is removed, and its tests are rewritten to assert the consistent empty-chart outcome.

**Known limitations, unchanged from before AG-18240**
- A registry with no series module at all still has no chart-level defaults and crashes, for any options including `series: []`.
- When the fallback engages (only when `line` itself is unregistered and no series survive), theme overrides keyed by the fallback type apply to the empty chart.
- A data-only delta update takes the fast path and does not re-validate a dropped series after its module is registered; a refresh request does.