### PR TITLE
AG-18445: Let the gallery example intro span the page width

### DIFF
--- a/packages/ag-charts-website/src/pages/gallery/[pageName].astro
+++ b/packages/ag-charts-website/src/pages/gallery/[pageName].astro
@@ -95,7 +95,6 @@ const relatedHeading = relatedExamplesHeading({ seriesTitle: page.seriesTitle, r
     }
 
     .intro {
-        max-width: 70ch;
         margin-bottom: $spacing-size-6;
         font-size: var(--text-fs-sm);
     }


### PR DESCRIPTION
Last outstanding design-review item on AG-18445: the intro text at the top of an individual gallery example page should be full width.

## Why it regressed

It *was* full width. `1be653551f` deliberately removed `max-width: 70ch` from `.intro`. Then `7c448cb50e` ("Drop the duplicate framework links paragraph") deleted the `.frameworkLinks` element and, collapsing the two now-redundant rules into one, kept the `.frameworkLinks` body under the `.intro` selector — silently reinstating the `max-width`:

```diff
     .intro {
-        margin-bottom: $spacing-size-2;
-        font-size: var(--text-fs-sm);
-    }
-
-    .frameworkLinks {
         max-width: 70ch;
```

So this was an accident of that cleanup, not a design decision.

## Change

One line removed from `packages/ag-charts-website/src/pages/gallery/[pageName].astro`:

```diff
     .intro {
-        max-width: 70ch;
         margin-bottom: $spacing-size-6;
         font-size: var(--text-fs-sm);
     }
```

The page sits in `layout-max-width-small` (1240px), so the intro now spans exactly the width of the example runner below it. 70ch was ~617px, which is why the review screenshot wrapped around half way.

## Testing

- Compared against the reported page (`archive/14.2.0/gallery/simple-bar/`): wraps at ~617px before, runs the full 1200px after, aligned with the chart card.
- Longest intro in `galleryCopy.ts` (`multiple-line-series-large-data`, ~450 rendered chars) reads as three clean full-width lines.
- Dark mode unaffected.
- Mobile (390px) pixel-identical to production — 70ch was never the binding constraint below ~617px, so removing it is a no-op there.
- The 121 `gallery-examples.spec.ts` snapshots target `/gallery/examples/<name>`, the standalone runner, which has no intro paragraph — unaffected.
- Prettier clean.

The two remaining "update text content" items on the ticket are out of scope here; David is handling that copy separately.