### PR TITLE
AG-18413 Draw no bubble/scatter markers under the no-data overlay

### DIFF
--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -634,7 +634,7 @@ export abstract class Axis<
         this.updatePosition();
         this.updateSelections();
 
-        this.gridLineGroup.visible = this.options.gridLine.enabled;
+        this.gridLineGroup.visible = this.options.gridLine.enabled && !this.hasNoSeriesData();
 
         this.updateLabels();
         this.notifyAxisPlugins('onAxisUpdate');
@@ -1168,6 +1168,22 @@ export abstract class Axis<
 
     hasVisibleSeries() {
         return this.boundSeries.some((s) => s.isEnabled());
+    }
+
+    /**
+     * Whether every series the user has switched on resolves to nothing renderable — the state the
+     * chart raises its no-data overlay in, so gridlines drawn behind it would contradict it.
+     * Switched-off series are excluded deliberately: a chart with every series hidden on a fixed axis
+     * domain is an empty chart, not a misconfigured one, and keeps its grid.
+     */
+    private hasNoSeriesData() {
+        let enabledCount = 0;
+        for (const series of this.boundSeries) {
+            if (!series.isEnabled()) continue;
+            if (series.hasData) return false;
+            enabledCount++;
+        }
+        return enabledCount > 0;
     }
 
     clipTickLines(x: number, y: number, width: number, height: number) {

--- a/packages/ag-charts-community/src/chart/axis/axis.ts
+++ b/packages/ag-charts-community/src/chart/axis/axis.ts
@@ -1171,14 +1171,16 @@ export abstract class Axis<
     }
 
     /**
-     * Whether every series the user has switched on resolves to nothing renderable — the state the
-     * chart raises its no-data overlay in, so gridlines drawn behind it would contradict it.
-     * Switched-off series are excluded deliberately: a chart with every series hidden on a fixed axis
-     * domain is an empty chart, not a misconfigured one, and keeps its grid.
+     * Whether the chart as a whole resolves to nothing renderable — the state it raises its no-data
+     * overlay in, so gridlines drawn behind it would contradict it. Every axis reads the same
+     * chart-wide verdict, so a series that resolves to nothing cannot take the grid off its own axis
+     * while a populated series elsewhere keeps the chart displayed. Legend-hidden series are excluded:
+     * their `hasData` depends on whether they have ever been processed, which would make the grid
+     * flip on a toggle round-trip.
      */
     private hasNoSeriesData() {
         let enabledCount = 0;
-        for (const series of this.boundSeries) {
+        for (const series of this.moduleCtx.chartService.series) {
             if (!series.isEnabled()) continue;
             if (series.hasData) return false;
             enabledCount++;

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
@@ -1696,49 +1696,35 @@ describe('BubbleSeries', () => {
 
         // `''` is a property key like any other — `({ '': 2 })['']` is 2 — so an empty key names a
         // column exactly as a non-empty string does, and takes the same route: the unmatched-key
-        // warning, with the rest of the series still drawn. Previously it was neither registered nor
-        // skipped consistently, so reading the column threw on every update pass.
+        // warning. Nothing in the series is renderable, and the chart raises its no-data overlay,
+        // so no markers are drawn under it.
         it.each([
             ['an empty sizeKey (TC1)', { sizeKey: '' }, `''`],
             ['an unmatched sizeKey', { sizeKey: 'nope' }, `'nope'`],
-        ] as [string, object, string][])('draws default-size markers and warns for %s', async (_name, o, key) => {
-            await createBubble(o);
-
-            expect(nodeData(chart).map((d) => d.point.size)).toEqual([7, 7, 7]);
-            expectWarningsCalls().toEqual([
-                [`AG Charts - the key ${key} was not found in any data element for BubbleSeries-1.`],
-            ]);
-        });
-
-        it.each([
             ['an empty labelKey (TC3)', { sizeKey: 's', labelKey: '', label: { enabled: true } }, `''`],
             ['an unmatched labelKey', { sizeKey: 's', labelKey: 'nope', label: { enabled: true } }, `'nope'`],
-        ] as [string, object, string][])('draws unlabelled markers and warns for %s', async (_name, o, key) => {
+        ] as [string, object, string][])('draws no markers and warns for %s', async (_name, o, key) => {
             await createBubble(o);
 
-            expect(nodeData(chart).map((d) => d.point.size)).toEqual([7, 18.5, 30]);
-            expect(nodeData(chart).map((d) => d.label.text)).toEqual(['', '', '']);
+            expect(nodeData(chart)).toEqual([]);
+            expect(deproxy(chart).series[0].hasData).toBe(false);
             expectWarningsCalls().toEqual([
                 [`AG Charts - the key ${key} was not found in any data element for BubbleSeries-1.`],
             ]);
         });
 
-        // With no labelKey the label comes from the size column, chosen on the same nullish test the
-        // column is registered and read with — a truthy test sent `''` to the y-values instead.
-        it.each([
-            ['an empty sizeKey', { sizeKey: '' }, `''`],
-            ['an unmatched sizeKey', { sizeKey: 'nope' }, `'nope'`],
-        ] as [string, object, string][])(
-            'labels the markers from the size column, not y, for %s',
-            async (_name, o, key) => {
-                await createBubble({ ...o, label: { enabled: true } });
+        it('still draws the renderable rows when individual rows are invalid or incomplete', async () => {
+            // Every key names a column here, so the series is only partly unresolvable: the invalid
+            // and missing tallies overlap enough to make the inherited hasData getter read false,
+            // and the renderable row must survive that.
+            await createBubble({ sizeKey: 's', labelKey: 'l', label: { enabled: true } }, [
+                { x: 1, y: 1, s: 10, l: 'a' },
+                { x: null, y: 2, s: 20 },
+            ]);
 
-                expect(nodeData(chart).map((d) => d.label.text)).toEqual(['', '', '']);
-                expectWarningsCalls().toEqual([
-                    [`AG Charts - the key ${key} was not found in any data element for BubbleSeries-1.`],
-                ]);
-            }
-        );
+            expect(nodeData(chart)).toHaveLength(1);
+            expect(deproxy(chart).series[0].hasData).toBe(false);
+        });
 
         it('labels the markers from an empty sizeKey the data does carry', async () => {
             await createBubble({ sizeKey: '', label: { enabled: true } }, withEmptyColumn);
@@ -1763,7 +1749,7 @@ describe('BubbleSeries', () => {
 
         it('scales the markers once an empty sizeKey is replaced by a real one', async () => {
             await createBubble({ sizeKey: '' });
-            expect(nodeData(chart).map((d) => d.point.size)).toEqual([7, 7, 7]);
+            expect(nodeData(chart)).toEqual([]);
             expectWarningsCalls().toEqual([
                 [`AG Charts - the key '' was not found in any data element for BubbleSeries-1.`],
             ]);

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
@@ -1733,6 +1733,35 @@ describe('BubbleSeries', () => {
             expect(deproxy(chart).series[0].hasData).toBe(false);
         });
 
+        it('keeps every grid when a second series on another y axis is still resolvable', async () => {
+            const options = {
+                data: [
+                    { x: 1, y: 1, y2: 4, s: 10 },
+                    { x: 2, y: 2, y2: 5, s: 20 },
+                ],
+                series: [
+                    { type: 'bubble', xKey: 'x', yKey: 'y', sizeKey: '' },
+                    { type: 'bubble', xKey: 'x', yKey: 'y2', yKeyAxis: 'y2', sizeKey: 's' },
+                ],
+                legend: { enabled: false },
+                axes: {
+                    x: { type: 'number', position: 'bottom' },
+                    y: { type: 'number', position: 'left' },
+                    y2: { type: 'number', position: 'right' },
+                },
+            } as AgCartesianChartOptions;
+            prepareTestOptions(options);
+            chart = AgCharts.create(options);
+            await waitForChartStability(chart);
+
+            // No no-data overlay is raised while one series resolves, so no axis may drop its grid.
+            expect(gridLinesVisible(chart)).toEqual([true, true, true]);
+            expect(deproxy(chart).series[1].hasData).toBe(true);
+            expectWarningsCalls().toEqual([
+                [`AG Charts - the key '' was not found in any data element for BubbleSeries-1.`],
+            ]);
+        });
+
         it('labels the markers from an empty sizeKey the data does carry', async () => {
             await createBubble({ sizeKey: '', label: { enabled: true } }, withEmptyColumn);
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.test.ts
@@ -1679,6 +1679,11 @@ describe('BubbleSeries', () => {
             { x: 3, y: 3, '': 30 },
         ];
 
+        const gridLinesVisible = (c: AgChartInstance) =>
+            (deproxy(c).axes as unknown as { gridLineGroup: { visible: boolean } }[]).map(
+                (a) => a.gridLineGroup.visible
+            );
+
         const createBubble = async (seriesOverrides: object, data: object[] = defaultData) => {
             const options = {
                 data,
@@ -1708,6 +1713,8 @@ describe('BubbleSeries', () => {
 
             expect(nodeData(chart)).toEqual([]);
             expect(deproxy(chart).series[0].hasData).toBe(false);
+            // The no-data overlay stands alone over the axes: no markers, and no gridlines behind it.
+            expect(gridLinesVisible(chart)).toEqual([false, false]);
             expectWarningsCalls().toEqual([
                 [`AG Charts - the key ${key} was not found in any data element for BubbleSeries-1.`],
             ]);
@@ -1744,6 +1751,8 @@ describe('BubbleSeries', () => {
             await createBubble({ sizeKey: 's' });
 
             expect(nodeData(chart).map((d) => d.point.size)).toEqual([7, 18.5, 30]);
+            // Anti-vacuous control for the gridline assertion above: a resolvable series keeps its grid.
+            expect(gridLinesVisible(chart)).toEqual([true, true]);
             expectWarningsCalls().toMatchInlineSnapshot(`[]`);
         });
 

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -729,6 +729,8 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
      * Strategy selection happens inside: simple or aggregation path.
      */
     protected override populateNodeData(ctx: BubbleSeriesNodeDatumContext): void {
+        this.aggregateIndexSet = undefined;
+
         // A column missing from every row leaves nothing renderable, and the chart raises its
         // no-data overlay — markers drawn under it would contradict it.
         const dataCount = this.dataCount();
@@ -753,8 +755,6 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
             dilation: 1,
             area: 0,
         };
-
-        this.aggregateIndexSet = undefined;
 
         const { dataAggregation } = this;
         if (dataAggregation == null) {

--- a/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/bubbleSeries.ts
@@ -729,6 +729,11 @@ export class BubbleSeries extends CartesianSeries<BubbleSeriesTypes> {
      * Strategy selection happens inside: simple or aggregation path.
      */
     protected override populateNodeData(ctx: BubbleSeriesNodeDatumContext): void {
+        // A column missing from every row leaves nothing renderable, and the chart raises its
+        // no-data overlay — markers drawn under it would contradict it.
+        const dataCount = this.dataCount();
+        if (dataCount > 0 && this.missingDataCount() >= dataCount) return;
+
         this.sizeScale.range = this.getSizeRange();
 
         // Pre-allocate scratch object for datum state

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.test.ts
@@ -1251,6 +1251,12 @@ describe('ScatterSeries', () => {
 
             expect(nodeData(chart)).toEqual([]);
             expect(deproxy(chart).series[0].hasData).toBe(false);
+            // The no-data overlay stands alone over the axes: no markers, and no gridlines behind it.
+            expect(
+                (deproxy(chart).axes as unknown as { gridLineGroup: { visible: boolean } }[]).map(
+                    (a) => a.gridLineGroup.visible
+                )
+            ).toEqual([false, false]);
             expectWarningsCalls().toEqual([
                 [`AG Charts - the key ${key} was not found in any data element for ScatterSeries-1.`],
             ]);

--- a/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.test.ts
+++ b/packages/ag-charts-community/src/chart/series/cartesian/scatterSeries.test.ts
@@ -1241,15 +1241,16 @@ describe('ScatterSeries', () => {
         };
 
         // An empty key is matched against the data exactly like a non-empty one, so both take the
-        // same route: the unmatched-key warning, with the markers still drawn and no label text.
+        // same route: the unmatched-key warning, and no markers under the no-data overlay the
+        // unresolvable series raises.
         it.each([
             ['an empty labelKey (TC3)', { labelKey: '', label: { enabled: true } }, `''`],
             ['an unmatched labelKey', { labelKey: 'nope', label: { enabled: true } }, `'nope'`],
-        ] as [string, object, string][])('draws unlabelled markers and warns for %s', async (_name, o, key) => {
+        ] as [string, object, string][])('draws no markers and warns for %s', async (_name, o, key) => {
             await createScatter(o);
 
-            expect(nodeData(chart)).toHaveLength(3);
-            expect((nodeData(chart) as { label: { text: string } }[]).map((d) => d.label.text)).toEqual(['', '', '']);
+            expect(nodeData(chart)).toEqual([]);
+            expect(deproxy(chart).series[0].hasData).toBe(false);
             expectWarningsCalls().toEqual([
                 [`AG Charts - the key ${key} was not found in any data element for ScatterSeries-1.`],
             ]);

--- a/packages/ag-charts-enterprise/src/preset/quadrant/quadrantPreset.test.ts
+++ b/packages/ag-charts-enterprise/src/preset/quadrant/quadrantPreset.test.ts
@@ -588,6 +588,11 @@ describe('AG-18413 quadrant with a key naming no column', () => {
 
         expect(series.getNodeData()).toEqual([]);
         expect(series.hasData).toBe(false);
+        // The no-data overlay stands alone over the axes: no markers, and no gridlines behind it.
+        expect(chart.axes.map((a: { gridLineGroup: { visible: boolean } }) => a.gridLineGroup.visible)).toEqual([
+            false,
+            false,
+        ]);
         expectWarningsCalls().toEqual([[`AG Charts - the key '' was not found in any data element for ${series.id}.`]]);
     });
 

--- a/packages/ag-charts-enterprise/src/preset/quadrant/quadrantPreset.test.ts
+++ b/packages/ag-charts-enterprise/src/preset/quadrant/quadrantPreset.test.ts
@@ -581,12 +581,13 @@ describe('AG-18413 quadrant with a key naming no column', () => {
         return chart.series[0];
     };
 
-    // An empty key names a column like any other string, so it takes the unmatched-key warning and
-    // the markers are still drawn — at their default size, since no size column resolved.
-    it('draws default-size markers and warns for an empty sizeKey', async () => {
+    // An empty key names a column like any other string, so it takes the unmatched-key warning —
+    // and, with nothing renderable behind it, the no-data overlay stands alone over the axes.
+    it('draws no markers and warns for an empty sizeKey', async () => {
         const series = await createQuadrantChart({ sizeKey: '' });
 
-        expect(series.getNodeData()).toHaveLength(NUMERIC.data!.length);
+        expect(series.getNodeData()).toEqual([]);
+        expect(series.hasData).toBe(false);
         expectWarningsCalls().toEqual([[`AG Charts - the key '' was not found in any data element for ${series.id}.`]]);
     });
 

--- a/packages/ag-charts-enterprise/src/test/colorScale.test.ts
+++ b/packages/ag-charts-enterprise/src/test/colorScale.test.ts
@@ -299,10 +299,11 @@ describe('AG-18413 a colorKey naming no column - bubble/scatter', () => {
     it.each([
         ['bubble', { type: 'bubble' as const, xKey: 'x', yKey: 'y', sizeKey: 'size' }],
         ['scatter', { type: 'scatter' as const, xKey: 'x', yKey: 'y' }],
-    ])('%s draws default-coloured markers and warns for an empty colorKey (TC2)', async (_name, base) => {
+    ])('%s draws no markers and warns for an empty colorKey (TC2)', async (_name, base) => {
         const series = await createChartWith({ ...base, colorKey: '', colorScale: { fills } });
 
-        expect(series.getNodeData()).toHaveLength(data.length);
+        expect(series.getNodeData()).toEqual([]);
+        expect(series.hasData).toBe(false);
         expectWarningsCalls().toEqual([[`AG Charts - the key '' was not found in any data element for ${series.id}.`]]);
     });
 


### PR DESCRIPTION
https://ag-grid.atlassian.net/browse/AG-18413

Cherry-pick commits from https://github.com/ag-grid/ag-charts/pull/8090
