### PR TITLE
Forward overrideDevicePixelRatio through the quadrant preset

### DIFF
--- a/packages/ag-charts-enterprise/src/preset/quadrant/quadrantPreset.test.ts
+++ b/packages/ag-charts-enterprise/src/preset/quadrant/quadrantPreset.test.ts
@@ -331,6 +331,29 @@ describe('Quadrant Preset', () => {
         }
     );
 
+    it('forwards overrideDevicePixelRatio to the cartesian chart options', () => {
+        const cartesianOptions = createQuadrant(
+            { ...BUBBLE_SIZED_NUMERIC, overrideDevicePixelRatio: 2 } as AgQuadrantChartOptions,
+            undefined,
+            undefined,
+            undefined,
+            new Logger(),
+            () => undefined
+        );
+
+        expect(cartesianOptions).toMatchObject({ overrideDevicePixelRatio: 2 });
+    });
+
+    it('accepts overrideDevicePixelRatio without a validation warning', async () => {
+        const options = { ...BUBBLE_SIZED_NUMERIC, overrideDevicePixelRatio: 2 } as AgQuadrantChartOptions;
+        prepareEnterpriseTestOptions(options);
+
+        chart = AgCharts.createQuadrantChart(options);
+        await waitForChartStability(chart);
+
+        expect(console.warn).not.toHaveBeenCalled();
+    });
+
     it('forwards sizeName to the tooltip renderer params', () => {
         const rendererParams: unknown[] = [];
 

--- a/packages/ag-charts-enterprise/src/preset/quadrant/quadrantPreset.ts
+++ b/packages/ag-charts-enterprise/src/preset/quadrant/quadrantPreset.ts
@@ -155,6 +155,7 @@ export function createQuadrant(
         'locale',
         'minHeight',
         'minWidth',
+        'overrideDevicePixelRatio',
         'padding',
         'selection',
         'subtitle',

--- a/packages/ag-charts-enterprise/src/preset/quadrant/quadrantPresetOptionsDefs.ts
+++ b/packages/ag-charts-enterprise/src/preset/quadrant/quadrantPresetOptionsDefs.ts
@@ -6,7 +6,9 @@ import {
     defined,
     number,
     numericValue,
+    positiveNumber,
     string,
+    undocumented,
     union,
     without,
 } from 'ag-charts-core';
@@ -135,3 +137,6 @@ export const quadrantOptionsDefs: OptionsDefs<AgQuadrantChartOptions> = {
     theme: defined,
     width: defined,
 };
+
+// @ts-expect-error undocumented option
+quadrantOptionsDefs.overrideDevicePixelRatio = undocumented(positiveNumber);


### PR DESCRIPTION
The quadrant preset did not forward `overrideDevicePixelRatio` to the underlying cartesian chart, and its options defs did not register it, so the option was stripped as unknown. The website thumbnail generator relies on it for the `@2x` gallery thumbnails, which rendered the quadrant chart at 1x scale inside a 2x canvas (visible on staging and the 14.2.0 archive on retina screens).

Adds the option to the preset's forwarded chart options and registers it as an undocumented positive number, matching the gauge and price-volume presets. Two tests cover the forwarding and the validation registration.

Once merged, the enterprise bundle hash changes, so all gallery thumbnails regenerate on the next deploy.