### PR TITLE
Add a Manage Cookies link to the footer that opens the consent preferences

### DIFF
--- a/packages/ag-charts-website/public/scripts/persist-cookie-consent.js
+++ b/packages/ag-charts-website/public/scripts/persist-cookie-consent.js
@@ -1,0 +1,74 @@
+/*
+ * Enzuzo, the GTM-injected cookie-consent banner, appends its banner and preference-modal
+ * markup to <body> and its stylesheets to <head>, then caches element references in closures
+ * (createModalFunctions grabs #enzuzo-modal and friends once, at init). Astro's client-side
+ * router replaces the whole <body> and removes any head element the incoming document does
+ * not also contain, so all of that is destroyed on the first navigation.
+ *
+ * The banner's 'hashchange' listener is bound to window, which survives the swap, so it still
+ * fires for #manage_cookies — but it toggles the now-detached nodes and nothing opens. Same
+ * for the __enzuzoApi.prefCenter.show() entry point, which routes to the same closure.
+ *
+ * Astro keeps a live element when the incoming document carries a matching
+ * data-astro-transition-persist id, so tag Enzuzo's roots and put placeholders carrying the
+ * same ids into the incoming document for the router to pair them with. Mirrors the head-only
+ * mechanism in persist-injected-styles.js.
+ *
+ * Externalised to a 'self' script (rather than inlined) so the site Content-Security-Policy
+ * can keep script-src free of 'unsafe-inline' without needing a per-build hash.
+ */
+(function () {
+    var BODY_ROOTS = ':scope > .ez-consent, :scope > [id^="ez-cookie"], :scope > [id^="enzuzo-"]';
+    var HEAD_STYLES = 'style[id^="enzuzo_cb"], style[ez-style], [data-astro-transition-persist]';
+    // Enzuzo's base and modal stylesheets carry no id or attribute, so they are matched on the
+    // class names they style instead.
+    var UNTAGGED_HEAD_STYLES = 'style:not([data-astro-transition-persist])';
+    var STYLE_CONTENT_MARKERS = ['.ez-consent', 'enzuzo-modal-wrapper'];
+    var nextPersistId = 0;
+
+    function persist(el, newDocument, target) {
+        if (!el.dataset.astroTransitionPersist) {
+            el.dataset.astroTransitionPersist = 'enzuzo-' + nextPersistId++;
+        }
+
+        var placeholder = newDocument.createElement(el.localName);
+        placeholder.dataset.astroTransitionPersist = el.dataset.astroTransitionPersist;
+        target.appendChild(placeholder);
+    }
+
+    function persistAll(elements, newDocument, target) {
+        for (var i = 0, len = elements.length; i < len; ++i) {
+            persist(elements[i], newDocument, target);
+        }
+    }
+
+    function matchesAnyMarker(style) {
+        for (var i = 0, len = STYLE_CONTENT_MARKERS.length; i < len; ++i) {
+            if (style.textContent.indexOf(STYLE_CONTENT_MARKERS[i]) !== -1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    document.addEventListener('astro:before-swap', function (event) {
+        var newDocument = event.newDocument;
+        var matchedStyles = [];
+
+        // Persist the identifiable stylesheets first: that tags them, so the content-matching
+        // pass below cannot pick the same element up a second time.
+        persistAll(document.head.querySelectorAll(HEAD_STYLES), newDocument, newDocument.head);
+
+        var untagged = document.head.querySelectorAll(UNTAGGED_HEAD_STYLES);
+
+        for (var i = 0, len = untagged.length; i < len; ++i) {
+            if (matchesAnyMarker(untagged[i])) {
+                matchedStyles.push(untagged[i]);
+            }
+        }
+
+        persistAll(matchedStyles, newDocument, newDocument.head);
+        persistAll(document.body.querySelectorAll(BODY_ROOTS), newDocument, newDocument.body);
+    });
+})();

--- a/packages/ag-charts-website/public/scripts/persist-cookie-consent.js
+++ b/packages/ag-charts-website/public/scripts/persist-cookie-consent.js
@@ -19,7 +19,11 @@
  */
 (function () {
     var BODY_ROOTS = ':scope > .ez-consent, :scope > [id^="ez-cookie"], :scope > [id^="enzuzo-"]';
-    var HEAD_STYLES = 'style[id^="enzuzo_cb"], style[ez-style], [data-astro-transition-persist]';
+    // Only re-persist the elements this script tagged on an earlier navigation. A bare
+    // [data-astro-transition-persist] would also match the AG stylesheets that
+    // persist-injected-styles.js has already given a placeholder, and a second placeholder for
+    // the same id is left behind as an empty <style> that accumulates on every navigation.
+    var HEAD_STYLES = 'style[id^="enzuzo_cb"], style[ez-style], [data-astro-transition-persist^="enzuzo-"]';
     // Enzuzo's base and modal stylesheets carry no id or attribute, so they are matched on the
     // class names they style instead.
     var UNTAGGED_HEAD_STYLES = 'style:not([data-astro-transition-persist])';

--- a/packages/ag-charts-website/src/content.config.ts
+++ b/packages/ag-charts-website/src/content.config.ts
@@ -88,6 +88,7 @@ const footer = defineCollection({
                     name: z.string(),
                     url: z.string(),
                     newTab: z.boolean().optional(),
+                    showCookiesPrefs: z.boolean().optional(),
                     iconName: z.string().optional(),
                 })
             ),

--- a/packages/ag-charts-website/src/content/footer/footer.json
+++ b/packages/ag-charts-website/src/content/footer/footer.json
@@ -83,6 +83,11 @@
                 "url": "https://www.ag-grid.com/cookies/"
             },
             {
+                "name": "Manage Cookies",
+                "url": "#manage_cookies",
+                "showCookiesPrefs": true
+            },
+            {
                 "name": "Modern Slavery",
                 "url": "https://www.ag-grid.com/modern-slavery/"
             },

--- a/packages/ag-charts-website/src/layouts/Layout.astro
+++ b/packages/ag-charts-website/src/layouts/Layout.astro
@@ -290,6 +290,12 @@ const structuredData: JsonLdObject[] = includeStructuredData
         {/* Externalised to a 'self' script so the site CSP can drop script-src 'unsafe-inline';
            see public/scripts/persist-injected-styles.js for why it is needed. */}
         <script is:inline src={urlWithBaseUrl('/scripts/persist-injected-styles.js')}></script>
+        {
+            /* Keep the GTM-injected cookie-consent banner's DOM and stylesheets alive across a
+        client-side navigation, so #manage_cookies still opens the preferences modal on every
+        page; see public/scripts/persist-cookie-consent.js for the mechanism. */
+        }
+        <script is:inline src={urlWithBaseUrl('/scripts/persist-cookie-consent.js')}></script>
 
         <style lang="scss">
             @use 'design-system' as *;

--- a/packages/ag-charts-website/src/types/ag-grid.d.ts
+++ b/packages/ag-charts-website/src/types/ag-grid.d.ts
@@ -58,6 +58,7 @@ export interface FooterItem {
         name: string;
         url: string;
         newTab?: boolean;
+        showCookiesPrefs?: boolean;
         iconName: string;
     }[];
 }

--- a/packages/ag-charts-website/src/utils/markdown-pages/chartsFrontmatter.test.ts
+++ b/packages/ag-charts-website/src/utils/markdown-pages/chartsFrontmatter.test.ts
@@ -17,6 +17,10 @@ describe('getFooterRelatedLinks', () => {
         expect(titlesFor('/contact/')).toContain('Privacy Policy');
     });
 
+    test('excludes the cookie-preferences control, which opens a dialog rather than a page', () => {
+        expect(titlesFor('/contact/')).not.toContain('Manage Cookies');
+    });
+
     test('excludes the page itself', () => {
         expect(titlesFor('/roadmap/')).not.toContain('Roadmap');
         expect(titlesFor('/contact/')).not.toContain('Contact Us');


### PR DESCRIPTION
## Summary

Ports the grid's Manage Cookies footer work (ag-grid/ag-grid#14799, #14805, #14807 and #14833) to the charts site.

- Adds a **Manage Cookies** link beside the Cookies Policy in the footer. It carries `showCookiesPrefs`, so the shared footer component opens the Enzuzo preference centre instead of navigating. The shared component and link-checker exclusion already arrived via the `ag-website-shared` sync, so this adds the site-specific half: footer data, content schema and type.
- Adds `persist-cookie-consent.js` and loads it from the layout. The view-transition router replaces the body on every client-side navigation, destroying the GTM-injected consent banner and modal, so the script tags Enzuzo's roots and stylesheets for the router to keep alive.
- Adds a test that the control is not treated as a related page in the markdown twins.

## Test plan

- [x] `yarn nx run-many -t lint,test -p ag-charts-website` passes